### PR TITLE
fix(dnd): fix drag-and-drop to folders on Windows (WebView2)

### DIFF
--- a/static/js/catalog.js
+++ b/static/js/catalog.js
@@ -447,6 +447,10 @@ function openFolderEditor(folderId) {
 
 let dragId = null;
 
+function isTrackDragEvent(event) {
+  return dragId != null || Boolean(event?.dataTransfer?.types?.includes(TRACK_DRAG_TYPE));
+}
+
 function getDraggedTrackId(event) {
   return event?.dataTransfer?.getData(TRACK_DRAG_TYPE) || dragId;
 }
@@ -505,8 +509,7 @@ function wireMainPanelDrop() {
   lanes.dataset.libraryDropReady = "1";
 
   lanes.addEventListener("dragover", (e) => {
-    const trackId = getDraggedTrackId(e);
-    if (!trackId || !tracks[trackId]) return;
+    if (!isTrackDragEvent(e)) return;
     e.preventDefault();
     e.dataTransfer.dropEffect = "copy";
     lanes.classList.add("library-drop-target");
@@ -529,8 +532,7 @@ function wireRailTrashDrop() {
   trash.dataset.dropReady = "1";
 
   trash.addEventListener("dragover", (e) => {
-    const trackId = getDraggedTrackId(e);
-    if (!trackId || !tracks[trackId]) return;
+    if (!isTrackDragEvent(e)) return;
     e.preventDefault();
     e.dataTransfer.dropEffect = "move";
     trash.classList.add("drop-target");
@@ -703,7 +705,7 @@ function renderFolder(folder) {
 
   // Drag-over for drop target
   el.addEventListener("dragover", (e) => {
-    if (!dragId) return;
+    if (!isTrackDragEvent(e)) return;
     e.preventDefault();
     e.dataTransfer.dropEffect = "move";
     el.classList.add("drop-target");


### PR DESCRIPTION
## Summary

Fixes drag-and-drop of tracks to library folders not working on the Windows desktop app.

**Root cause**: The `dragover` handlers guarded `e.preventDefault()` behind `if (!dragId)` — a module-level variable set in `dragstart`. On WebView2 (Windows), `dragId` can be `null` when `dragover` fires on a different element, so `e.preventDefault()` was never called, causing the browser to reject the drop entirely.

**Fix**: Replaced the `dragId` guard with `isTrackDragEvent(e)` which checks `e.dataTransfer.types.includes(TRACK_DRAG_TYPE)` — the `types` array is always populated during `dragover` across all browsers, including WebView2. The custom MIME type (`application/x-stemdeck-track`) is only ever set by our own `dragstart` handler, so this guard remains exclusive to internal track drags.

`drop` handlers are unchanged — they still validate the track ID and existence before acting.

## Test plan

- [ ] On Windows desktop app: drag a track from the library list and drop it onto a different folder — should move correctly
- [ ] Drag a track onto the Trash rail — should move to trash
- [ ] Drag a track onto the main waveform panel — should load into studio
- [ ] Confirm same behaviour works unchanged on macOS and in the browser