### PR TITLE
fix(ui): wire collapsed appbar strip and fix version placeholder

### DIFF
--- a/.woodpecker/windows-release.yml
+++ b/.woodpecker/windows-release.yml
@@ -6,7 +6,19 @@ labels:
   backend: local
 
 steps:
+  write-version:
+    image: powershell
+    commands:
+      - |
+        $tag = $env:CI_COMMIT_TAG
+        if (-not $tag) { throw "CI_COMMIT_TAG is not set" }
+        $json = "{`"version`": `"$tag`"}"
+        Set-Content -Path "static/version.json" -Value $json -Encoding UTF8
+        Write-Host "Wrote static/version.json: $json"
+
   build-windows-nvidia:
+    depends_on:
+      - write-version
     image: powershell
     commands:
       - powershell -NoProfile -ExecutionPolicy Bypass -File scripts/windows/make-portable.ps1

--- a/app/core/registry.py
+++ b/app/core/registry.py
@@ -73,7 +73,7 @@ def restore(jobs_dir: Path) -> None:
             to_add = {}
             for record in data.get("jobs", []):
                 job = Job.from_record(record)
-                if JOB_ID_RE.match(job.id) and job.status in _TERMINAL:
+                if JOB_ID_RE.match(job.id) and job.status in _TERMINAL and job.title:
                     to_add[job.id] = job
             with _lock:
                 _jobs.update(to_add)
@@ -110,6 +110,14 @@ def _recover_done_job(job_dir: Path) -> Job | None:
     if (stems_dir / "mix.wav").is_file():
         mix_url = f"/api/jobs/{job_dir.name}/stems/mix.wav"
     selected = [stem["name"] for stem in stems if stem["name"] in STEM_NAMES] or list(STEM_NAMES)
+    meta_path = job_dir / "metadata.json"
+    if not meta_path.is_file():
+        return None
+    meta: dict = {}
+    try:
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        pass
     return Job(
         id=job_dir.name,
         status="done",
@@ -119,6 +127,15 @@ def _recover_done_job(job_dir: Path) -> Job | None:
         selected_stems=selected,
         mix_url=mix_url,
         created_at=job_dir.stat().st_mtime,
+        title=meta.get("title"),
+        thumbnail=meta.get("thumbnail"),
+        duration_sec=meta.get("duration_sec"),
+        bpm=meta.get("bpm"),
+        key=meta.get("key"),
+        scale=meta.get("scale"),
+        key_confidence=meta.get("key_confidence"),
+        lufs=meta.get("lufs"),
+        peak_db=meta.get("peak_db"),
     )
 
 

--- a/app/pipeline/runner.py
+++ b/app/pipeline/runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import shutil
 from pathlib import Path
@@ -78,6 +79,24 @@ def _run_blocking(job: Job, url: str, job_dir: Path) -> None:
     _check_cancel(job)
 
 
+def _write_metadata(job: Job, job_dir: Path) -> None:
+    meta = {
+        "title": job.title,
+        "thumbnail": job.thumbnail,
+        "duration_sec": job.duration_sec,
+        "bpm": job.bpm,
+        "key": job.key,
+        "scale": job.scale,
+        "key_confidence": job.key_confidence,
+        "lufs": job.lufs,
+        "peak_db": job.peak_db,
+    }
+    try:
+        (job_dir / "metadata.json").write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+    except OSError:
+        logger.warning("could not write metadata.json for job %s", job.id, exc_info=True)
+
+
 async def run_pipeline(job: Job, url: str, jobs_dir: Path) -> None:
     job_dir = jobs_dir / job.id
     # One try/except covers everything from directory creation through pipeline
@@ -114,4 +133,5 @@ async def run_pipeline(job: Job, url: str, jobs_dir: Path) -> None:
         persist_registry(jobs_dir)
         return
     _set(job, status="done", progress=1.0, stage="Done")
+    _write_metadata(job, job_dir)
     persist_registry(jobs_dir)

--- a/static/css/widgets.css
+++ b/static/css/widgets.css
@@ -832,6 +832,23 @@
   visibility: hidden;
 }
 
+.wave-loading-msg {
+  display: none;
+  position: absolute;
+  bottom: 16px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.6);
+  letter-spacing: 0.04em;
+  pointer-events: none;
+}
+
+.wave-loading-overlay.stalled .wave-loading-msg {
+  display: block;
+}
+
 .wave-loading-glow {
   position: absolute;
   inset: 0;

--- a/static/css/widgets.css
+++ b/static/css/widgets.css
@@ -16,6 +16,7 @@
   gap: 12px !important;
   overflow: hidden !important;
   margin: 0 !important;
+  transition: grid-template-columns 240ms ease;
 }
 .app.cat-collapsed { --cat-w: 78px; }
 
@@ -340,6 +341,7 @@
   padding: 0 !important;
   border-radius: 12px !important;
   overflow: hidden !important;
+  transition: grid-template-columns 240ms ease;
 }
 
 .catalog-rail {
@@ -545,8 +547,14 @@
   grid-template-columns: 72px !important;
 }
 
+.catalog-main {
+  transition: opacity 200ms ease;
+}
+
 .app.cat-collapsed .catalog-main {
-  display: none !important;
+  opacity: 0;
+  pointer-events: none;
+  overflow: hidden;
 }
 
 /* ─── 4. File drop pill ─── */

--- a/static/index.html
+++ b/static/index.html
@@ -405,6 +405,7 @@
                         <div class="wave-loading-lines" aria-hidden="true">
                           <i></i><i></i><i></i><i></i><i></i><i></i>
                         </div>
+                        <p class="wave-loading-msg">Still loading waveform…</p>
                       </div>
                     </div>
                   </div>

--- a/static/index.html
+++ b/static/index.html
@@ -35,7 +35,7 @@
               <span class="beta-badge">ALPHA</span>
             </div>
             <span class="brand-sub">AI stem separation</span>
-            <div class="brand-version" id="brandVersion">v0.1.0</div>
+            <div class="brand-version" id="brandVersion">…</div>
           </div>
 
           <form id="job-form" class="appbar-import-panel">
@@ -485,7 +485,7 @@
       <div class="about-card">
         <button class="about-close" id="aboutClose" type="button" aria-label="Close about dialog">×</button>
         <h2 id="aboutTitle">StemDeck</h2>
-        <p class="about-version" id="aboutVersion">v0.1.0</p>
+        <p class="about-version" id="aboutVersion">…</p>
         <a class="about-link" href="https://github.com/thcp/stemdeck" target="_blank" rel="noopener noreferrer">
           github.com/thcp/stemdeck
         </a>

--- a/static/js/catalog.js
+++ b/static/js/catalog.js
@@ -106,6 +106,14 @@ function loadState() {
       if ((data.v ?? 1) >= STORAGE_VERSION) {
         folders = data.folders ?? [];
         tracks = data.tracks ?? {};
+        // Drop title-less entries left over from before metadata persistence.
+        const noTitle = Object.keys(tracks).filter((id) => !tracks[id].title);
+        if (noTitle.length) {
+          const toRemove = new Set(noTitle);
+          noTitle.forEach((id) => delete tracks[id]);
+          folders.forEach((f) => { f.items = f.items.filter((id) => !toRemove.has(id)); });
+          changed = true;
+        }
       }
       // else: stale version → start fresh
     }
@@ -593,15 +601,15 @@ function renderTrackItem(trackId, { inTrash = false } = {}) {
   el.innerHTML = `
     <div class="cat-thumb">${thumbHtml(track)}</div>
     <div class="cat-meta">
-      <div class="cat-title">${track.title}</div>
+      <div class="cat-title">${track.title ?? "Unknown track"}</div>
       <div class="cat-sub">
-        <span>${track.channel}</span>
+        <span>${track.channel ?? ""}</span>
         <span class="dot">·</span>
         <span>${inTrash ? "Removed" : `${stemCount} stem${stemCount !== 1 ? "s" : ""}`}</span>
       </div>
     </div>
     <div class="cat-status${PROCESSING_STATUSES.has(track.status) ? " processing" : ""}"></div>
-    ${inTrash ? "" : `<button class="cat-del" type="button" aria-label="Move ${track.title} to Trash" title="Move to Trash">
+    ${inTrash ? "" : `<button class="cat-del" type="button" aria-label="Move ${track.title ?? "track"} to Trash" title="Move to Trash">
       <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
         <polyline points="3 6 5 6 21 6"></polyline>
         <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"></path>

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -3,7 +3,7 @@ import {
   setLoopStart, setLoopEnd, selectedStems, saveSelectedStems,
 } from "./state.js";
 import { STEM_NAMES } from "./constants.js";
-import { renderEmptyShell } from "./player.js";
+import { renderEmptyShell, buildStripStems } from "./player.js";
 import { wireJobForm } from "./job.js";
 import { wireTransportButtons } from "./transport.js";
 import { togglePlayPause, updateLoopRegionVisual } from "./transport.js";
@@ -55,6 +55,7 @@ function handleStemChoiceClick(stem) {
   }
   saveSelectedStems();
   refreshStemChoiceVisuals();
+  buildStripStems();
 }
 
 function wireStemChoiceButtons() {
@@ -147,6 +148,26 @@ function wireAppShellControls() {
     e.stopPropagation();
     document.getElementById("catalogToggle")?.click();
   });
+
+  const app = document.querySelector(".app");
+
+  // Double-click the appbar header (outside form controls) to collapse it
+  // into the icon strip.
+  document.querySelector(".appbar-body")?.addEventListener("dblclick", (e) => {
+    if (e.target.closest("form, input, button, a, select")) return;
+    app?.classList.toggle("appbar-collapsed");
+  });
+
+  // Clicking any strip icon expands the appbar, with context-specific focus.
+  document.getElementById("appbarStrip")?.addEventListener("click", (e) => {
+    app?.classList.remove("appbar-collapsed");
+    if (e.target.closest(".strip-sq-url")) {
+      document.getElementById("url")?.focus();
+    } else if (e.target.closest(".strip-sq-process")) {
+      document.getElementById("submit")?.click();
+    }
+    // strip-sq-stems: expand only — user clicks stem buttons once visible
+  });
 }
 
 // ─── Keyboard shortcuts ───
@@ -212,4 +233,5 @@ window.addEventListener("unhandledrejection", (e) => {
 
 // ─── Bootstrap ───
 
+buildStripStems();
 renderEmptyShell();

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -149,25 +149,6 @@ function wireAppShellControls() {
     document.getElementById("catalogToggle")?.click();
   });
 
-  const app = document.querySelector(".app");
-
-  // Double-click the appbar header (outside form controls) to collapse it
-  // into the icon strip.
-  document.querySelector(".appbar-body")?.addEventListener("dblclick", (e) => {
-    if (e.target.closest("form, input, button, a, select")) return;
-    app?.classList.toggle("appbar-collapsed");
-  });
-
-  // Clicking any strip icon expands the appbar, with context-specific focus.
-  document.getElementById("appbarStrip")?.addEventListener("click", (e) => {
-    app?.classList.remove("appbar-collapsed");
-    if (e.target.closest(".strip-sq-url")) {
-      document.getElementById("url")?.focus();
-    } else if (e.target.closest(".strip-sq-process")) {
-      document.getElementById("submit")?.click();
-    }
-    // strip-sq-stems: expand only — user clicks stem buttons once visible
-  });
 }
 
 // ─── Keyboard shortcuts ───

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -582,7 +582,10 @@ function renderAllMiniWaves(mt, stems) {
 }
 
 function setWaveformLoading(loading) {
-  document.getElementById("waveLoadingOverlay")?.classList.toggle("hidden", !loading);
+  const el = document.getElementById("waveLoadingOverlay");
+  if (!el) return;
+  el.classList.toggle("hidden", !loading);
+  if (!loading) el.classList.remove("stalled");
 }
 
 export function buildStripStems() {
@@ -618,8 +621,14 @@ export function wireUpAudio(jobId, stems, duration, thumbnail) {
   visualRenderToken += 1;
   const token = visualRenderToken;
   window.setTimeout(() => {
-    if (token === visualRenderToken) setWaveformLoading(false);
+    const el = document.getElementById("waveLoadingOverlay");
+    if (token === visualRenderToken && el && !el.classList.contains("hidden")) {
+      el.classList.add("stalled");
+    }
   }, 20000);
+  window.setTimeout(() => {
+    if (token === visualRenderToken) setWaveformLoading(false);
+  }, 60000);
   setCurrentJobId(jobId);
   setTotalDuration(duration || 0);
   loadMixIntoState(jobId);

--- a/tests/test_registry_persistence.py
+++ b/tests/test_registry_persistence.py
@@ -43,17 +43,30 @@ def test_persist_and_restore_terminal_job(tmp_path: Path):
 
 
 def test_restore_recovers_orphan_done_job_from_stems(tmp_path: Path):
-    stems_dir = tmp_path / "abcdefabcdee" / "stems"
+    job_dir = tmp_path / "abcdefabcdee"
+    stems_dir = job_dir / "stems"
     stems_dir.mkdir(parents=True)
     (stems_dir / "vocals.wav").write_bytes(b"RIFF")
     (stems_dir / "drums.wav").write_bytes(b"RIFF")
+    (job_dir / "metadata.json").write_text(json.dumps({"title": "Test Song"}), encoding="utf-8")
 
     restore_registry(tmp_path)
 
     restored = _jobs["abcdefabcdee"]
     assert restored.status == "done"
     assert restored.progress == 1.0
+    assert restored.title == "Test Song"
     assert {stem["name"] for stem in restored.stems} == {"vocals", "drums"}
+
+
+def test_restore_skips_orphan_without_metadata(tmp_path: Path):
+    stems_dir = tmp_path / "abcdefabcde0" / "stems"
+    stems_dir.mkdir(parents=True)
+    (stems_dir / "vocals.wav").write_bytes(b"RIFF")
+
+    restore_registry(tmp_path)
+
+    assert "abcdefabcde0" not in _jobs
 
 
 def test_restored_job_serves_stems(tmp_path: Path, monkeypatch):
@@ -66,6 +79,7 @@ def test_restored_job_serves_stems(tmp_path: Path, monkeypatch):
             Job(
                 id="abcdefabcded",
                 status="done",
+                title="Test Song",
                 stems=[{"name": "vocals", "url": "/api/jobs/abcdefabcded/stems/vocals.wav"}],
                 selected_stems=["vocals"],
             ).to_record()


### PR DESCRIPTION
## Summary

Addresses bugs reported in issue #15 comments:

- **Hardcoded version label**: replaced `v0.1.0` in `#brandVersion` / `#aboutVersion` with `…`; correct version loads async from `/api/health`
- **Release version injection**: `write-version` CI step in `windows-release.yml` writes `static/version.json` from `\$CI_COMMIT_TAG` before packaging
- **Waveform loading overlay**: shows "Still loading waveform…" hint at 20s, auto-hides at 60s
- **Appbar strip wiring**: `buildStripStems()` called on init and on each stem toggle so strip dots stay in sync
- **Appbar collapse removed**: appbar is always fully visible; dblclick-collapse behaviour dropped
- **Unknown tracks cleanup**: jobs without a title are skipped on registry restore and purged from localStorage on load; new jobs write `metadata.json` on completion so titles survive restarts
- **Smooth sidebar collapse**: sidebar width and panel content fade/slide on toggle, matching main panel transitions

## Test plan

- [x] Stem dots in the appbar strip update when toggling stem choices
- [x] No collapse on double-clicking the appbar
- [x] Library shows no "Unknown track" entries after reload
- [x] Newly processed songs appear with correct title after app restart
- [x] Sidebar opens/closes with a smooth slide animation
- [ ] On a packaged release build, version label shows the release tag