### PR TITLE
fix(ci): drop --summary flag removed in ClamAV 1.x

### DIFF
--- a/.woodpecker/windows-release.yml
+++ b/.woodpecker/windows-release.yml
@@ -52,7 +52,7 @@ steps:
 
         Write-Host "Running ClamAV scan over dist/..."
         docker run --rm -v "${PWD}/dist:/scan:ro" clamav/clamav:latest `
-          clamscan --recursive --infected --bell --summary /scan
+          clamscan --recursive --infected --bell /scan
         if ($LASTEXITCODE -ne 0) {
           throw "ClamAV scan failed or reported infected files. Exit code: $LASTEXITCODE"
         }


### PR DESCRIPTION
## Summary

- `--summary` was removed in ClamAV 1.x (`latest` now pulls 1.x); the flag was redundant anyway since clamscan always prints a summary by default
- Fixes the Windows release scan step exiting with code 2

## Test plan

- [x] Trigger a release build and confirm the ClamAV scan step passes