### PR TITLE
ci: allow manual trigger on windows-release pipeline from any branch

### DIFF
--- a/.woodpecker/windows-release.yml
+++ b/.woodpecker/windows-release.yml
@@ -1,5 +1,6 @@
 when:
   - event: release
+  - event: manual
 
 depends_on:
   - ci


### PR DESCRIPTION
Removes the branch: windows* restriction on the manual trigger so the windows-release pipeline can be kicked off from main or any branch.