### PR TITLE
fix(playback): resolve stem silence in WKWebView

### DIFF
--- a/app/api/stems.py
+++ b/app/api/stems.py
@@ -15,7 +15,7 @@ router = APIRouter(tags=["stems"])
 _ALLOWED_NAMES = frozenset(STEM_NAMES) | {"original", "mix"}
 
 
-@router.get("/jobs/{job_id}/stems/{name}.wav")
+@router.api_route("/jobs/{job_id}/stems/{name}.wav", methods=["GET", "HEAD"])
 def get_stem(job_id: str, name: str) -> FileResponse:
     if not JOB_ID_RE.match(job_id):
         raise HTTPException(status_code=404, detail="job not found")

--- a/static/js/mixer.js
+++ b/static/js/mixer.js
@@ -64,27 +64,11 @@ export function applyMix() {
     // accepts any positive number, enabling real boost and reliable mute.
     const audioEl = multitrack.audios?.[idx];
     if (audioEl instanceof HTMLMediaElement) {
-      if (!audioEl._stGainNode) {
-        const ctx = multitrack.audioContext;
-        if (ctx) {
-          try {
-            if (!audioEl._stMediaSource) {
-              audioEl._stMediaSource = ctx.createMediaElementSource(audioEl);
-            }
-            audioEl._stGainNode = ctx.createGain();
-            audioEl._stMediaSource.connect(audioEl._stGainNode);
-            audioEl._stGainNode.connect(ctx.destination);
-            audioEl.volume = 1;
-          } catch (err) {
-            console.warn(`[mixer] GainNode setup failed for "${name}":`, err);
-          }
-        }
-      }
-      if (audioEl._stGainNode) {
-        audioEl._stGainNode.gain.value = targetGain;
-      } else {
-        multitrack.setTrackVolume(idx, Math.min(1, targetGain));
-      }
+      // Use the HTMLAudioElement's native volume instead of routing through a
+      // MediaElementAudioSourceNode. WKWebView (Safari) does not reliably pass
+      // audio from MediaElementSource → GainNode → destination to the speakers,
+      // so we stay on the browser's default output path and cap gain at 1.0.
+      audioEl.volume = Math.min(1, Math.max(0, targetGain));
     } else {
       multitrack.setTrackVolume(idx, targetGain);
     }

--- a/static/js/transport.js
+++ b/static/js/transport.js
@@ -181,9 +181,8 @@ export function togglePlayPause() {
   }
   const ctx = multitrack.audioContext;
   // Safari requires play() to be called synchronously within the user-gesture
-  // handler. Calling it in a resume().then() callback breaks that guarantee on
-  // Safari's AudioBufferSourceNode path, causing silence or stuttering.
-  // Resume fire-and-forget so the context becomes live, then play() immediately.
+  // handler. Resume the AudioContext fire-and-forget so the context becomes
+  // live, then call play() immediately on the same tick.
   if (ctx && ctx.state === "suspended") {
     ctx.resume().catch(() => {});
   }


### PR DESCRIPTION
## Summary

- **HEAD request 404**: FastAPI's `@router.get` does not auto-register the HEAD method (unlike Starlette's base Route). WKWebView probes audio URLs with HEAD before streaming; the 404 response caused `MEDIA_ERR_SRC_NOT_SUPPORTED` (code 4) on all stems. Fixed by switching to `@router.api_route(methods=["GET", "HEAD"])`.
- **Silent GainNode routing**: `MediaElementAudioSourceNode` does not reliably route audio to speakers in Safari/WKWebView — GainNodes were wired correctly and gains were set, but output was silent. Replaced with direct `audioEl.volume` assignment on the native browser output path (gain capped at 1.0).

## Files changed

- `app/api/stems.py` — register HEAD method on stem WAV endpoint
- `static/js/mixer.js` — use `audioEl.volume` instead of Web Audio GainNode routing
- `static/js/transport.js` — clean up stale comment

## Test plan

- [ ] Process a track and verify all stems play with audio
- [ ] Mute / solo individual stems
- [ ] Adjust per-stem faders and confirm volume changes
- [ ] Verify HEAD request returns 200 for stem URLs (`curl -X HEAD .../api/jobs/{id}/stems/vocals.wav`)

Closes #15