### PR TITLE
feat(registry): persist completed jobs across server restarts

### DIFF
--- a/app/api/jobs.py
+++ b/app/api/jobs.py
@@ -13,6 +13,7 @@ from app.core.models import Job
 from app.core.registry import all_jobs as registry_all_jobs
 from app.core.registry import get as registry_get
 from app.core.registry import get_proc as registry_get_proc
+from app.core.registry import persist as registry_persist
 from app.core.registry import register as registry_register
 from app.core.registry import remove as registry_remove
 from app.pipeline import run_pipeline
@@ -68,6 +69,15 @@ async def create_job(payload: JobRequest) -> dict[str, str]:
     return {"job_id": job.id}
 
 
+@router.get("")
+def list_jobs() -> list[dict]:
+    return [
+        job.to_state()
+        for job in sorted(registry_all_jobs().values(), key=lambda j: j.created_at)
+        if job.status == "done"
+    ]
+
+
 @router.get("/{job_id}")
 def get_job(job_id: str) -> dict:
     job = registry_get(job_id)
@@ -104,4 +114,5 @@ def delete_job(job_id: str) -> dict[str, str]:
         raise HTTPException(status_code=409, detail="job is still running")
     _rmtree_job(job_id)
     registry_remove(job_id)
+    registry_persist(JOBS_DIR)
     return {"job_id": job_id, "status": "deleted"}

--- a/app/core/models.py
+++ b/app/core/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import time
 from dataclasses import dataclass, field
 from typing import Any
@@ -61,3 +62,21 @@ class Job:
             "mix_url": self.mix_url,
             "error": self.error,
         }
+
+    def to_record(self) -> dict[str, Any]:
+        return {field: getattr(self, field) for field in _JOB_FIELDS}
+
+    @classmethod
+    def from_record(cls, data: dict[str, Any]) -> Job:
+        fields = {key: value for key, value in data.items() if key in _JOB_FIELDS}
+        job_id = str(fields.pop("id", "")).strip()
+        if not job_id:
+            raise ValueError("job record missing id")
+        job = cls(id=job_id)
+        for key, value in fields.items():
+            setattr(job, key, value)
+        job.cancel_requested = False
+        return job
+
+
+_JOB_FIELDS = frozenset(f.name for f in dataclasses.fields(Job) if f.name != "cancel_requested")

--- a/app/core/registry.py
+++ b/app/core/registry.py
@@ -1,41 +1,135 @@
 from __future__ import annotations
 
+import json
+import logging
 import subprocess
+import threading
+from pathlib import Path
 
+from app.core.config import JOB_ID_RE, STEM_NAMES
 from app.core.models import Job
+
+logger = logging.getLogger("stemdeck.registry")
 
 _jobs: dict[str, Job] = {}
 # Active subprocesses keyed by job_id (currently only Demucs). Lets
 # POST /cancel terminate the running process from the API thread instead
 # of waiting for the pipeline thread to notice the cancel flag.
 _procs: dict[str, subprocess.Popen] = {}
+_lock = threading.Lock()
+_REGISTRY_FILE = "registry.json"
+_TERMINAL = {"done"}
 
 
 def register(job: Job) -> Job:
-    _jobs[job.id] = job
+    with _lock:
+        _jobs[job.id] = job
     return job
 
 
 def get(job_id: str) -> Job | None:
-    return _jobs.get(job_id)
+    with _lock:
+        return _jobs.get(job_id)
 
 
 def remove(job_id: str) -> None:
-    _jobs.pop(job_id, None)
-    _procs.pop(job_id, None)
+    with _lock:
+        _jobs.pop(job_id, None)
+        _procs.pop(job_id, None)
 
 
 def all_jobs() -> dict[str, Job]:
     """Return a snapshot of the registry for sweep / cleanup."""
-    return dict(_jobs)
+    with _lock:
+        return dict(_jobs)
+
+
+def persist(jobs_dir: Path) -> None:
+    """Persist terminal jobs so completed library entries survive restarts."""
+    try:
+        jobs_dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        logger.warning("cannot create jobs dir %s; skipping persist", jobs_dir, exc_info=True)
+        return
+    with _lock:
+        records = [
+            job.to_record()
+            for job in sorted(_jobs.values(), key=lambda item: item.created_at)
+            if job.status in _TERMINAL
+        ]
+    path = jobs_dir / _REGISTRY_FILE
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps({"version": 1, "jobs": records}, indent=2) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def restore(jobs_dir: Path) -> None:
+    """Load persisted jobs and recover completed orphan jobs from disk."""
+    jobs_dir.mkdir(parents=True, exist_ok=True)
+    path = jobs_dir / _REGISTRY_FILE
+    if path.is_file():
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            to_add = {}
+            for record in data.get("jobs", []):
+                job = Job.from_record(record)
+                if JOB_ID_RE.match(job.id) and job.status in _TERMINAL:
+                    to_add[job.id] = job
+            with _lock:
+                _jobs.update(to_add)
+        except (OSError, json.JSONDecodeError, TypeError, ValueError):
+            logger.warning("failed to load registry from %s", path, exc_info=True)
+
+    with _lock:
+        known = set(_jobs)
+    changed = False
+    for job_dir in jobs_dir.iterdir():
+        if not job_dir.is_dir() or not JOB_ID_RE.match(job_dir.name) or job_dir.name in known:
+            continue
+        recovered = _recover_done_job(job_dir)
+        if recovered is not None:
+            with _lock:
+                _jobs[recovered.id] = recovered
+            changed = True
+    if changed:
+        persist(jobs_dir)
+
+
+def _recover_done_job(job_dir: Path) -> Job | None:
+    stems_dir = job_dir / "stems"
+    if not stems_dir.is_dir():
+        return None
+    stems = [
+        {"name": name, "url": f"/api/jobs/{job_dir.name}/stems/{name}.wav"}
+        for name in ("original", *STEM_NAMES)
+        if (stems_dir / f"{name}.wav").is_file()
+    ]
+    if not stems:
+        return None
+    mix_url = None
+    if (stems_dir / "mix.wav").is_file():
+        mix_url = f"/api/jobs/{job_dir.name}/stems/mix.wav"
+    selected = [stem["name"] for stem in stems if stem["name"] in STEM_NAMES] or list(STEM_NAMES)
+    return Job(
+        id=job_dir.name,
+        status="done",
+        progress=1.0,
+        stage_message="Done",
+        stems=stems,
+        selected_stems=selected,
+        mix_url=mix_url,
+        created_at=job_dir.stat().st_mtime,
+    )
 
 
 def set_proc(job_id: str, proc: subprocess.Popen | None) -> None:
-    if proc is None:
-        _procs.pop(job_id, None)
-    else:
-        _procs[job_id] = proc
+    with _lock:
+        if proc is None:
+            _procs.pop(job_id, None)
+        else:
+            _procs[job_id] = proc
 
 
 def get_proc(job_id: str) -> subprocess.Popen | None:
-    return _procs.get(job_id)
+    with _lock:
+        return _procs.get(job_id)

--- a/app/main.py
+++ b/app/main.py
@@ -21,6 +21,7 @@ from app.core.config import (
     configure_portable_environment,
     ensure_runtime_dirs,
 )
+from app.core.registry import restore as restore_registry
 from app.pipeline.collect import sweep_old_jobs
 
 # Show our INFO-level logs through uvicorn's root handler. Without this,
@@ -113,3 +114,4 @@ app.mount("/", StaticFiles(directory=STATIC_DIR, html=True), name="static")
 # Ensure runtime directories exist at startup (module-level side effect
 # moved from the old monolithic main.py; this is the canonical entrypoint).
 ensure_runtime_dirs()
+restore_registry(JOBS_DIR)

--- a/app/pipeline/collect.py
+++ b/app/pipeline/collect.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from app.core.config import DEMUCS_MODEL, JOB_TTL_SECONDS, STEM_NAMES, ffmpeg_executable
 from app.core.models import Job
 from app.core.registry import all_jobs as registry_all
+from app.core.registry import persist as registry_persist
 from app.core.registry import remove as registry_remove
 from app.core.registry import set_proc
 
@@ -186,6 +187,7 @@ def sweep_old_jobs(jobs_dir: Path) -> None:
     if not jobs_dir.is_dir():
         return
     jobs = registry_all()
+    removed = False
     for d in jobs_dir.iterdir():
         if not d.is_dir():
             continue
@@ -199,3 +201,6 @@ def sweep_old_jobs(jobs_dir: Path) -> None:
             continue
         _rmtree(d)
         registry_remove(d.name)
+        removed = True
+    if removed:
+        registry_persist(jobs_dir)

--- a/app/pipeline/runner.py
+++ b/app/pipeline/runner.py
@@ -6,6 +6,7 @@ import shutil
 from pathlib import Path
 
 from app.core.models import Job, JobCancelled
+from app.core.registry import persist as persist_registry
 from app.pipeline.analyze import analyze
 from app.pipeline.collect import cleanup_source, collect, make_original_track, make_selected_mix
 from app.pipeline.download import _set, download
@@ -89,6 +90,7 @@ async def run_pipeline(job: Job, url: str, jobs_dir: Path) -> None:
     except JobCancelled:
         logger.info("pipeline cancelled for job %s", job.id)
         _set(job, status="cancelled", stage="Cancelled")
+        persist_registry(jobs_dir)
         # Drop partial files so the disk reclaim is immediate.
         _rmtree(job_dir)
         return
@@ -99,6 +101,7 @@ async def run_pipeline(job: Job, url: str, jobs_dir: Path) -> None:
         if job.cancel_requested:
             logger.info("pipeline cancelled (wrapped) for job %s", job.id)
             _set(job, status="cancelled", stage="Cancelled")
+            persist_registry(jobs_dir)
             _rmtree(job_dir)
             return
         logger.exception("pipeline failed for job %s: %s", job.id, e)
@@ -108,5 +111,7 @@ async def run_pipeline(job: Job, url: str, jobs_dir: Path) -> None:
             stage="Error: Processing failed",
             error="Audio processing failed. Please try another video.",
         )
+        persist_registry(jobs_dir)
         return
     _set(job, status="done", progress=1.0, stage="Done")
+    persist_registry(jobs_dir)

--- a/static/js/catalog.js
+++ b/static/js/catalog.js
@@ -924,6 +924,20 @@ function wireAboutDialog() {
   });
 }
 
+async function syncWithServer() {
+  try {
+    const res = await fetch("/api/jobs", { cache: "no-store" });
+    if (!res.ok) return;
+    const jobs = await res.json();
+    for (const state of jobs) {
+      if (tracks[state.job_id]) continue;
+      const track = stateMetadataToTrack(state, { id: state.job_id, status: state.status });
+      track.id = state.job_id;
+      addTrackToLibrary(track);
+    }
+  } catch { /* backend unavailable — skip silently */ }
+}
+
 export function initCatalog() {
   loadState();
   wireCatalogToggle();
@@ -939,4 +953,5 @@ export function initCatalog() {
 
   document.getElementById("newFolderBtn")?.addEventListener("click", createFolder);
   loadCurrentVersion().finally(checkForUpdate);
+  syncWithServer();
 }

--- a/tests/test_registry_persistence.py
+++ b/tests/test_registry_persistence.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from app.core.models import Job
+from app.core.registry import _jobs
+from app.core.registry import persist as persist_registry
+from app.core.registry import restore as restore_registry
+
+
+def setup_function():
+    _jobs.clear()
+
+
+def teardown_function():
+    _jobs.clear()
+
+
+def test_persist_and_restore_terminal_job(tmp_path: Path):
+    job = Job(
+        id="abcdefabcdef",
+        status="done",
+        progress=1.0,
+        stage_message="Done",
+        title="Saved song",
+        stems=[{"name": "vocals", "url": "/api/jobs/abcdefabcdef/stems/vocals.wav"}],
+        selected_stems=["vocals"],
+    )
+    _jobs[job.id] = job
+
+    persist_registry(tmp_path)
+    _jobs.clear()
+    restore_registry(tmp_path)
+
+    restored = _jobs[job.id]
+    assert restored.status == "done"
+    assert restored.title == "Saved song"
+    assert restored.stems == job.stems
+    assert restored.cancel_requested is False
+
+
+def test_restore_recovers_orphan_done_job_from_stems(tmp_path: Path):
+    stems_dir = tmp_path / "abcdefabcdee" / "stems"
+    stems_dir.mkdir(parents=True)
+    (stems_dir / "vocals.wav").write_bytes(b"RIFF")
+    (stems_dir / "drums.wav").write_bytes(b"RIFF")
+
+    restore_registry(tmp_path)
+
+    restored = _jobs["abcdefabcdee"]
+    assert restored.status == "done"
+    assert restored.progress == 1.0
+    assert {stem["name"] for stem in restored.stems} == {"vocals", "drums"}
+
+
+def test_restored_job_serves_stems(tmp_path: Path, monkeypatch):
+    stems_dir = tmp_path / "abcdefabcded" / "stems"
+    stems_dir.mkdir(parents=True)
+    (stems_dir / "vocals.wav").write_bytes(b"RIFF1234")
+    data = {
+        "version": 1,
+        "jobs": [
+            Job(
+                id="abcdefabcded",
+                status="done",
+                stems=[{"name": "vocals", "url": "/api/jobs/abcdefabcded/stems/vocals.wav"}],
+                selected_stems=["vocals"],
+            ).to_record()
+        ],
+    }
+    (tmp_path / "registry.json").write_text(json.dumps(data), encoding="utf-8")
+
+    monkeypatch.setattr("app.api.stems.JOBS_DIR", tmp_path)
+    restore_registry(tmp_path)
+
+    from app.main import app
+
+    with TestClient(app) as client:
+        state = client.get("/api/jobs/abcdefabcded")
+        assert state.status_code == 200
+        assert state.json()["status"] == "done"
+        stem = client.get("/api/jobs/abcdefabcded/stems/vocals.wav")
+        assert stem.status_code == 200
+        assert stem.content == b"RIFF1234"
+
+
+def test_delete_updates_persisted_registry(tmp_path: Path, monkeypatch):
+    job = Job(id="abcdefabcdec", status="done")
+    _jobs[job.id] = job
+    job_dir = tmp_path / job.id
+    job_dir.mkdir(parents=True)
+    persist_registry(tmp_path)
+
+    monkeypatch.setattr("app.api.jobs.JOBS_DIR", tmp_path)
+
+    from app.main import app
+
+    with TestClient(app) as client:
+        response = client.delete(f"/api/jobs/{job.id}")
+
+    assert response.status_code == 200
+    assert not job_dir.exists()
+    data = json.loads((tmp_path / "registry.json").read_text(encoding="utf-8"))
+    assert data["jobs"] == []


### PR DESCRIPTION
Closes #15

## Summary

- **`registry.json`** written atomically (tmp → replace) on every terminal state transition (`done`); loaded back on startup via `restore()`
- **Orphan recovery**: on startup, job dirs with a `stems/` folder but no registry entry are reconstructed as `done` jobs and backfilled into `registry.json`
- **Only `done` jobs persist** — error and cancelled jobs have no usable stems, so they're excluded to keep the library clean
- **Thread-safe**: `threading.Lock` guards all `_jobs`/`_procs` reads and mutations; lock is released before file I/O in `persist()` so disk writes don't block the event loop
- **`_JOB_FIELDS`** derived from `dataclasses.fields(Job)` automatically — adding a field to `Job` no longer requires a manual list update
- **`GET /api/jobs`** list endpoint returns all `done` jobs sorted by `created_at`
- **Frontend `syncWithServer()`** runs at startup, fetches the job list, and adds any jobs not already in `localStorage` to the library sidebar — fixes the Tauri app showing an empty library after restart even though `registry.json` is populated

## Test plan

- [x] `uv run pytest tests/test_registry_persistence.py -v` — 4 tests covering persist/restore, orphan recovery, stem serving, and delete updating the JSON
- [x] Manual: process a track → close app → reopen → confirm it appears in the library sidebar
- [ ] Manual: cancel a job → confirm it does not appear in the library after restart