### PR TITLE
fix: mixer volume/mute, download button, pyvenv.cfg portability, CI agent routing

### DIFF
--- a/.woodpecker/ci.yml
+++ b/.woodpecker/ci.yml
@@ -12,6 +12,8 @@ when:
 steps:
   lint:
     image: ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+    labels:
+      platform: linux/amd64
     environment:
       UV_LINK_MODE: copy
     commands:
@@ -22,6 +24,8 @@ steps:
 
   test:
     image: ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+    labels:
+      platform: linux/amd64
     environment:
       UV_LINK_MODE: copy
     commands:
@@ -31,11 +35,15 @@ steps:
 
   js-syntax:
     image: node:20-alpine
+    labels:
+      platform: linux/amd64
     commands:
       - for f in static/js/*.js; do node --check "$f"; done
 
   sast-bandit:
     image: ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+    labels:
+      platform: linux/amd64
     environment:
       UV_LINK_MODE: copy
     commands:
@@ -44,6 +52,8 @@ steps:
 
   deps-audit:
     image: ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+    labels:
+      platform: linux/amd64
     environment:
       UV_LINK_MODE: copy
     commands:
@@ -68,6 +78,8 @@ steps:
     # would scan its bundled extractor files and flag false-positive
     # secrets that ship inside third-party packages like yt-dlp).
     image: aquasec/trivy:latest
+    labels:
+      platform: linux/amd64
     commands:
       - trivy fs
           --scanners vuln,secret,misconfig
@@ -81,5 +93,7 @@ steps:
   trivy-config:
     # Dedicated Dockerfile + compose static analysis (Trivy's IaC linter).
     image: aquasec/trivy:latest
+    labels:
+      platform: linux/amd64
     commands:
       - trivy config --severity HIGH,CRITICAL --exit-code 1 build/

--- a/.woodpecker/windows-release.yml
+++ b/.woodpecker/windows-release.yml
@@ -1,5 +1,6 @@
 when:
   - event: release
+  - event: manual
 
 depends_on:
   - ci

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -332,12 +332,54 @@ fn cuda_tag_from_url(index_url: &str) -> &str {
     index_url.rsplit('/').next().unwrap_or("cu124")
 }
 
+/// Update pyvenv.cfg's `home` line to the actual Scripts directory of the
+/// bundled Python. The venv was created on the build machine, so `home` holds
+/// the builder's Python path (e.g. C:\Users\thale\...). pip validates that
+/// path before running and fails if it doesn't exist on the user's machine.
+/// We patch it once at runtime so every pip call works regardless of where
+/// the user extracted the zip.
+fn patch_pyvenv_cfg(python: &Path) {
+    let Some(scripts_dir) = python.parent() else {
+        return;
+    };
+    let Some(venv_root) = scripts_dir.parent() else {
+        return;
+    };
+    let cfg_path = venv_root.join("pyvenv.cfg");
+    let Ok(content) = fs::read_to_string(&cfg_path) else {
+        return;
+    };
+    let scripts_str = scripts_dir.display().to_string();
+    let patched: String = content
+        .lines()
+        .map(|line| {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("home") && trimmed[4..].trim_start().starts_with('=') {
+                format!("home = {scripts_str}")
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let patched = if content.ends_with('\n') {
+        patched + "\n"
+    } else {
+        patched
+    };
+    let _ = fs::write(&cfg_path, patched);
+}
+
 fn install_cuda_torch(python: &Path, index_url: &str) -> Result<(), String> {
     // Skip only when CUDA torch is already active — torch.version.cuda is
     // None for CPU-only wheels, so this correctly re-installs when needed.
     if verify_cuda_torch(python) {
         return Ok(());
     }
+
+    // Fix the build machine's Python path baked into pyvenv.cfg before pip
+    // runs — pip validates the `home` entry and fails if it doesn't exist.
+    patch_pyvenv_cfg(python);
 
     // Use the explicit local-version suffix (e.g. torch==2.6.0+cu124) so pip
     // treats the CUDA wheel as a distinct version from the CPU-only 2.6.0

--- a/static/js/audio.js
+++ b/static/js/audio.js
@@ -38,18 +38,23 @@ export function attachAnalysers() {
         // analyser taps the post-gain signal.
         audioEl.getGainNode().connect(analyser);
       } else {
-        // Bare HTMLAudioElement (Safari path -- captureStream isn't
-        // supported on <audio>, so we route the element through Web
-        // Audio via createMediaElementSource. Once converted, the
-        // element's output flows through the AudioContext: we send it
-        // to ctx.destination so the user still hears it, and tap a
-        // branch into the analyser. createMediaElementSource may only
-        // be called once per element, so we cache the source on it.
+        // Bare HTMLAudioElement: route through Web Audio so we can tap
+        // the post-gain signal. applyMix() may have already created the
+        // MediaElementSource + GainNode chain; re-use it if so (the spec
+        // only allows createMediaElementSource once per element).
         if (!audioEl._stMediaSource) {
           audioEl._stMediaSource = ctx.createMediaElementSource(audioEl);
-          audioEl._stMediaSource.connect(ctx.destination);
+          audioEl._stGainNode = ctx.createGain();
+          audioEl._stMediaSource.connect(audioEl._stGainNode);
+          audioEl._stGainNode.connect(ctx.destination);
+          audioEl.volume = 1;
+        } else if (!audioEl._stGainNode) {
+          audioEl._stGainNode = ctx.createGain();
+          audioEl._stMediaSource.connect(audioEl._stGainNode);
+          audioEl._stGainNode.connect(ctx.destination);
+          audioEl.volume = 1;
         }
-        audioEl._stMediaSource.connect(analyser);
+        audioEl._stGainNode.connect(analyser);
       }
     } catch (err) {
       console.warn("VU analyser hookup failed for stem", stemName, err);

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -104,6 +104,12 @@ document.addEventListener("keydown", (e) => {
 // ─── External links ───
 
 document.addEventListener("click", (e) => {
+  const dl = e.target.closest("a.lane-dl");
+  if (dl?.href) {
+    e.preventDefault();
+    window.__TAURI__.core.invoke("open_url", { url: dl.href });
+    return;
+  }
   const anchor = e.target.closest('a[target="_blank"]');
   if (anchor?.href) {
     e.preventDefault();

--- a/static/js/mixer.js
+++ b/static/js/mixer.js
@@ -54,14 +54,39 @@ export function applyMix() {
     else if (anySolo && !s.soloed) effective = 0;
     const idx = trackIndex[name];
     if (idx === undefined) continue;
-    // The bundled multitrack player uses HTMLAudioElement.volume on most
-    // browsers, which throws when set outside 0..1. One over-hot fader must
-    // not abort the whole mixer pass and leave later channels stale.
-    const volume = Math.max(0, Math.min(1, effective * masterVolume));
-    try {
-      multitrack.setTrackVolume(idx, volume);
-    } catch (err) {
-      console.warn(`[mixer] failed to set ${name} volume`, err);
+
+    const targetGain = effective * masterVolume;
+
+    // HTMLAudioElement.volume is capped at [0,1] by the browser spec.
+    // Values > 1 throw in Firefox/Safari (breaking the whole loop) and
+    // are silently clamped in Chrome (boost never audible). Route each
+    // HTMLAudioElement through a Web Audio GainNode instead — gain.value
+    // accepts any positive number, enabling real boost and reliable mute.
+    const audioEl = multitrack.audios?.[idx];
+    if (audioEl instanceof HTMLMediaElement) {
+      if (!audioEl._stGainNode) {
+        const ctx = multitrack.audioContext;
+        if (ctx) {
+          try {
+            if (!audioEl._stMediaSource) {
+              audioEl._stMediaSource = ctx.createMediaElementSource(audioEl);
+            }
+            audioEl._stGainNode = ctx.createGain();
+            audioEl._stMediaSource.connect(audioEl._stGainNode);
+            audioEl._stGainNode.connect(ctx.destination);
+            audioEl.volume = 1;
+          } catch (err) {
+            console.warn(`[mixer] GainNode setup failed for "${name}":`, err);
+          }
+        }
+      }
+      if (audioEl._stGainNode) {
+        audioEl._stGainNode.gain.value = targetGain;
+      } else {
+        multitrack.setTrackVolume(idx, Math.min(1, targetGain));
+      }
+    } else {
+      multitrack.setTrackVolume(idx, targetGain);
     }
   }
 }


### PR DESCRIPTION
## Summary

- **Mixer volume & mute** (`mixer.js`, `audio.js`): routes `HTMLAudioElement` tracks through a Web Audio `GainNode` so volume boost above 0 dB actually works and mute never gets permanently stuck. `HTMLAudioElement.volume` is capped at `[0, 1]` and throws in Firefox/Safari on out-of-range values, aborting the whole mixer loop. `GainNode.gain.value` accepts any positive number and eliminates the exception entirely. Closes #7 (full fix — previous patch only clamped the value).

- **Download button** (`main.js`): intercepts `.lane-dl` clicks and routes them through the existing `open_url` Tauri command so WAV downloads work in the Windows desktop app. Native `<a download>` is silently blocked by the Tauri webview.

- **pyvenv.cfg portability** (`main.rs`): patches the `home` entry in `pyvenv.cfg` at runtime before pip runs. The venv is built on the CI machine and records the builder's Python path; on any other machine pip fails to find that path and aborts the CUDA torch install. Closes #10.

- **CI agent routing** (`.woodpecker/ci.yml`): adds `labels: platform: linux/amd64` to every step so the Windows bare-metal agent never picks up Linux Docker image steps.

## Test plan

- [x] Load stems, drag a fader above center — audio level should increase beyond 0 dB
- [x] Mute a channel, unmute — audio should come back cleanly
- [x] Click a download button in the Windows desktop app — file should open in the default browser and download
- [x] Extract the NVIDIA zip on a machine that is not the build machine — CUDA torch install step should complete without "No Python at..." error
- [x] Trigger a pipeline run — CI steps should route to the Linux agent, Windows steps to the Windows agent