### PR TITLE
fix(ui): fix drag-and-drop on Windows and catalog rail layout

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -17,7 +17,8 @@
         "height": 900,
         "minWidth": 1440,
         "minHeight": 900,
-        "backgroundColor": "#050b10"
+        "backgroundColor": "#050b10",
+      "dragDropEnabled": false
       }
     ],
     "security": {

--- a/static/css/widgets.css
+++ b/static/css/widgets.css
@@ -337,6 +337,10 @@
 .catalog {
   display: grid !important;
   grid-template-columns: 72px minmax(0, 1fr);
+  grid-template-rows: 1fr;
+  align-items: stretch !important;
+  height: 100% !important;
+  min-height: 0 !important;
   gap: 0 !important;
   padding: 0 !important;
   border-radius: 12px !important;
@@ -345,6 +349,8 @@
 }
 
 .catalog-rail {
+  grid-column: 1;
+  grid-row: 1;
   display: flex;
   flex-direction: column;
   align-items: stretch;
@@ -428,6 +434,8 @@
 }
 
 .catalog-main {
+  grid-column: 2;
+  grid-row: 1;
   display: flex;
   flex-direction: column;
   gap: 10px;

--- a/static/js/catalog.js
+++ b/static/js/catalog.js
@@ -452,7 +452,9 @@ function isTrackDragEvent(event) {
 }
 
 function getDraggedTrackId(event) {
-  return event?.dataTransfer?.getData(TRACK_DRAG_TYPE) || dragId;
+  return event?.dataTransfer?.getData(TRACK_DRAG_TYPE)
+    || event?.dataTransfer?.getData("text/plain")
+    || dragId;
 }
 
 function startDrag(trackId, itemEl, event) {
@@ -473,16 +475,17 @@ function endDrag(itemEl) {
   document.getElementById("lanes")?.classList.remove("library-drop-target");
 }
 
-function dropOnFolder(folderId) {
-  if (!dragId) return;
+function dropOnFolder(folderId, trackId) {
+  const id = trackId ?? dragId;
+  if (!id) return;
   // Remove from current folder
   for (const f of folders) {
-    const idx = f.items.indexOf(dragId);
+    const idx = f.items.indexOf(id);
     if (idx !== -1) { f.items.splice(idx, 1); break; }
   }
   // Add to target folder
   const target = folders.find((f) => f.id === folderId);
-  if (target && !target.items.includes(dragId)) target.items.push(dragId);
+  if (target && !target.items.includes(id)) target.items.push(id);
   saveState();
   render();
 }
@@ -546,6 +549,46 @@ function wireRailTrashDrop() {
     e.preventDefault();
     trash.classList.remove("drop-target");
     moveTrackToTrash(trackId);
+  });
+}
+
+function restoreTrackFromTrash(trackId) {
+  if (!tracks[trackId]) return;
+  const trash = getTrashFolder();
+  if (!trash?.items.includes(trackId)) return;
+  trash.items = trash.items.filter((id) => id !== trackId);
+  let target = folders.find((f) => f.id !== TRASH_ID);
+  if (!target) {
+    target = makeFolder({ id: `f-${Date.now()}`, name: "Unsorted" });
+    folders.unshift(target);
+  }
+  if (!target.items.includes(trackId)) target.items.push(trackId);
+  saveState();
+  render();
+}
+
+function wireRailLibraryDrop() {
+  const btn = document.querySelector(".rail-library");
+  if (!btn || btn.dataset.dropReady === "1") return;
+  btn.dataset.dropReady = "1";
+
+  btn.addEventListener("dragover", (e) => {
+    if (!isTrackDragEvent(e) || catalogView !== "trash") return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+    btn.classList.add("drop-target");
+  });
+  btn.addEventListener("dragleave", (e) => {
+    if (!btn.contains(e.relatedTarget)) btn.classList.remove("drop-target");
+  });
+  btn.addEventListener("drop", (e) => {
+    btn.classList.remove("drop-target");
+    if (catalogView !== "trash") return;
+    const trackId = getDraggedTrackId(e);
+    if (!trackId || !tracks[trackId]) return;
+    e.preventDefault();
+    restoreTrackFromTrash(trackId);
+    setCatalogView("library");
   });
 }
 
@@ -716,7 +759,7 @@ function renderFolder(folder) {
   el.addEventListener("drop", (e) => {
     e.preventDefault();
     el.classList.remove("drop-target");
-    dropOnFolder(folder.id);
+    dropOnFolder(folder.id, getDraggedTrackId(e));
   });
 
   return el;
@@ -956,6 +999,7 @@ export function initCatalog() {
   wireWidgets();
   wireMainPanelDrop();
   wireRailTrashDrop();
+  wireRailLibraryDrop();
   wireLibraryDeleteKeys();
   wireAboutDialog();
   setDisplayedVersion(currentVersion);


### PR DESCRIPTION
## Summary

- **`dragDropEnabled: false`** in `tauri.conf.json` — WebView2 was intercepting OS-level drag events before they reached the HTML page, silently swallowing all `dragover`/`drop` events. This is the documented requirement for HTML5 DnD on Windows in Tauri v2.
- **Catalog rail background fills full height** — the rail column was auto-placing `catalog-main` into an implicit grid row in the collapsed state, stealing height from the `1fr` row and leaving the rail background short. Fixed by pinning both children to explicit `grid-column`/`grid-row` and adding `grid-template-rows: 1fr` to the catalog grid.
- **`dropOnFolder` / `getDraggedTrackId` hardening** — accepts an explicit `trackId` argument and a `text/plain` fallback for WebView2's cross-origin `dataTransfer` restrictions.
- **Restore from trash** — dragging a track from the trash view onto the Library rail button now restores it to the first non-trash folder and switches back to library view.

## Test plan

- [x] Drag a song card from Unsorted to a user folder — moves cleanly
- [x] Drag a song card to the Trash rail button — moves to trash
- [ ] Switch to Trash view, drag a track back onto the Library rail button — restores to Unsorted, view switches to Library
- [ ] Collapse the library panel — rail background fills full height with no lighter strip below About
- [ ] Expand the library panel — layout correct, no regression