### PR TITLE
fix: inject certifi SSL certs into demucs subprocess

### DIFF
--- a/app/pipeline/separate.py
+++ b/app/pipeline/separate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import re
 import subprocess
 import sys
@@ -38,12 +39,22 @@ def separate(job: Job, source: Path, job_dir: Path) -> Path:
         str(job_dir),
         str(source),
     ]
+    env = os.environ.copy()
+    try:
+        import certifi
+
+        env.setdefault("SSL_CERT_FILE", certifi.where())
+        env.setdefault("REQUESTS_CA_BUNDLE", certifi.where())
+    except ModuleNotFoundError:
+        pass
+
     proc = subprocess.Popen(
         cmd,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.PIPE,
         text=True,
         bufsize=0,
+        env=env,
     )
     if proc.stderr is None:
         raise RuntimeError("demucs subprocess has no stderr pipe")


### PR DESCRIPTION
## Summary

Fixes #18 — `CERTIFICATE_VERIFY_FAILED` when demucs downloads model weights on first run.

**Root cause**: Python installed from python.org on macOS does not link to the system SSL certificate store. The demucs subprocess inherits this broken SSL context and fails when fetching model weights over HTTPS.

**Fix**: Before spawning demucs, copy the current environment and inject `SSL_CERT_FILE` + `REQUESTS_CA_BUNDLE` pointing to certifi's bundled CA store. Uses `setdefault` so user-defined values are not overridden. Fails silently if certifi is unavailable (it is always present as a transitive dependency via yt-dlp).

## Test plan

- [ ] On a macOS Python.org install (3.12+) with no prior demucs model cache, submit a URL and confirm separation completes without SSL errors
- [ ] Confirm existing `SSL_CERT_FILE` env var is not overridden if already set