### PR TITLE
Fix Windows setup hang after data reset

### DIFF
--- a/.woodpecker/ci.yml
+++ b/.woodpecker/ci.yml
@@ -9,12 +9,13 @@ when:
     branch: main
   - event: release
 
+labels:
+  platform: linux/amd64
+  backend: kubernetes
+
 steps:
   lint:
     image: ghcr.io/astral-sh/uv:python3.12-bookworm-slim
-    labels:
-      platform: linux/amd64
-      backend: kubernetes
     environment:
       UV_LINK_MODE: copy
     commands:
@@ -25,9 +26,6 @@ steps:
 
   test:
     image: ghcr.io/astral-sh/uv:python3.12-bookworm-slim
-    labels:
-      platform: linux/amd64
-      backend: kubernetes
     environment:
       UV_LINK_MODE: copy
     commands:
@@ -37,17 +35,11 @@ steps:
 
   js-syntax:
     image: node:20-alpine
-    labels:
-      platform: linux/amd64
-      backend: kubernetes
     commands:
       - for f in static/js/*.js; do node --check "$f"; done
 
   sast-bandit:
     image: ghcr.io/astral-sh/uv:python3.12-bookworm-slim
-    labels:
-      platform: linux/amd64
-      backend: kubernetes
     environment:
       UV_LINK_MODE: copy
     commands:
@@ -56,9 +48,6 @@ steps:
 
   deps-audit:
     image: ghcr.io/astral-sh/uv:python3.12-bookworm-slim
-    labels:
-      platform: linux/amd64
-      backend: kubernetes
     environment:
       UV_LINK_MODE: copy
     commands:
@@ -83,9 +72,6 @@ steps:
     # would scan its bundled extractor files and flag false-positive
     # secrets that ship inside third-party packages like yt-dlp).
     image: aquasec/trivy:latest
-    labels:
-      platform: linux/amd64
-      backend: kubernetes
     commands:
       - trivy fs
           --scanners vuln,secret,misconfig
@@ -99,8 +85,5 @@ steps:
   trivy-config:
     # Dedicated Dockerfile + compose static analysis (Trivy's IaC linter).
     image: aquasec/trivy:latest
-    labels:
-      platform: linux/amd64
-      backend: kubernetes
     commands:
       - trivy config --severity HIGH,CRITICAL --exit-code 1 build/

--- a/.woodpecker/windows-release.yml
+++ b/.woodpecker/windows-release.yml
@@ -11,6 +11,7 @@ steps:
     commands:
       - powershell -NoProfile -ExecutionPolicy Bypass -File scripts/windows/make-portable.ps1
           -PackageName StemDeck-Windows-x64.NVIDIA
+          -PackageVersion "$env:CI_COMMIT_TAG"
           -StripVenv
 
   build-windows-cpu:
@@ -18,6 +19,7 @@ steps:
     commands:
       - powershell -NoProfile -ExecutionPolicy Bypass -File scripts/windows/make-portable.ps1
           -PackageName StemDeck-Windows-x64
+          -PackageVersion "$env:CI_COMMIT_TAG"
           -CpuOnly
           -StripVenv
 

--- a/.woodpecker/windows-release.yml
+++ b/.woodpecker/windows-release.yml
@@ -49,6 +49,15 @@ steps:
         if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
           throw "GitHub CLI is required on the Windows agent to upload release assets."
         }
+      - |
+        $scanNote = "Windows portable packages were scanned with ClamAV in CI before upload."
+        $body = gh release view "$env:CI_COMMIT_TAG" --repo "thcp/stemdeck" --json body --jq ".body"
+        if ($body -notlike "*$scanNote*") {
+          $notesPath = Join-Path $env:TEMP "stemdeck-release-notes.md"
+          $updatedBody = (($body.TrimEnd()), "", "### Artifact scan", "", "- $scanNote") -join "`n"
+          Set-Content -Path $notesPath -Value $updatedBody -Encoding UTF8
+          gh release edit "$env:CI_COMMIT_TAG" --repo "thcp/stemdeck" --notes-file $notesPath
+        }
       - gh release upload "$env:CI_COMMIT_TAG"
           "dist/StemDeck-Windows-x64.NVIDIA.zip"
           "dist/StemDeck-Windows-x64.NVIDIA.zip.sha256"

--- a/.woodpecker/windows-release.yml
+++ b/.woodpecker/windows-release.yml
@@ -1,12 +1,13 @@
 when:
   - event: release
 
+labels:
+  platform: windows/amd64
+  backend: local
+
 steps:
   build-windows-nvidia:
     image: powershell
-    labels:
-      platform: windows/amd64
-      backend: local
     commands:
       - powershell -NoProfile -ExecutionPolicy Bypass -File scripts/windows/make-portable.ps1
           -PackageName StemDeck-Windows-x64.NVIDIA
@@ -14,9 +15,6 @@ steps:
 
   build-windows-cpu:
     image: powershell
-    labels:
-      platform: windows/amd64
-      backend: local
     depends_on:
       - build-windows-nvidia
     commands:
@@ -28,9 +26,6 @@ steps:
 
   scan-windows-artifacts:
     image: powershell
-    labels:
-      platform: windows/amd64
-      backend: local
     depends_on:
       - build-windows-cpu
     commands:
@@ -40,9 +35,6 @@ steps:
     image: powershell
     when:
       - event: release
-    labels:
-      platform: windows/amd64
-      backend: local
     depends_on:
       - scan-windows-artifacts
     environment:

--- a/.woodpecker/windows-release.yml
+++ b/.woodpecker/windows-release.yml
@@ -15,14 +15,11 @@ steps:
 
   build-windows-cpu:
     image: powershell
-    depends_on:
-      - build-windows-nvidia
     commands:
       - powershell -NoProfile -ExecutionPolicy Bypass -File scripts/windows/make-portable.ps1
           -PackageName StemDeck-Windows-x64
           -CpuOnly
           -StripVenv
-          -SkipTauriBuild
 
   scan-windows-artifacts:
     image: powershell

--- a/.woodpecker/windows-release.yml
+++ b/.woodpecker/windows-release.yml
@@ -29,7 +29,33 @@ steps:
     depends_on:
       - build-windows-cpu
     commands:
-      - docker run --rm -v "${PWD}/dist:/scan" clamav/clamav:latest clamscan --no-summary --infected /scan
+      - |
+        Write-Host "Preparing ClamAV scan for Windows release artifacts..."
+        Write-Host "Artifacts staged in: $PWD\dist"
+        Get-ChildItem -Path "dist" -File |
+          Sort-Object Name |
+          Select-Object Name,
+            @{Name="SizeMB"; Expression={ [math]::Round($_.Length / 1MB, 2) }} |
+          Format-Table -AutoSize
+
+        Write-Host "SHA256 checksums:"
+        Get-ChildItem -Path "dist" -Filter "*.zip" -File |
+          Sort-Object Name |
+          ForEach-Object {
+            $hash = Get-FileHash -Algorithm SHA256 $_.FullName
+            Write-Host "  $($hash.Hash)  $($_.Name)"
+          }
+
+        Write-Host "Pulling latest ClamAV scanner image..."
+        docker pull clamav/clamav:latest
+
+        Write-Host "Running ClamAV scan over dist/..."
+        docker run --rm -v "${PWD}/dist:/scan:ro" clamav/clamav:latest `
+          clamscan --recursive --infected --bell --summary /scan
+        if ($LASTEXITCODE -ne 0) {
+          throw "ClamAV scan failed or reported infected files. Exit code: $LASTEXITCODE"
+        }
+        Write-Host "ClamAV scan completed successfully. No infected files reported."
 
   upload-windows-artifacts:
     image: powershell

--- a/app/main.py
+++ b/app/main.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from importlib.metadata import PackageNotFoundError, version as package_version
 
 from fastapi import FastAPI, Request
 from fastapi.staticfiles import StaticFiles
@@ -41,6 +43,21 @@ except ImportError:
 _log = logging.getLogger("stemdeck")
 
 
+def app_version() -> str:
+    version_file = STATIC_DIR / "version.json"
+    try:
+        data = json.loads(version_file.read_text(encoding="utf-8"))
+        value = str(data.get("version", "")).strip().removeprefix("v")
+        if value:
+            return value
+    except (OSError, json.JSONDecodeError):
+        pass
+    try:
+        return package_version("stemdeck")
+    except PackageNotFoundError:
+        return "0.0.0-dev"
+
+
 async def _sweep_loop() -> None:
     while True:
         try:
@@ -69,7 +86,7 @@ def health() -> dict[str, object]:
     return {
         "name": "StemDeck",
         "status": "ok",
-        "version": "0.1.0",
+        "version": app_version(),
         "ffmpeg_configured": FFMPEG_BIN.is_file(),
         "demucs_model": DEMUCS_MODEL,
         "demucs_device": DEMUCS_DEVICE,

--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,8 @@ import json
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from importlib.metadata import PackageNotFoundError, version as package_version
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as package_version
 
 from fastapi import FastAPI, Request
 from fastapi.staticfiles import StaticFiles

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -160,6 +160,16 @@ fn start_backend(state: tauri::State<BackendState>) -> Result<BackendStarted, St
     patch_pyvenv_cfg(&python);
     let port = free_port()?;
     let url = format!("http://127.0.0.1:{port}");
+    let log_path = data_dir.join("logs").join("backend.log");
+    if let Some(parent) = log_path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("failed to create backend log directory: {e}"))?;
+    }
+    let log_file = File::create(&log_path)
+        .map_err(|e| format!("failed to create backend log {}: {e}", log_path.display()))?;
+    let log_file_for_stderr = log_file
+        .try_clone()
+        .map_err(|e| format!("failed to prepare backend log {}: {e}", log_path.display()))?;
 
     let mut cmd = Command::new(python);
     cmd.args([
@@ -177,8 +187,8 @@ fn start_backend(state: tauri::State<BackendState>) -> Result<BackendStarted, St
         .env("PYTHONUNBUFFERED", "1")
         .env("XDG_CACHE_HOME", data_dir.join("cache"))
         .env("TORCH_HOME", data_dir.join("models").join("torch"))
-        .stdout(Stdio::null())
-        .stderr(Stdio::piped());
+        .stdout(Stdio::from(log_file))
+        .stderr(Stdio::from(log_file_for_stderr));
 
     if let Some(ffmpeg_dir) = ffmpeg_dir_if_present(&data_dir) {
         let existing = env::var_os("PATH").unwrap_or_default();
@@ -200,7 +210,7 @@ fn start_backend(state: tauri::State<BackendState>) -> Result<BackendStarted, St
         .map_err(|e| format!("failed to start backend: {e}"))?;
     *state.child.lock().map_err(|e| e.to_string())? = Some(child);
 
-    wait_for_health(port, Duration::from_secs(30))?;
+    wait_for_health(port, Duration::from_secs(90), &log_path)?;
     *state.url.lock().map_err(|e| e.to_string())? = Some(url.clone());
     Ok(BackendStarted { url })
 }
@@ -580,17 +590,43 @@ fn free_port() -> Result<u16, String> {
     Ok(port)
 }
 
-fn wait_for_health(port: u16, timeout: Duration) -> Result<(), String> {
+fn wait_for_health(port: u16, timeout: Duration, log_path: &Path) -> Result<(), String> {
     let deadline = Instant::now() + timeout;
     loop {
         if Instant::now() >= deadline {
-            return Err("backend did not become healthy before timeout".to_string());
+            let tail = file_tail(log_path, 30);
+            let hint = if tail.trim().is_empty() {
+                format!(
+                    "No backend log output was captured at {}.",
+                    log_path.display()
+                )
+            } else {
+                format!(
+                    "Last backend log lines from {}:\n{}",
+                    log_path.display(),
+                    tail
+                )
+            };
+            return Err(format!(
+                "backend did not become healthy within {} seconds.\n\n{}",
+                timeout.as_secs(),
+                hint
+            ));
         }
         if health_once(port).is_ok() {
             return Ok(());
         }
         thread::sleep(Duration::from_millis(250));
     }
+}
+
+fn file_tail(path: &Path, max_lines: usize) -> String {
+    fs::read_to_string(path)
+        .map(|text| {
+            let lines: Vec<&str> = text.lines().rev().take(max_lines).collect();
+            lines.into_iter().rev().collect::<Vec<_>>().join("\n")
+        })
+        .unwrap_or_default()
 }
 
 fn health_once(port: u16) -> Result<(), String> {

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -150,6 +150,7 @@ fn start_backend(state: tauri::State<BackendState>) -> Result<BackendStarted, St
     if let Some(url) = state.url.lock().map_err(|e| e.to_string())?.clone() {
         return Ok(BackendStarted { url });
     }
+    stop_backend(&state);
 
     let root = app_root()?;
     let backend_dir = backend_dir(&root)?;
@@ -205,12 +206,17 @@ fn start_backend(state: tauri::State<BackendState>) -> Result<BackendStarted, St
         cmd.creation_flags(CREATE_NO_WINDOW);
     }
 
-    let child = cmd
+    let mut child = cmd
         .spawn()
         .map_err(|e| format!("failed to start backend: {e}"))?;
-    *state.child.lock().map_err(|e| e.to_string())? = Some(child);
 
-    wait_for_health(port, Duration::from_secs(90), &log_path)?;
+    if let Err(err) = wait_for_health(port, Duration::from_secs(90), &log_path) {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(err);
+    }
+
+    *state.child.lock().map_err(|e| e.to_string())? = Some(child);
     *state.url.lock().map_err(|e| e.to_string())? = Some(url.clone());
     Ok(BackendStarted { url })
 }

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -363,12 +363,9 @@ fn cuda_tag_from_url(index_url: &str) -> &str {
     index_url.rsplit('/').next().unwrap_or("cu124")
 }
 
-/// Update pyvenv.cfg's `home` line to the actual Scripts directory of the
-/// bundled Python. The venv was created on the build machine, so `home` holds
-/// the builder's Python path (e.g. C:\Users\thale\...). pip validates that
-/// path before running and fails if it doesn't exist on the user's machine.
-/// We patch it once at runtime so every pip call works regardless of where
-/// the user extracted the zip.
+/// Update pyvenv.cfg to the bundled Python runtime. Windows venv launchers read
+/// this file before Python starts, so stale build-machine paths can prevent the
+/// backend from emitting any log output at all.
 fn patch_pyvenv_cfg(python: &Path) {
     let Some(scripts_dir) = python.parent() else {
         return;
@@ -376,17 +373,30 @@ fn patch_pyvenv_cfg(python: &Path) {
     let Some(venv_root) = scripts_dir.parent() else {
         return;
     };
+    let bundled_python = venv_root.join(if cfg!(windows) {
+        "python.exe"
+    } else {
+        "python"
+    });
+    if !bundled_python.is_file() || !venv_root.join("Lib").join("os.py").is_file() {
+        return;
+    }
     let cfg_path = venv_root.join("pyvenv.cfg");
     let Ok(content) = fs::read_to_string(&cfg_path) else {
         return;
     };
-    let scripts_str = scripts_dir.display().to_string();
+    let root_str = venv_root.display().to_string();
+    let python_str = bundled_python.display().to_string();
     let patched: String = content
         .lines()
         .map(|line| {
             let trimmed = line.trim_start();
             if trimmed.starts_with("home") && trimmed[4..].trim_start().starts_with('=') {
-                format!("home = {scripts_str}")
+                format!("home = {root_str}")
+            } else if trimmed.starts_with("executable")
+                && trimmed["executable".len()..].trim_start().starts_with('=')
+            {
+                format!("executable = {python_str}")
             } else {
                 line.to_string()
             }

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -4,7 +4,7 @@ use std::{
     io::{Read, Write},
     net::{TcpListener, TcpStream},
     path::{Path, PathBuf},
-    process::{Child, Command, Stdio},
+    process::{Child, Command, Output, Stdio},
     sync::Mutex,
     thread,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
@@ -85,6 +85,9 @@ fn probe_runtime() -> Result<RuntimeProbe, String> {
     let root = app_root()?;
     let data_dir = root.join("data");
     let python = python_path(&root);
+    if let Some(path) = python.as_deref() {
+        patch_pyvenv_cfg(path);
+    }
     let ffmpeg = ffmpeg_path(&data_dir);
     let torch_device = read_config_str(&data_dir, "torchDevice");
     Ok(RuntimeProbe {
@@ -107,10 +110,15 @@ fn read_config_str(data_dir: &std::path::Path, key: &str) -> Option<String> {
 
 #[tauri::command]
 fn ensure_workspace() -> Result<(), String> {
-    let data = app_root()?.join("data");
+    let root = app_root()?;
+    let data = root.join("data");
     for dir in ["cache", "downloads", "ffmpeg", "jobs", "logs", "models"] {
         fs::create_dir_all(data.join(dir))
             .map_err(|e| format!("failed to create data/{dir}: {e}"))?;
+    }
+    if is_cpu_only_package(&root) {
+        fs::write(data.join("cpu-only"), "")
+            .map_err(|e| format!("failed to write data/cpu-only: {e}"))?;
     }
     let config = data.join("config.json");
     if !config.exists() {
@@ -149,6 +157,7 @@ fn start_backend(state: tauri::State<BackendState>) -> Result<BackendStarted, St
     let python = python_path(&root).filter(|p| p.is_file()).ok_or_else(|| {
         "Python runtime not found. Expected python/ or .venv/ under StemDeck.".to_string()
     })?;
+    patch_pyvenv_cfg(&python);
     let port = free_port()?;
     let url = format!("http://127.0.0.1:{port}");
 
@@ -202,7 +211,7 @@ fn ensure_torch_device() -> Result<GpuSetup, String> {
     let data_dir = root.join("data");
 
     // CPU-only portable build: skip GPU detection and pip entirely.
-    if data_dir.join("cpu-only").exists() {
+    if is_cpu_only_package(&root) {
         persist_torch_device(&data_dir, "cpu");
         return Ok(GpuSetup {
             gpu_detected: false,
@@ -216,6 +225,7 @@ fn ensure_torch_device() -> Result<GpuSetup, String> {
     let python = python_path(&root)
         .filter(|p| p.is_file())
         .ok_or_else(|| "Python not found".to_string())?;
+    patch_pyvenv_cfg(&python);
 
     let setup = match detect_nvidia_gpu() {
         Some((gpu_name, cuda_version)) => {
@@ -241,6 +251,10 @@ fn ensure_torch_device() -> Result<GpuSetup, String> {
     // Persist so subsequent launches skip this step entirely.
     persist_torch_device(&data_dir, &setup.torch_device);
     Ok(setup)
+}
+
+fn is_cpu_only_package(root: &Path) -> bool {
+    root.join("cpu-only").is_file() || root.join("data").join("cpu-only").is_file()
 }
 
 fn persist_torch_device(data_dir: &std::path::Path, device: &str) {
@@ -270,7 +284,7 @@ fn detect_nvidia_gpu() -> Option<(String, String)> {
         .stdout(Stdio::piped())
         .stderr(Stdio::null());
     hide_console_window(&mut cmd);
-    let name_out = cmd.output().ok()?;
+    let name_out = command_output_with_timeout(cmd, Duration::from_secs(10), "nvidia-smi").ok()?;
     if !name_out.status.success() {
         return None;
     }
@@ -283,7 +297,8 @@ fn detect_nvidia_gpu() -> Option<(String, String)> {
     let mut smi_cmd = Command::new(smi);
     smi_cmd.stdout(Stdio::piped()).stderr(Stdio::null());
     hide_console_window(&mut smi_cmd);
-    let smi_out = smi_cmd.output().ok()?;
+    let smi_out =
+        command_output_with_timeout(smi_cmd, Duration::from_secs(10), "nvidia-smi").ok()?;
     let smi_text = String::from_utf8_lossy(&smi_out.stdout);
     let cuda_version = parse_cuda_version(&smi_text).unwrap_or_else(|| "12.4".to_string());
 
@@ -389,7 +404,8 @@ fn install_cuda_torch(python: &Path, index_url: &str) -> Result<(), String> {
     let torchaudio_spec = format!("torchaudio==2.6.0+{tag}");
     // --ignore-installed: overwrites even a corrupted/partial install that
     // has no RECORD file. --no-deps: only replace torch/torchaudio wheels.
-    let output = Command::new(python)
+    let mut command = Command::new(python);
+    command
         .args([
             "-m",
             "pip",
@@ -403,9 +419,9 @@ fn install_cuda_torch(python: &Path, index_url: &str) -> Result<(), String> {
             "--quiet",
         ])
         .stdout(Stdio::null())
-        .stderr(Stdio::piped())
-        .output()
-        .map_err(|e| format!("failed to run pip: {e}"))?;
+        .stderr(Stdio::piped());
+    let output =
+        command_output_with_timeout(command, Duration::from_secs(20 * 60), "CUDA torch install")?;
 
     if output.status.success() {
         Ok(())
@@ -435,7 +451,8 @@ fn open_url(url: String) -> Result<(), String> {
         let mut cmd = Command::new("cmd");
         cmd.args(["/c", "start", "", &url]);
         hide_console_window(&mut cmd);
-        cmd.spawn().map_err(|e| format!("failed to open URL: {e}"))?;
+        cmd.spawn()
+            .map_err(|e| format!("failed to open URL: {e}"))?;
     }
     #[cfg(not(windows))]
     {
@@ -656,9 +673,8 @@ fn download_file_with_powershell(url: &str, target: &Path) -> Result<(), String>
         .stdout(Stdio::null())
         .stderr(Stdio::piped());
     hide_console_window(&mut command);
-    let output = command
-        .output()
-        .map_err(|e| format!("failed to start FFmpeg download: {e}"))?;
+    let output =
+        command_output_with_timeout(command, Duration::from_secs(5 * 60), "FFmpeg download")?;
     if output.status.success() && target.is_file() {
         Ok(())
     } else {
@@ -729,8 +745,7 @@ fn verify_ffmpeg(path: &Path) -> Result<(), String> {
         .stdout(Stdio::null())
         .stderr(Stdio::piped());
     hide_console_window(&mut command);
-    let output = command
-        .output()
+    let output = command_output_with_timeout(command, Duration::from_secs(15), "FFmpeg check")
         .map_err(|e| format!("failed to run FFmpeg at {}: {e}", path.display()))?;
     if output.status.success() {
         Ok(())
@@ -799,6 +814,51 @@ fn update_setup_config<const N: usize>(
         .map_err(|e| format!("failed to serialize setup config: {e}"))?;
     fs::write(&config_path, body + "\n")
         .map_err(|e| format!("failed to write {}: {e}", config_path.display()))
+}
+
+fn command_output_with_timeout(
+    mut command: Command,
+    timeout: Duration,
+    label: &str,
+) -> Result<Output, String> {
+    let mut child = command
+        .spawn()
+        .map_err(|e| format!("failed to start {label}: {e}"))?;
+    let deadline = Instant::now() + timeout;
+
+    loop {
+        if let Some(status) = child
+            .try_wait()
+            .map_err(|e| format!("failed to wait for {label}: {e}"))?
+        {
+            let mut stdout = Vec::new();
+            if let Some(mut pipe) = child.stdout.take() {
+                let _ = pipe.read_to_end(&mut stdout);
+            }
+
+            let mut stderr = Vec::new();
+            if let Some(mut pipe) = child.stderr.take() {
+                let _ = pipe.read_to_end(&mut stderr);
+            }
+
+            return Ok(Output {
+                status,
+                stdout,
+                stderr,
+            });
+        }
+
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(format!(
+                "{label} timed out after {} seconds",
+                timeout.as_secs()
+            ));
+        }
+
+        thread::sleep(Duration::from_millis(100));
+    }
 }
 
 #[cfg(windows)]

--- a/desktop/ui/index.html
+++ b/desktop/ui/index.html
@@ -18,8 +18,8 @@
         <ol class="setup-steps" id="steps">
           <li data-step="runtime">Checking portable runtime</li>
           <li data-step="workspace">Creating workspace</li>
-          <li data-step="gpu">Configuring compute device</li>
           <li data-step="ffmpeg">Checking FFmpeg</li>
+          <li data-step="gpu">Configuring compute device</li>
           <li data-step="model">Checking AI separation model</li>
           <li data-step="backend">Starting backend</li>
         </ol>

--- a/desktop/ui/setup.js
+++ b/desktop/ui/setup.js
@@ -17,7 +17,6 @@ function setStatus(message) {
 }
 
 function showError(error) {
-  // Mark any step still spinning as errored, then show the error panel.
   for (const el of steps) {
     if (el.classList.contains("active")) {
       el.classList.replace("active", "error");
@@ -29,7 +28,6 @@ function showError(error) {
   retryBtn.classList.remove("hidden");
 }
 
-// Marks a step active, runs fn(), then marks done — or marks error and rethrows.
 async function runStep(name, fn) {
   setStep(name, "active");
   try {
@@ -42,8 +40,6 @@ async function runStep(name, fn) {
   }
 }
 
-// Resolves after at least `ms` milliseconds AND one animation frame, so state
-// changes are always visually distinct (not batched into the same paint).
 function minDelay(ms) {
   return Promise.all([
     new Promise((r) => setTimeout(r, ms)),
@@ -57,17 +53,13 @@ async function runSetup() {
   for (const step of steps) step.classList.remove("active", "done", "error");
 
   try {
-    // ── Step 1: runtime (serial — everything else needs the python path) ──
     setStep("runtime", "active");
     setStatus("Checking Python runtime...");
-    // Run with a minimum display time so the active state is always painted
-    // before we transition — probe_runtime resolves in < 1 frame on warm starts.
     const [runtime] = await Promise.all([
       invoke("probe_runtime"),
       minDelay(350),
     ]);
 
-    // Fast path: config from a previous run confirms everything is ready.
     if (runtime.pythonReady && runtime.ffmpegReady && runtime.torchDevice) {
       for (const step of steps) {
         step.classList.remove("active", "error");
@@ -87,65 +79,46 @@ async function runSetup() {
     }
     setStep("runtime", "done");
     setStatus(`Python runtime found at ${runtime.pythonPath}`);
-    // Ensure runtime=done is painted before workspace+gpu go active.
     await minDelay(200);
-
-    // ── Steps 2-4: parallel phase ─────────────────────────────────────────
-    //
-    // Dependency graph:
-    //   workspace → ffmpeg  ┐
-    //   gpu                 ├─→ (all done) → model → backend
-    //
-    // workspace and gpu are independent — run them concurrently.
-    // ffmpeg needs workspace (data/ffmpeg/ dir must exist first).
 
     let gpuSummary = "";
 
-    // Chain: workspace → ffmpeg (IIFE keeps async/await consistent)
-    const workspaceChain = (async () => {
-      await runStep("workspace", () => invoke("ensure_workspace"));
+    await runStep("workspace", () => invoke("ensure_workspace"));
 
-      if (runtime.ffmpegReady) {
-        setStep("ffmpeg", "done");
-      } else {
-        await runStep("ffmpeg", async () => {
-          setStatus("Downloading FFmpeg… (this may take a minute)");
-          const assets = await invoke("ensure_external_assets");
-          if (!assets.ffmpegReady) {
-            throw new Error(
-              "FFmpeg setup did not complete. Check your internet connection and retry."
-            );
-          }
-        });
-      }
-    })();
+    if (runtime.ffmpegReady) {
+      setStep("ffmpeg", "done");
+    } else {
+      await runStep("ffmpeg", async () => {
+        setStatus("Downloading FFmpeg... (this may take a minute)");
+        const assets = await invoke("ensure_external_assets");
+        if (!assets.ffmpegReady) {
+          throw new Error(
+            "FFmpeg setup did not complete. Check your internet connection and retry."
+          );
+        }
+      });
+    }
 
-    // GPU detection + torch install (independent of workspace)
-    const gpuTask = runStep("gpu", async () => {
+    await runStep("gpu", async () => {
+      setStatus("Configuring compute device...");
       const gpu = await invoke("ensure_torch_device");
       gpuSummary = gpu.gpuDetected
         ? gpu.cudaVerified
-          ? `${gpu.gpuName} — CUDA ${gpu.cudaVersion} enabled`
-          : `${gpu.gpuName} found — falling back to CPU (CUDA unverified)`
-        : "No NVIDIA GPU — stem separation will use CPU";
+          ? `${gpu.gpuName} - CUDA ${gpu.cudaVersion} enabled`
+          : `${gpu.gpuName} found - falling back to CPU (CUDA unverified)`
+        : "No NVIDIA GPU - stem separation will use CPU";
       return gpu;
     });
 
-    setStatus("Detecting GPU and preparing workspace…");
-    await Promise.all([workspaceChain, gpuTask]);
-
-    // ── Step 5: model (no async work — goes straight to done) ────────────
     setStep("model", "done");
     setStatus("AI separation model will download on first use (~340 MB).");
 
-    // ── Step 6: backend (serial — needs everything above) ─────────────────
     await runStep("backend", async () => {
-      setStatus(gpuSummary ? `${gpuSummary} — starting backend…` : "Starting StemDeck backend…");
+      setStatus(gpuSummary ? `${gpuSummary} - starting backend...` : "Starting StemDeck backend...");
       const backend = await invoke("start_backend");
       setStatus("Opening StemDeck...");
       window.location.replace(backend.url);
     });
-
   } catch (error) {
     showError(error);
   }

--- a/desktop/ui/setup.js
+++ b/desktop/ui/setup.js
@@ -91,11 +91,18 @@ async function runSetup() {
     if (runtime.pythonReady && runtime.ffmpegReady && runtime.torchDevice) {
       for (const step of steps) {
         step.classList.remove("active", "error");
-        step.classList.add("done");
+        if (step.dataset.step === "backend") {
+          step.classList.remove("done");
+        } else {
+          step.classList.add("done");
+        }
       }
-      setStatus("All systems ready. Starting StemDeck...");
-      const backend = await invoke("start_backend");
-      window.location.replace(backend.url);
+      await runStep("backend", async () => {
+        setStatus("Runtime is ready. Starting StemDeck backend...");
+        const backend = await invoke("start_backend");
+        setStatus("Opening StemDeck...");
+        window.location.replace(backend.url);
+      });
       return;
     }
 

--- a/desktop/ui/setup.js
+++ b/desktop/ui/setup.js
@@ -47,6 +47,34 @@ function minDelay(ms) {
   ]);
 }
 
+function formatElapsed(startedAt) {
+  const seconds = Math.floor((Date.now() - startedAt) / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const rest = seconds % 60;
+  return minutes > 0 ? `${minutes}m ${rest}s` : `${rest}s`;
+}
+
+function startProgressStatus(messages) {
+  const startedAt = Date.now();
+  let messageIndex = 0;
+
+  const update = () => {
+    const elapsedSeconds = Math.floor((Date.now() - startedAt) / 1000);
+    while (
+      messageIndex + 1 < messages.length &&
+      elapsedSeconds >= messages[messageIndex + 1].afterSeconds
+    ) {
+      messageIndex += 1;
+    }
+
+    setStatus(`${messages[messageIndex].text} Elapsed: ${formatElapsed(startedAt)}.`);
+  };
+
+  update();
+  const timer = window.setInterval(update, 10000);
+  return () => window.clearInterval(timer);
+}
+
 async function runSetup() {
   detailsEl.classList.add("hidden");
   retryBtn.classList.add("hidden");
@@ -89,25 +117,61 @@ async function runSetup() {
       setStep("ffmpeg", "done");
     } else {
       await runStep("ffmpeg", async () => {
-        setStatus("Downloading FFmpeg... (this may take a minute)");
-        const assets = await invoke("ensure_external_assets");
-        if (!assets.ffmpegReady) {
-          throw new Error(
-            "FFmpeg setup did not complete. Check your internet connection and retry."
-          );
+        const stopProgress = startProgressStatus([
+          {
+            afterSeconds: 0,
+            text: "Downloading FFmpeg... this can take a few minutes on first run.",
+          },
+          {
+            afterSeconds: 60,
+            text: "Still downloading FFmpeg... slow networks or antivirus scans can delay this.",
+          },
+        ]);
+
+        try {
+          const assets = await invoke("ensure_external_assets");
+          if (!assets.ffmpegReady) {
+            throw new Error(
+              "FFmpeg setup did not complete. Check your internet connection and retry."
+            );
+          }
+        } finally {
+          stopProgress();
         }
       });
     }
 
     await runStep("gpu", async () => {
-      setStatus("Configuring compute device...");
-      const gpu = await invoke("ensure_torch_device");
-      gpuSummary = gpu.gpuDetected
-        ? gpu.cudaVerified
-          ? `${gpu.gpuName} - CUDA ${gpu.cudaVersion} enabled`
-          : `${gpu.gpuName} found - falling back to CPU (CUDA unverified)`
-        : "No NVIDIA GPU - stem separation will use CPU";
-      return gpu;
+      const stopProgress = startProgressStatus([
+        {
+          afterSeconds: 0,
+          text: "Checking NVIDIA GPU and compute support...",
+        },
+        {
+          afterSeconds: 20,
+          text: "Installing NVIDIA acceleration if needed... first run can take 5-15 minutes.",
+        },
+        {
+          afterSeconds: 120,
+          text: "Still installing NVIDIA acceleration... CUDA Torch packages are large.",
+        },
+        {
+          afterSeconds: 300,
+          text: "Still working... setup should finish or time out automatically.",
+        },
+      ]);
+
+      try {
+        const gpu = await invoke("ensure_torch_device");
+        gpuSummary = gpu.gpuDetected
+          ? gpu.cudaVerified
+            ? `${gpu.gpuName} - CUDA ${gpu.cudaVersion} enabled`
+            : `${gpu.gpuName} found - falling back to CPU (CUDA unverified)`
+          : "No NVIDIA GPU - stem separation will use CPU";
+        return gpu;
+      } finally {
+        stopProgress();
+      }
     });
 
     setStep("model", "done");

--- a/desktop/ui/setup.js
+++ b/desktop/ui/setup.js
@@ -71,7 +71,7 @@ function startProgressStatus(messages) {
   };
 
   update();
-  const timer = window.setInterval(update, 10000);
+  const timer = window.setInterval(update, 1000);
   return () => window.clearInterval(timer);
 }
 

--- a/scripts/windows/make-portable.ps1
+++ b/scripts/windows/make-portable.ps1
@@ -39,6 +39,32 @@ function Copy-Tree([string]$Source, [string]$Destination) {
   Copy-Item -Recurse -Force $Source $Destination
 }
 
+function Assert-Fresh-TauriBuild {
+  if (-not (Test-Path $TargetExe)) {
+    throw "Tauri executable not found at $TargetExe. Remove -SkipTauriBuild or build the NVIDIA package first."
+  }
+
+  $exe = Get-Item $TargetExe
+  $newerSources = @(
+    Get-ChildItem -Path (Join-Path $DesktopDir "ui") -File -Recurse
+    Get-ChildItem -Path (Join-Path $TauriDir "src") -File -Recurse
+    Get-Item (Join-Path $TauriDir "Cargo.toml")
+    Get-Item (Join-Path $TauriDir "tauri.conf.json")
+  ) | Where-Object { $_.LastWriteTimeUtc -gt $exe.LastWriteTimeUtc }
+
+  if ($newerSources.Count -gt 0) {
+    $list = ($newerSources | Select-Object -First 8 | ForEach-Object { "  - $($_.FullName)" }) -join "`n"
+    throw @"
+-SkipTauriBuild would package a stale StemDeck.exe.
+
+The existing executable is older than desktop UI/Tauri source files:
+$list
+
+Remove -SkipTauriBuild or run the NVIDIA package build first so the CPU package reuses a fresh executable.
+"@
+  }
+}
+
 Require-Command "node"
 Require-Command "npm"
 Require-Command "cargo"
@@ -123,6 +149,8 @@ try {
     $env:CI = "true"  # Woodpecker sets CI=woodpecker; Tauri only accepts true/false
     rustup default stable
     npm run tauri build
+  } else {
+    Assert-Fresh-TauriBuild
   }
 } finally {
   Pop-Location

--- a/scripts/windows/make-portable.ps1
+++ b/scripts/windows/make-portable.ps1
@@ -64,6 +64,7 @@ foreach ($Dir in @("cache", "downloads", "ffmpeg", "jobs", "logs", "models")) {
   New-Item -ItemType Directory -Force (Join-Path $Stage "data\$Dir") | Out-Null
 }
 if ($CpuOnly) {
+  New-Item -ItemType File -Force (Join-Path $Stage "cpu-only") | Out-Null
   New-Item -ItemType File -Force (Join-Path $Stage "data\cpu-only") | Out-Null
 }
 

--- a/scripts/windows/make-portable.ps1
+++ b/scripts/windows/make-portable.ps1
@@ -2,6 +2,7 @@ param(
   [string]$Configuration = "release",
   [string]$OutputRoot    = "dist",
   [string]$PackageName   = "StemDeck-Windows-x64",
+  [string]$PackageVersion,
   [switch]$SkipTauriBuild,
   [switch]$CpuOnly,
   [switch]$StripVenv
@@ -37,6 +38,74 @@ function Copy-Tree([string]$Source, [string]$Destination) {
     Remove-Item -Recurse -Force $Destination
   }
   Copy-Item -Recurse -Force $Source $Destination
+}
+
+function Copy-TreeContents([string]$Source, [string]$Destination, [string[]]$ExcludeNames = @()) {
+  New-Item -ItemType Directory -Force $Destination | Out-Null
+  Get-ChildItem -LiteralPath $Source -Force |
+    Where-Object { $ExcludeNames -notcontains $_.Name } |
+    ForEach-Object {
+      Copy-Item -LiteralPath $_.FullName -Destination $Destination -Recurse -Force
+    }
+}
+
+function Set-PyvenvValue([string]$ConfigPath, [string]$Key, [string]$Value) {
+  $content = Get-Content -LiteralPath $ConfigPath
+  $pattern = "^\s*$([regex]::Escape($Key))\s*="
+  $line = "$Key = $Value"
+  $found = $false
+  $updated = foreach ($entry in $content) {
+    if ($entry -match $pattern) {
+      $found = $true
+      $line
+    } else {
+      $entry
+    }
+  }
+  if (-not $found) {
+    $updated += $line
+  }
+  $utf8NoBom = New-Object System.Text.UTF8Encoding $false
+  [System.IO.File]::WriteAllLines($ConfigPath, [string[]]$updated, $utf8NoBom)
+}
+
+function Get-PackageVersion {
+  if ($PackageVersion) {
+    return $PackageVersion.TrimStart("v")
+  }
+  $tauriConfig = Get-Content -LiteralPath (Join-Path $TauriDir "tauri.conf.json") -Raw |
+    ConvertFrom-Json
+  return [string]$tauriConfig.version
+}
+
+function Bundle-PythonRuntime([string]$VenvDir, [string]$VenvPython) {
+  $baseExecutable = (& $VenvPython -c "import sys; print(getattr(sys, '_base_executable', sys.executable))").Trim()
+  if (-not (Test-Path $baseExecutable)) {
+    throw "Could not locate base Python executable: $baseExecutable"
+  }
+  $baseHome = Split-Path -Parent $baseExecutable
+  $baseLib = Join-Path $baseHome "Lib"
+  $baseDlls = Join-Path $baseHome "DLLs"
+  if (-not (Test-Path $baseLib)) {
+    throw "Could not locate base Python standard library: $baseLib"
+  }
+
+  Write-Host "Bundling Python runtime from $baseHome..."
+  Copy-Item -Force $baseExecutable (Join-Path $VenvDir "python.exe")
+  $basePythonw = Join-Path $baseHome "pythonw.exe"
+  if (Test-Path $basePythonw) {
+    Copy-Item -Force $basePythonw (Join-Path $VenvDir "pythonw.exe")
+  }
+  Get-ChildItem -LiteralPath $baseHome -Filter "*.dll" -File -Force |
+    Copy-Item -Destination $VenvDir -Force
+  if (Test-Path $baseDlls) {
+    Copy-Tree $baseDlls (Join-Path $VenvDir "DLLs")
+  }
+  Copy-TreeContents $baseLib (Join-Path $VenvDir "Lib") @("site-packages")
+
+  $cfg = Join-Path $VenvDir "pyvenv.cfg"
+  Set-PyvenvValue $cfg "home" $VenvDir
+  Set-PyvenvValue $cfg "executable" (Join-Path $VenvDir "python.exe")
 }
 
 function Assert-Fresh-TauriBuild {
@@ -96,6 +165,10 @@ if ($CpuOnly) {
 
 Copy-Tree (Join-Path $Root "app") (Join-Path $BackendDir "app")
 Copy-Tree (Join-Path $Root "static") (Join-Path $BackendDir "static")
+$PackageVersion = Get-PackageVersion
+$VersionJson = @{ version = $PackageVersion } | ConvertTo-Json -Compress
+$utf8NoBom = New-Object System.Text.UTF8Encoding $false
+[System.IO.File]::WriteAllText((Join-Path $BackendDir "static\version.json"), $VersionJson + "`n", $utf8NoBom)
 Copy-Item -Force (Join-Path $Root "pyproject.toml") (Join-Path $BackendDir "pyproject.toml")
 Copy-Item -Force (Join-Path $Root "uv.lock") (Join-Path $BackendDir "uv.lock")
 Copy-Item -Force (Join-Path $Root "packaging\windows\README-WINDOWS.txt") (Join-Path $Stage "README-WINDOWS.txt")
@@ -121,6 +194,9 @@ if ($CpuOnly) {
 }
 
 & $PythonExe -c "import fastapi, uvicorn, yt_dlp, demucs, torch, torchaudio, librosa, pyloudnorm, soundfile"
+
+Bundle-PythonRuntime $PythonDir $PythonExe
+& $PythonExe -c "import sys, fastapi, uvicorn; print('Portable Python:', sys.executable)"
 
 if ($StripVenv) {
   Write-Host "Stripping venv of build-time artifacts..."

--- a/static/js/catalog.js
+++ b/static/js/catalog.js
@@ -858,22 +858,43 @@ function wireWidgets() {
 
 // ─── Init ───
 
-const CURRENT_VERSION = "0.1.0";
+const FALLBACK_VERSION = "0.1.0";
+let currentVersion = FALLBACK_VERSION;
 const REPO_URL = "https://github.com/thcp/stemdeck";
 const RELEASES_URL = "https://github.com/thcp/stemdeck/releases";
 const RELEASES_API = "https://api.github.com/repos/thcp/stemdeck/releases/latest";
 
+function normalizeVersion(value) {
+  return String(value || "").trim().replace(/^v/i, "") || FALLBACK_VERSION;
+}
+
+function setDisplayedVersion(version) {
+  const brand = document.getElementById("brandVersion");
+  const about = document.getElementById("aboutVersion");
+  currentVersion = normalizeVersion(version);
+  if (brand) brand.textContent = `v${currentVersion}`;
+  if (about) about.textContent = `v${currentVersion}`;
+}
+
+async function loadCurrentVersion() {
+  try {
+    const res = await fetch("/api/health", { cache: "no-store" });
+    if (!res.ok) return;
+    const data = await res.json();
+    setDisplayedVersion(data.version);
+  } catch { /* backend unavailable during bootstrap -- keep fallback */ }
+}
+
 async function checkForUpdate() {
   const el = document.getElementById("brandVersion");
   if (!el) return;
-  el.textContent = "";
   el.classList.remove("has-update");
   try {
     const res = await fetch(RELEASES_API, { headers: { Accept: "application/vnd.github+json" } });
     if (!res.ok) return;
     const data = await res.json();
-    const latest = (data.tag_name || "").replace(/^v/, "");
-    if (!latest || latest === CURRENT_VERSION) return;
+    const latest = normalizeVersion(data.tag_name);
+    if (!latest || latest === currentVersion) return;
     el.classList.add("has-update");
     el.innerHTML = `<a href="${RELEASES_URL}/tag/${data.tag_name}" target="_blank" rel="noopener noreferrer">new release available</a>`;
   } catch { /* network unavailable — silently skip */ }
@@ -887,7 +908,7 @@ function wireAboutDialog() {
   const link = dialog?.querySelector(".about-link");
   if (!btn || !dialog) return;
 
-  if (version) version.textContent = `v${CURRENT_VERSION}`;
+  if (version) version.textContent = `v${currentVersion}`;
   if (link) link.setAttribute("href", REPO_URL);
 
   const open = () => dialog.classList.remove("hidden");
@@ -913,8 +934,9 @@ export function initCatalog() {
   wireRailTrashDrop();
   wireLibraryDeleteKeys();
   wireAboutDialog();
+  setDisplayedVersion(currentVersion);
   render();
 
   document.getElementById("newFolderBtn")?.addEventListener("click", createFolder);
-  checkForUpdate();
+  loadCurrentVersion().finally(checkForUpdate);
 }


### PR DESCRIPTION
## Summary

Fixes #13.

This addresses the Windows setup state where the CPU package can get stuck around compute-device configuration and FFmpeg setup after a user deletes `data/`.

Changes:
- Add a root-level `cpu-only` marker to CPU portable builds so package identity survives `data/` deletion.
- Restore `data/cpu-only` from the root marker during workspace setup.
- Skip GPU/PIP setup whenever either CPU-only marker exists.
- Patch the bundled venv `pyvenv.cfg` before Python is used by runtime probing, GPU setup, or backend startup.
- Run first-run setup sequentially through workspace -> FFmpeg -> compute device, matching the visible step order.
- Add timeouts around `nvidia-smi`, FFmpeg download/check, and CUDA torch install so external helpers cannot hang forever.

## Verification

- `cargo fmt --check`
- `cargo check`
- `git diff --check`