### PR TITLE
ci: add Woodpecker pipeline

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -55,7 +55,10 @@ steps:
 
   trivy-fs:
     # Scans the source tree for: known CVEs in deps, leaked secrets,
-    # and Dockerfile / compose misconfigurations.
+    # and Dockerfile / compose misconfigurations. Skips .venv (it can
+    # be left over from earlier steps in the shared workspace; trivy
+    # would scan its bundled extractor files and flag false-positive
+    # secrets that ship inside third-party packages like yt-dlp).
     image: aquasec/trivy:latest
     commands:
       - trivy fs
@@ -63,6 +66,8 @@ steps:
           --severity HIGH,CRITICAL
           --exit-code 1
           --ignore-unfixed
+          --skip-dirs .venv
+          --skip-dirs jobs
           .
 
   trivy-config:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -4,7 +4,10 @@
 # misconfig) so CI does not need a docker-in-docker setup.
 
 when:
-  - event: [push, pull_request]
+  - event: pull_request
+  - event: push
+    branch: main
+  - event: release
 
 steps:
   lint:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -1,0 +1,59 @@
+# Woodpecker CI: lint + unit tests + security scans.
+# Does not build or publish artifacts. Image scanning is done via
+# `trivy fs` on the project tree (covers deps, secrets, and Dockerfile
+# misconfig) so CI does not need a docker-in-docker setup.
+
+when:
+  - event: [push, pull_request]
+
+steps:
+  lint:
+    image: ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+    commands:
+      - uv sync --frozen
+      - uv run ruff check app/ tests/
+      - uv run ruff format --check app/ tests/
+      - bash -n run.sh
+
+  test:
+    image: ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+    commands:
+      - apt-get update && apt-get install -y --no-install-recommends ffmpeg
+      - uv sync --frozen
+      - uv run pytest tests/ -q
+
+  js-syntax:
+    image: node:20-alpine
+    commands:
+      - for f in static/js/*.js; do node --check "$f"; done
+
+  sast-bandit:
+    image: ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+    commands:
+      - uv tool install bandit
+      - uv tool run bandit -r app/ -ll  # fail on medium+ severity
+
+  deps-audit:
+    image: ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+    commands:
+      - uv tool install pip-audit
+      - uv pip compile pyproject.toml -o /tmp/requirements.txt
+      - uv tool run pip-audit -r /tmp/requirements.txt --strict
+
+  trivy-fs:
+    # Scans the source tree for: known CVEs in deps, leaked secrets,
+    # and Dockerfile / compose misconfigurations.
+    image: aquasec/trivy:latest
+    commands:
+      - trivy fs
+          --scanners vuln,secret,misconfig
+          --severity HIGH,CRITICAL
+          --exit-code 1
+          --ignore-unfixed
+          .
+
+  trivy-config:
+    # Dedicated Dockerfile + compose static analysis (Trivy's IaC linter).
+    image: aquasec/trivy:latest
+    commands:
+      - trivy config --severity HIGH,CRITICAL --exit-code 1 build/

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -41,7 +41,17 @@ steps:
     commands:
       - uv tool install pip-audit
       - uv pip compile pyproject.toml -o /tmp/requirements.txt
+      # Ignored CVEs (review periodically):
+      #   CVE-2025-2953  torch.mkldnn_max_pool2d local-DoS, fixed in 2.7.1
+      #   CVE-2025-3730  torch.nn.functional.ctc_loss local-DoS, fixed in 2.8
+      # We are pinned to torch <2.7 because torchaudio 2.7+ requires torchcodec,
+      # which has ABI issues that break demucs's torchaudio.save() path. Both
+      # CVEs are in ops StemDeck does not invoke; risk on a local-only single-
+      # user app is negligible. Drop these ignores once the torchaudio /
+      # torchcodec story stabilizes upstream.
       - uv tool run pip-audit -r /tmp/requirements.txt --strict
+          --ignore-vuln CVE-2025-2953
+          --ignore-vuln CVE-2025-3730
 
   trivy-fs:
     # Scans the source tree for: known CVEs in deps, leaked secrets,

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -13,7 +13,7 @@ steps:
   lint:
     image: ghcr.io/astral-sh/uv:python3.12-bookworm-slim
     commands:
-      - uv sync --frozen
+      - uv sync --frozen --all-extras
       - uv run ruff check app/ tests/
       - uv run ruff format --check app/ tests/
       - bash -n run.sh
@@ -22,7 +22,7 @@ steps:
     image: ghcr.io/astral-sh/uv:python3.12-bookworm-slim
     commands:
       - apt-get update && apt-get install -y --no-install-recommends ffmpeg
-      - uv sync --frozen
+      - uv sync --frozen --all-extras
       - uv run pytest tests/ -q
 
   js-syntax:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # StemDeck
 
+[![status-badge](https://ci.popchores.app/api/badges/2/status.svg?events=push%2Crelease%2Cpull_request_metadata%2Cpull_request_closed%2Cpull_request)](https://ci.popchores.app/repos/2)
+
 If you like StemDeck and find it useful, consider [buying me a coffee ☕](https://buymeacoffee.com/tha.les).
 
 ![StemDeck](stemdeck.png)

--- a/app/api/jobs.py
+++ b/app/api/jobs.py
@@ -35,11 +35,7 @@ async def create_job(payload: JobRequest) -> dict[str, str]:
         url = validate_youtube_url(payload.url)
     except InvalidYouTubeURL as e:
         raise HTTPException(status_code=422, detail=str(e)) from e
-    selected = (
-        [s for s in payload.stems if s in STEM_NAMES]
-        if payload.stems
-        else list(STEM_NAMES)
-    )
+    selected = [s for s in payload.stems if s in STEM_NAMES] if payload.stems else list(STEM_NAMES)
     if not selected:  # everything was unknown -- treat as full set
         selected = list(STEM_NAMES)
     job = registry_register(Job(id=uuid.uuid4().hex[:12], selected_stems=selected))

--- a/app/pipeline/collect.py
+++ b/app/pipeline/collect.py
@@ -39,12 +39,15 @@ def _run_ffmpeg(job: Job, cmd: list[str]) -> bool:
             tail = (stderr or b"").decode(errors="replace").splitlines()[-3:]
             logger.warning(
                 "ffmpeg exit %s for job %s: %s",
-                proc.returncode, job.id, " | ".join(tail) or "(no stderr)",
+                proc.returncode,
+                job.id,
+                " | ".join(tail) or "(no stderr)",
             )
             return False
         return True
     finally:
         set_proc(job.id, None)
+
 
 _TERMINAL = frozenset(("done", "error", "cancelled"))
 
@@ -77,9 +80,7 @@ def cleanup_source(job_dir: Path) -> None:
         f.unlink(missing_ok=True)
 
 
-def make_original_track(
-    job: Job, job_dir: Path, stems_dir: Path
-) -> Path | None:
+def make_original_track(job: Job, job_dir: Path, stems_dir: Path) -> Path | None:
     """Build the "Original" backing track at stems/original.wav as the
     sum of the stems the user did NOT select. This way the studio can
     play (original + each selected stem) and reconstruct the full song
@@ -121,9 +122,7 @@ def make_original_track(
     return out if _run_ffmpeg(job, cmd) else None
 
 
-def make_selected_mix(
-    job: Job, stems_dir: Path, found: list[str]
-) -> Path | None:
+def make_selected_mix(job: Job, stems_dir: Path, found: list[str]) -> Path | None:
     """If the user picked a strict subset of stems at submit time,
     sum those stems with ffmpeg amix into mix.wav. Returns the output
     path on success, or None when there's nothing to mix.

--- a/app/pipeline/runner.py
+++ b/app/pipeline/runner.py
@@ -42,10 +42,7 @@ def _run_blocking(job: Job, url: str, job_dir: Path) -> None:
     # from the demucs-emitted stems. Reclaim disk before the ffmpeg
     # amix steps in case they need scratch space.
     cleanup_source(job_dir)
-    job.stems = [
-        {"name": name, "url": f"/api/jobs/{job.id}/stems/{name}.wav"}
-        for name in found
-    ]
+    job.stems = [{"name": name, "url": f"/api/jobs/{job.id}/stems/{name}.wav"} for name in found]
     # Subset post-processing. When the user kept all 6 stems, both of
     # these are skipped -- the original is the sum of the stems and a
     # mix would equal the original. When a strict subset was chosen:
@@ -59,10 +56,13 @@ def _run_blocking(job: Job, url: str, job_dir: Path) -> None:
     _set(job, stage="Mixing tracks...")
     original_path = make_original_track(job, job_dir, stems_dir)
     if original_path is not None:
-        job.stems.insert(0, {
-            "name": "original",
-            "url": f"/api/jobs/{job.id}/stems/original.wav",
-        })
+        job.stems.insert(
+            0,
+            {
+                "name": "original",
+                "url": f"/api/jobs/{job.id}/stems/original.wav",
+            },
+        )
     _check_cancel(job)
     mix_path = make_selected_mix(job, stems_dir, found)
     if mix_path is not None:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -90,5 +90,14 @@ WORKDIR /app
 COPY app/ ./app/
 COPY static/ ./static/
 
+# Run as a non-root user. /app is owned by app so the process can
+# write nothing surprising; /cache is writable for torch/demucs model
+# downloads and /jobs is the standard mount point for job artifacts.
+RUN groupadd --system --gid 1001 app \
+    && useradd --system --uid 1001 --gid app --home /app --no-create-home app \
+    && mkdir -p /cache /jobs \
+    && chown -R app:app /app /cache /jobs
+USER app
+
 EXPOSE 8000
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
Adds `.woodpecker.yml` with lint, unit tests, and security scans. No build/publish steps.

**Steps**
- `lint`: ruff check + format-check + bash syntax on run.sh
- `test`: pytest (installs ffmpeg)
- `js-syntax`: node --check on static/js/*.js
- `sast-bandit`: Python SAST, fails on medium+
- `deps-audit`: pip-audit on resolved requirements
- `trivy-fs`: deps CVEs + secret scan + IaC misconfig (HIGH/CRITICAL)
- `trivy-config`: Dockerfile/compose linter on build/

Triggers on push and pull_request.