### PR TITLE
feat: local MP3/WAV file import and README overhaul

### DIFF
--- a/.woodpecker/windows-release.yml
+++ b/.woodpecker/windows-release.yml
@@ -90,10 +90,11 @@ steps:
         }
       - |
         $scanNote = "Windows portable packages were scanned with ClamAV in CI before upload."
-        $body = gh release view "$env:CI_COMMIT_TAG" --repo "thcp/stemdeck" --json body --jq ".body"
+        $bodyRaw = gh release view "$env:CI_COMMIT_TAG" --repo "thcp/stemdeck" --json body --jq ".body"
+        $body = ($bodyRaw -join "`n")
         if ($body -notlike "*$scanNote*") {
           $notesPath = Join-Path $env:TEMP "stemdeck-release-notes.md"
-          $updatedBody = (($body.TrimEnd()), "", "### Artifact scan", "", "- $scanNote") -join "`n"
+          $updatedBody = ($body.TrimEnd(), "", "### Artifact scan", "", "- $scanNote") -join "`n"
           Set-Content -Path $notesPath -Value $updatedBody -Encoding UTF8
           gh release edit "$env:CI_COMMIT_TAG" --repo "thcp/stemdeck" --notes-file $notesPath
         }

--- a/README.md
+++ b/README.md
@@ -1,231 +1,253 @@
-# StemDeck
-
-If you like StemDeck and find it useful, consider [tipping the maker](https://buymeacoffee.com/tha.les), these will always go to random acts of kindness towards others.
+<div align="center">
 
 ![StemDeck](stemdeck.png)
 
-Paste a YouTube URL, get the audio split into stems (vocals / drums / bass / guitar / piano / other) and play them back in a DAW-style multitrack mixer. Mute, solo, mix, zoom the waveform, loop a region, and download individual stems or a custom mix.
+# StemDeck
 
-Local-only, single-user. One Python process serves both the REST/SSE API and the static frontend.
+**Free, local AI stem separation. No account. No upload. No subscription.**
 
-> **What is this?** StemDeck is meant to be an open, free, simplified alternative to commercial stem-splitter products like Moises, LALAL.AI, and similar tools. It runs entirely on your own machine, with no account, no quota, no upload, and no subscription. Source-available so you can read, fork, or self-host it. It is not trying to match those products feature-for-feature; it covers the basics well and stops there.
+<div align="center">
+  <a href="https://github.com/thcp/stemdeck/stargazers"><img src="https://img.shields.io/github/stars/thcp/stemdeck?style=flat-square" alt="GitHub Stars"></a>
+  <a href="https://github.com/thcp/stemdeck/releases"><img src="https://img.shields.io/github/downloads/thcp/stemdeck/total?style=flat-square&color=52c65f" alt="Total Downloads"></a>
+  <a href="https://github.com/thcp/stemdeck/releases/latest"><img src="https://img.shields.io/github/v/release/thcp/stemdeck?style=flat-square" alt="Latest Release"></a>
+  <a href="https://github.com/thcp/stemdeck/blob/main/LICENSE"><img src="https://img.shields.io/github/license/thcp/stemdeck?style=flat-square" alt="License"></a>
+  <img src="https://img.shields.io/badge/CI-Woodpecker-4D9DE0?style=flat-square&logo=woodpecker-ci&logoColor=white" alt="CI: Woodpecker">
+  <img src="https://img.shields.io/badge/Platform-Windows%20%7C%20macOS%20%7C%20Linux-0078D6?style=flat-square&logo=windows" alt="Platform">
+  <img src="https://img.shields.io/badge/Powered_by-Demucs-FF6B35?style=flat-square" alt="Powered by Demucs">
+</div>
 
-### Honest comparison
+</div>
 
-| | StemDeck | Moises / LALAL.AI / similar |
-| --- | --- | --- |
-| Price | Free | Freemium or pay-per-use |
-| Hosting | Runs locally on your machine | Cloud, upload required |
-| Account / login | None | Required |
-| Stem model | Demucs `htdemucs_6s` (6 stems) | Proprietary, often higher quality |
-| Polish | Functional, hobby-grade UI | Polished apps (web + mobile) |
-| Extra features (pitch shift, chord detection, click track, lyrics, BPM tap, mobile apps, cloud library) | No | Yes |
-| Privacy | Audio never leaves your machine | Audio uploaded to a third party |
-| Source code | Available, modifiable | Closed |
+<br>
 
-If you need the polish, the mobile app, or the extra musician-facing tooling, the commercial products are a better fit and worth the money. If you mainly want stems for personal study and prefer to keep things local and free, StemDeck should be enough.
+Drop an MP3 or WAV, or paste a YouTube URL. StemDeck splits the audio into up to six stems (vocals, drums, bass, guitar, piano, other) and plays them back in a DAW-style multitrack mixer. Mute, solo, mix, zoom the waveform, loop a region, and download individual stems or a custom mix. Everything runs on your own machine.
 
-## Features
+> **What is this?** StemDeck is a stem separation tool, not a downloader. Its primary use case is processing audio files you already own — drag an MP3 or WAV onto the import bar and go. YouTube URL support is provided as a convenience for content you have the right to process. StemDeck does not store, cache, or redistribute any downloaded content. All processing happens locally on your machine and nothing leaves it.
 
-- **6-stem separation** via Demucs `htdemucs_6s`. Auto-detects the best Torch device (CUDA, MPS, CPU); on Apple Silicon you get ~3-5× speedup over CPU for free.
-- **DAW-style waveform editor.** Min/max sample rendering across all stems with shared global normalization, zoom in / out / Fit (`+` / `−` / `Cmd-wheel`), loop drag on the ruler, gold playhead overlay, and stem-aligned lanes.
-- **Stem subset extraction.** Click stem chips on the import page to pick which stems to keep. Filter-chip semantics: clicking from "all selected" snaps to "only this one"; subsequent clicks add or remove. Selection persists in `localStorage`.
-- **"Original" backing track.** When you pick a subset, the studio includes a 7th lane with the *complement* (full song minus the selected stems). Playing it alongside the isolated stems reconstructs the full mix without doubling, which is perfect for A/B reference.
-- **Downloadable selected mix.** A single `mix.wav` of just the selected stems, summed via ffmpeg amix. Surfaces as the **Download Mix** button in the footer.
-- **Per-stem mixer.** Volume fader, mute, solo, and "monitor" (solo-only) per stem. State is synced between the preview mixer and the stems sidebar.
-- **Live VU per stem.** Post-gain RMS via Web Audio analysers on each stem's gain node. Peak hold + slow falloff for the classic DAW meter feel.
-- **Song analysis.** BPM (librosa beat tracker on percussive HPSS), key + scale + confidence (Albrecht-Shanahan profile with root-prominence weighting), integrated LUFS (BS.1770 via pyloudnorm), sample peak in dBFS. All surfaced in the now-playing card.
-- **Cancellable jobs.** Click cancel mid-pipeline (download, Demucs, ffmpeg amix) and the runner terminates the active subprocess immediately, deletes the partial job dir, and returns the API to ready.
+> StemDeck is a free, open alternative to cloud stem-splitters like Moises and LALAL.AI. No account, no quota, no upload, no subscription. If you mainly want stems for personal study and prefer to keep things local and free, StemDeck should be enough. If you need the polish, the mobile app, or the extra musician tooling, the commercial products are a better fit.
 
-## Windows desktop app
-
-Pre-built portable zips are attached to each [GitHub release](https://github.com/thcp/stemdeck/releases). Two variants are available:
-
-| Zip | GPU | Approx. size |
-| --- | --- | --- |
-| `StemDeck-Windows-x64.zip` | CPU only | ~700 MB |
-| `StemDeck-Windows-x64.NVIDIA.zip` | NVIDIA CUDA | ~1.6 GB |
-
-Pick the CPU variant if you don't have an NVIDIA GPU, or just want a smaller download — separation still works, it's just slower. Pick the NVIDIA variant if you have a CUDA-capable GPU and want faster separation.
-
-**Running it:**
-1. Extract the zip anywhere (no installer needed).
-2. Run `StemDeck.exe`.
-3. On first launch the app runs a short setup: checks the bundled Python runtime, creates the workspace, verifies FFmpeg and the Demucs model (downloaded on first run, ~170 MB). Subsequent launches skip most of this and start in seconds.
-
-Everything is self-contained — no Python, no uv, no system dependencies required.
+If you find StemDeck useful, consider [buying the maker a coffee](https://buymeacoffee.com/tha.les); proceeds go to random acts of kindness.
 
 ---
 
-## Requirements
+## Features
 
-*(for running from source on macOS / Linux)*
+- **6-stem separation** via Demucs `htdemucs_6s`. Auto-detects the best Torch device (CUDA on NVIDIA, MPS on Apple Silicon, CPU fallback).
+- **YouTube + local file import.** Paste a YouTube URL or drop an MP3/WAV directly onto the import bar.
+- **DAW-style waveform editor.** Min/max sample rendering across all stems with shared normalization, zoom in/out/Fit, loop drag on the ruler, gold playhead overlay, and stem-aligned lanes.
+- **Stem subset extraction.** Click stem chips to pick which stems to keep. Filter-chip semantics: clicking from "all selected" snaps to "only this one"; subsequent clicks add or remove.
+- **"Original" backing track.** When you pick a subset, a 7th lane contains the *complement* (full song minus selected stems), perfect for A/B reference without doubling.
+- **Downloadable selected mix.** A single `mix.wav` of just your selected stems, summed via ffmpeg amix.
+- **Per-stem mixer.** Volume fader, mute, solo, and "monitor" (solo-only) per stem. State syncs between the preview mixer and the stems sidebar.
+- **Live VU per stem.** Post-gain RMS via Web Audio analysers on each stem's gain node with peak hold and slow falloff.
+- **Song analysis.** BPM (librosa beat tracker), key + scale + confidence (Albrecht-Shanahan profiles with root-prominence weighting), integrated LUFS (BS.1770), and sample peak in dBFS.
+- **Cancellable jobs.** Cancel mid-pipeline and the runner terminates the active subprocess immediately, deletes the partial job dir, and returns to ready.
+- **Library panel.** Folder-based track organisation with drag-and-drop, search, and trash.
+
+---
+
+## Honest Comparison
+
+StemDeck is not trying to compete with commercial stem-separation products. It covers the core use case well and stops there. This table exists so you can make an informed choice rather than discover the gaps after the fact.
+
+| | StemDeck | Moises / LALAL.AI / similar |
+|---|---|---|
+| **Price** | Free, forever | Freemium; credits or subscription required for regular use |
+| **Hosting** | Runs entirely on your machine | Cloud; audio must be uploaded to their servers |
+| **Account / login** | None | Required |
+| **Internet required** | Only for YouTube download and first model fetch (~170 MB, cached after) | Always; no offline use |
+| **Privacy** | Audio never leaves your machine | Audio is uploaded and processed on third-party servers |
+| **Data retention** | You control it; delete anytime | Governed by their privacy policy and retention period |
+| **Stem model** | Demucs `htdemucs_6s` (open source, Meta AI) | Proprietary models, regularly updated, generally higher quality |
+| **Stem count** | 6 (vocals, drums, bass, guitar, piano, other) | Up to 10 depending on service and plan |
+| **Input formats** | YouTube URL, MP3, WAV | MP3, WAV, FLAC, M4A, and more depending on service |
+| **Processing speed** | Depends on your hardware; fast with a GPU, slow on CPU only | Fast regardless of your hardware (runs on their servers) |
+| **Batch processing** | One job at a time | Yes, on paid plans |
+| **Mobile app** | No | iOS and Android |
+| **Extra features** | No (no pitch shift, chord detection, lyrics, click track, BPM tap) | Yes, varies by product |
+| **Polish** | Functional, hobby-grade UI | Polished, production-grade apps |
+| **Source code** | Open source, forkable, self-hostable | Closed source |
+
+If you need speed, quality, mobile access, or the extra musician tooling, the commercial products are worth the money. If you want stems for personal study, prefer to keep audio private, or just want something that runs locally with no strings attached, StemDeck is enough.
+
+---
+
+## Download
+
+Pre-built portable zips are attached to each [GitHub Release](https://github.com/thcp/stemdeck/releases). No installer needed; extract and run.
+
+| Zip | GPU | Approx. size |
+|---|---|---|
+| `StemDeck-Windows-x64.zip` | CPU only | ~700 MB |
+| `StemDeck-Windows-x64.NVIDIA.zip` | NVIDIA CUDA | ~1.6 GB |
+
+**Running it:**
+1. Extract the zip anywhere.
+2. Run `StemDeck.exe`.
+3. On first launch the app verifies the bundled Python runtime, downloads FFmpeg and the Demucs model (~170 MB). Subsequent launches skip this and start in seconds.
+
+Everything is self-contained. No Python, no system dependencies required.
+
+---
+
+## Technologies
+
+- **[Python 3.10+](https://python.org)**: backend runtime, managed via [uv](https://github.com/astral-sh/uv).
+- **[FastAPI](https://fastapi.tiangolo.com)**: REST + Server-Sent Events API.
+- **[Demucs](https://github.com/facebookresearch/demucs)** (`htdemucs_6s`): Meta AI's neural network for 6-stem source separation.
+- **[yt-dlp](https://github.com/yt-dlp/yt-dlp)**: audio download from YouTube URLs.
+- **[FFmpeg](https://ffmpeg.org)**: audio transcoding, amix, and analysis.
+- **[librosa](https://librosa.org)**: BPM detection and chroma-based key analysis.
+- **[pyloudnorm](https://github.com/csteinmetz1/pyloudnorm)**: ITU-R BS.1770 integrated loudness (LUFS).
+- **[Tauri v2](https://tauri.app)**: Rust/WebView2 desktop shell for the Windows app.
+- **Vanilla JS + Web Audio API**: frontend with no framework and no build step. Waveforms are rendered on `<canvas>` using min/max sample rendering.
+
+*Thanks to the creators and maintainers of all the open-source libraries that make StemDeck possible.*
+
+---
+
+## Build from Source
+
+*(macOS / Linux / Windows with Python 3.10+)*
+
+### Prerequisites
 
 - Python 3.10+
-- `ffmpeg` on `PATH` (install instructions per-platform below)
-- [uv](https://github.com/astral-sh/uv) (recommended) or `pip`
-- ~170 MB free disk for the Demucs `htdemucs_6s` model (downloaded automatically on first run)
-- Reasonably modern CPU. An Apple-Silicon `mps` or NVIDIA `cuda` GPU dramatically speeds up separation.
-
-## Setup
+- `ffmpeg` on `PATH`
+- [uv](https://github.com/astral-sh/uv)
+- ~170 MB free disk for the Demucs model (downloaded on first run)
 
 ### macOS / Linux (one-shot)
 
 ```sh
 git clone https://github.com/thcp/stemdeck stemdeck && cd stemdeck
-./run.sh setup     # detects OS, installs ffmpeg + uv, runs `uv sync`
+./run.sh setup     # installs ffmpeg + uv, runs uv sync
 ./run.sh start
 ```
 
-`setup` uses Homebrew on macOS and `apt-get` on Debian/Ubuntu. It skips anything that's already installed. For other Linux distros, install `ffmpeg` and [uv](https://github.com/astral-sh/uv) manually, then run `uv sync` followed by `./run.sh start`.
-
 Open <http://localhost:8000>.
 
-## Running
+`setup` uses Homebrew on macOS and `apt-get` on Debian/Ubuntu. For other Linux distros, install `ffmpeg` and [uv](https://github.com/astral-sh/uv) manually, then run `uv sync` followed by `./run.sh start`.
 
-### `run.sh` (macOS / Linux)
-
-The bundled control script manages the dev server as a background process with a PID file and a log:
+### Manual (any platform)
 
 ```sh
-./run.sh setup      # one-shot: install ffmpeg + uv (brew/apt), then `uv sync`
-./run.sh start      # boots uvicorn, writes .run/uvicorn.pid + .run/uvicorn.log
-./run.sh stop       # graceful shutdown, force-kills after 5 s, sweeps stray demucs children
-./run.sh restart    # stop + start
-./run.sh status     # is it running, on which URL
-```
-
-Environment variables it respects:
-
-| Variable | Default | Purpose |
-| --- | --- | --- |
-| `HOST` | `127.0.0.1` | Bind address. Set to `0.0.0.0` to expose on the LAN. |
-| `PORT` | `8000` | Listening port. |
-| `RELOAD` | `0` | Set to `1` to pass `--reload` for hot reload during development. |
-| `FOREGROUND` | `0` | Set to `1` to run uvicorn in the foreground (blocking, no PID file dance). |
-
-Examples:
-
-```sh
-RELOAD=1 ./run.sh start          # dev mode with auto-reload on file change
-PORT=9000 ./run.sh start         # listen on a different port
-HOST=0.0.0.0 ./run.sh start      # accessible from other machines on the LAN
-FOREGROUND=1 ./run.sh start      # blocking; Ctrl-C to stop
-tail -f .run/uvicorn.log         # follow logs while running in background
-```
-
-### Manual uvicorn (any platform)
-
-```sh
+git clone https://github.com/thcp/stemdeck stemdeck && cd stemdeck
+uv sync
 uv run uvicorn app.main:app --reload
-# or:  source .venv/bin/activate && uvicorn app.main:app --reload
 ```
 
 ### Docker
-
-The Dockerfile and compose file live in `build/`:
 
 ```sh
 docker compose -f build/docker-compose.yml up --build
 ```
 
-Open <http://localhost:8000>. Stems land in `./jobs/` on the host. Demucs model weights are kept in a named volume (`stemdeck-cache`) so they don't re-download on rebuild.
+Stems land in `./jobs/` on the host. Demucs weights are cached in a named volume so they don't re-download on rebuild. Note: no GPU passthrough on macOS Docker.
 
-**Caveats:**
+### `run.sh` control script
 
-- **No GPU on macOS Docker.** Docker Desktop on Mac doesn't expose MPS or CUDA, so Demucs runs CPU-only inside the container, which is significantly slower than the native install. Use the native install on Apple Silicon for speed.
-- **NVIDIA GPU passthrough (Linux)** isn't enabled in `build/docker-compose.yml` by default. Add `deploy.resources.reservations.devices` with `driver: nvidia` if you want it; you'll also need `nvidia-container-toolkit` on the host.
-- **First build is slow.** `pip install .` pulls torch (~2 GB) and friends. Subsequent rebuilds reuse the layer unless `pyproject.toml` changes.
-- **First job is slow.** Demucs downloads `htdemucs_6s` weights (~170 MB) on the first run; cached after that.
+```sh
+./run.sh setup      # one-shot: install ffmpeg + uv, then uv sync
+./run.sh start      # boots uvicorn in the background
+./run.sh stop       # graceful shutdown
+./run.sh restart    # stop + start
+./run.sh status     # is it running?
+```
 
-## How to use
+---
 
-1. (Optional) On the import page, click stem chips to pick which stems to extract. By default all 6 are selected. Clicking a chip while everything is highlighted snaps to "only this stem"; subsequent clicks add to or remove from the selection.
-2. Paste a YouTube URL and click **Process**.
-3. Wait through `Downloading…`, `Analyzing…`, `Separating…`, `Mixing tracks…`. First run also downloads the Demucs model (~170 MB).
-4. When it's done, the studio dashboard appears. If you picked a subset, the first lane is **Original** (the song minus the selected stems); the rest are the isolated stems you chose. Otherwise all 6 stems show.
+## How to Use
+
+1. On the import bar, click stem chips to choose which stems to extract (defaults to all 6).
+2. Paste a YouTube URL **or** drop an MP3/WAV file, then click **Process**.
+3. Wait through `Uploading...` / `Downloading...` → `Analyzing...` → `Separating...` → `Mixing tracks...`.
+4. When done, the studio dashboard appears. If you picked a subset, the first lane is **Original** (full song minus your selection); the rest are your isolated stems.
 5. Mix:
-   - **▶ ⏸ ⏹** master transport
-   - **M** mute, **S** solo (additive: solo two stems and both stay audible)
-   - **○ Monitor** solo-only this stem (clears other solos)
-   - **vol fader**: drag for 1:1 movement; double-click resets to 0 dB; `Shift+wheel` for coarse, plain wheel for fine adjustment
-   - **Reset / Mute / Solo** toolbar buttons at the top reset/toggle all stems at once
-6. Wave editor: drag on the ruler to define a loop region, click `Loop` to enable, `+` / `−` / `Fit` to zoom, `Cmd/Ctrl-wheel` to zoom centered on cursor.
-7. **Download Mix** in the footer gives you a single WAV of just your selected stems summed together.
+   - **Play / Pause / Stop**: master transport
+   - **M** mute · **S** solo (additive) · **Monitor**: solo-only this stem
+   - **Vol fader**: drag for 1:1; double-click resets to 0 dB; `Shift+wheel` coarse, `wheel` fine
+   - **Reset / Mute / Solo** toolbar buttons act on all stems at once
+6. Drag on the ruler to define a loop region; click `Loop` to enable. `+` / `-` / `Fit` or `Ctrl/Cmd+wheel` to zoom.
+7. **Download Mix** in the footer gives you a WAV of your selected stems summed together.
 
-**Keyboard shortcuts:** `Space` play/pause · `[` seek -5s · `]` seek +5s · `L` toggle loop · `I` set loop start at playhead · `O` set loop end at playhead.
+**Keyboard shortcuts:** `Space` play/pause · `[` seek -5s · `]` seek +5s · `L` loop · `I` loop in · `O` loop out
 
-## Layout on disk
+---
+
+## Configuration
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `STEMDECK_DEMUCS_DEVICE` | auto | Force Torch device: `cuda`, `mps`, or `cpu`. |
+| `STEMDECK_DEMUCS_MODEL` | `htdemucs_6s` | Demucs model name. |
+| `STEMDECK_JOBS_DIR` | `./jobs` | Where job directories land. |
+| `STEMDECK_MAX_DURATION_SEC` | `1200` | Reject audio longer than this (seconds). |
+| `STEMDECK_JOB_TTL_SECONDS` | `86400` | How long to keep job dirs on disk. |
+| `STEMDECK_MAX_PENDING_JOBS` | `3` | Max queued jobs before returning 503. |
+
+---
+
+## API
+
+| Method | Path | Purpose |
+|---|---|---|
+| POST | `/api/jobs` | JSON `{url, stems?}` or multipart `file + stems` → `{job_id}` |
+| GET | `/api/jobs/{id}` | Job state snapshot |
+| GET | `/api/jobs/{id}/events` | SSE stream of job state |
+| POST | `/api/jobs/{id}/cancel` | Terminate active subprocess and cancel job |
+| GET | `/api/jobs/{id}/stems/{name}.wav` | Stream/download a single stem (range requests) |
+| DELETE | `/api/jobs/{id}` | Remove job dir from disk (terminal jobs only) |
+
+---
+
+## Troubleshooting
+
+- **`ffmpeg: command not found`**: install ffmpeg and restart (`./run.sh restart`).
+- **`WARNING: [youtube] No supported JavaScript runtime`**: install deno (`brew install deno` on macOS) and restart. Downloads still work without it but may pick suboptimal formats.
+- **First separation is very slow**: Demucs downloads `htdemucs_6s` weights (~170 MB) on first run; cached afterwards.
+- **Demucs runs on CPU only**: check the startup log for `device=mps` or `device=cuda`. If you see `cpu`, your torch install may be CPU-only.
+- **Page reloaded mid-job**: the job keeps running server-side. Wait for it to finish, then resubmit.
+- **`./run.sh: Permission denied`**: run `chmod +x run.sh`.
+
+---
+
+## Layout on Disk
 
 ```
 jobs/<job_id>/
 └── stems/
-    ├── vocals.wav      # always: the 6 demucs stems
+    ├── vocals.wav      # the 6 Demucs stems (always present)
     ├── drums.wav
     ├── bass.wav
     ├── guitar.wav
     ├── piano.wav
     ├── other.wav
-    ├── original.wav    # only when a strict subset was selected:
-    │                   #   sum of the un-selected stems
-    └── mix.wav         # only when ≥2 stems were selected:
-                        #   ffmpeg amix of the selected stems
+    ├── original.wav    # sum of un-selected stems (subset only)
+    └── mix.wav         # ffmpeg amix of selected stems (subset only)
 ```
 
-The source download is deleted after Demucs finishes (it's 100-300 MB and isn't used again).
+Job state is in-memory. Restart the server and the job list resets, but files persist on disk. Old dirs are swept automatically (TTL 24 h, configurable).
 
-Job state is in-memory only. Restart the server and the job list is wiped, but the files persist on disk. Send `DELETE /api/jobs/<job_id>` (or just delete `jobs/<job_id>/`) to reclaim space. Old job dirs are also swept automatically when a new job is submitted (TTL 24 h, configurable via `STEMDECK_JOB_TTL_SECONDS`).
-
-## Configuration
-
-App environment variables, all optional:
-
-| Variable | Default | Purpose |
-| --- | --- | --- |
-| `STEMDECK_DEMUCS_DEVICE` | auto | Force a Torch device: `cuda`, `mps`, or `cpu`. |
-| `STEMDECK_DEMUCS_MODEL` | `htdemucs_6s` | Demucs model name. |
-| `STEMDECK_JOBS_DIR` | `./jobs` | Where job dirs land. |
-| `STEMDECK_MAX_DURATION_SEC` | `1200` | Reject videos longer than this. |
-| `STEMDECK_JOB_TTL_SECONDS` | `86400` | How long to keep a job dir on disk. |
-| `STEMDECK_MAX_PENDING_JOBS` | `3` | Admission control (currently advisory). |
-
-## Troubleshooting
-
-- **`uvicorn not found at .venv/bin/uvicorn`** when running `./run.sh start`: you haven't installed deps yet. Run `uv sync` first.
-- **`ffmpeg: command not found`** during a job: install ffmpeg per the platform-specific Setup section above and restart the server (`./run.sh restart`).
-- **`WARNING: [youtube] No supported JavaScript runtime could be found`**: yt-dlp needs a JS runtime to reliably pick the best YouTube audio format. Install deno (`brew install deno` on macOS, `curl -fsSL https://deno.land/install.sh | sh` on Linux) and restart. Without it, downloads still work but may pick suboptimal formats.
-- **First separation is very slow**: the Demucs model weights download on first run. Subsequent runs reuse the cached weights in `~/.cache/torch/hub/checkpoints`.
-- **Demucs runs on CPU and takes minutes**: Demucs picks the best device automatically (CUDA, MPS, CPU). On Apple Silicon you should see MPS acceleration; if not, your `torch` install may be CPU-only. Check the server log on startup for `demucs config: model=htdemucs_6s device=mps`.
-- **Browser memory grows on long videos**: the multitrack player decodes each stem into a Web Audio buffer for the overview waveform. A 6-minute song uses a few hundred MB of decoded audio in memory; long lectures will be uncomfortable. Trim the input or close other tabs.
-- **Page reloaded mid-job**: the job keeps running on the server, but the UI loses track of it. Wait for it to finish, then re-submit (the stems on disk get overwritten, or, if you want the previous output, find it under `jobs/<job_id>/stems/`).
-- **`./run.sh: Permission denied`**: the script lost its executable bit. Run `chmod +x run.sh`.
-
-## API (for tinkering)
-
-| Method | Path | Purpose |
-| --- | --- | --- |
-| POST | `/api/jobs` | Body `{url, stems?}` → `{job_id}`. `stems` is an optional array of stem names; defaults to all 6. |
-| GET | `/api/jobs/{id}` | Job state snapshot. |
-| GET | `/api/jobs/{id}/events` | Server-Sent Events stream of job state. |
-| POST | `/api/jobs/{id}/cancel` | Set the cancel flag and terminate the active subprocess. |
-| GET | `/api/jobs/{id}/stems/{name}.wav` | Stream/download a single stem (range requests). `name` ∈ {6 demucs stems, `original`, `mix`}. |
-| DELETE | `/api/jobs/{id}` | Remove the job dir from disk (must be done/error/cancelled). |
+---
 
 ## Disclaimer
 
-StemDeck is an educational project intended for study, research, and experimentation with audio source separation. It bundles two notable third-party tools:
+StemDeck is a local audio stem separation tool intended for personal study, research, and experimentation. It is not a downloading service. It does not store, cache, or redistribute any audio content. All processing runs on the user's own machine and no audio is transmitted anywhere.
 
-- **[yt-dlp](https://github.com/yt-dlp/yt-dlp)** for downloading audio from URLs you provide.
-- **[Demucs](https://github.com/facebookresearch/demucs)** (`htdemucs_6s` model) for source separation.
+YouTube URL support is provided via [yt-dlp](https://github.com/yt-dlp/yt-dlp) as a convenience. Automated downloading may violate YouTube's Terms of Service. You, the user, are solely responsible for ensuring you have the right to process any audio you submit, complying with the terms of service of any site you download from, and respecting the copyright of the material you work with.
 
-You, the user running this software, are solely responsible for how you use it, including:
+You are also responsible for following the licenses of the underlying tools this project depends on (yt-dlp, Demucs, FFmpeg, PyTorch, and others listed in `pyproject.toml`).
 
-- Complying with the terms of service of any site you download from (YouTube's ToS, in particular, restricts automated downloads).
-- Respecting the copyright of the audio you process. Separating stems from copyrighted material may be permissible for personal study or fair-use analysis in some jurisdictions, but redistribution of the resulting stems generally is not.
-- Following the licenses of the underlying tools and models (yt-dlp, Demucs, FFmpeg, PyTorch, etc.).
+The author(s) of StemDeck provide this software "as is", without warranty of any kind, and accept no responsibility or liability for how it is used.
 
-The author(s) of StemDeck provide this code "as is", without warranty of any kind, and accept no responsibility or liability for how it is used. If you're unsure whether a particular use is allowed in your jurisdiction, consult a lawyer before proceeding.
+---
 
+## Contributing
+
+Issues, feature suggestions, and pull requests are welcome. See open issues for what's planned.
+
+---
 
 ## Star History
 

--- a/README.md
+++ b/README.md
@@ -32,17 +32,27 @@ If you find StemDeck useful, consider [buying the maker a coffee](https://buymea
 
 ## Features
 
-- **6-stem separation** via Demucs `htdemucs_6s`. Auto-detects the best Torch device (CUDA on NVIDIA, MPS on Apple Silicon, CPU fallback).
-- **YouTube + local file import.** Paste a YouTube URL or drop an MP3/WAV directly onto the import bar.
-- **DAW-style waveform editor.** Min/max sample rendering across all stems with shared normalization, zoom in/out/Fit, loop drag on the ruler, gold playhead overlay, and stem-aligned lanes.
-- **Stem subset extraction.** Click stem chips to pick which stems to keep. Filter-chip semantics: clicking from "all selected" snaps to "only this one"; subsequent clicks add or remove.
-- **"Original" backing track.** When you pick a subset, a 7th lane contains the *complement* (full song minus selected stems), perfect for A/B reference without doubling.
-- **Downloadable selected mix.** A single `mix.wav` of just your selected stems, summed via ffmpeg amix.
-- **Per-stem mixer.** Volume fader, mute, solo, and "monitor" (solo-only) per stem. State syncs between the preview mixer and the stems sidebar.
-- **Live VU per stem.** Post-gain RMS via Web Audio analysers on each stem's gain node with peak hold and slow falloff.
-- **Song analysis.** BPM (librosa beat tracker), key + scale + confidence (Albrecht-Shanahan profiles with root-prominence weighting), integrated LUFS (BS.1770), and sample peak in dBFS.
-- **Cancellable jobs.** Cancel mid-pipeline and the runner terminates the active subprocess immediately, deletes the partial job dir, and returns to ready.
-- **Library panel.** Folder-based track organisation with drag-and-drop, search, and trash.
+**6-stem separation** via Demucs `htdemucs_6s`, with auto-detection of the best Torch device (CUDA on NVIDIA, MPS on Apple Silicon, CPU fallback).
+
+**YouTube and local file import.** Paste a YouTube URL or drop an MP3 or WAV directly onto the import bar.
+
+**DAW-style waveform editor** with min/max sample rendering across all stems, shared normalization, zoom in/out/Fit, loop drag on the ruler, gold playhead overlay, and stem-aligned lanes.
+
+**Stem subset extraction.** Click stem chips to choose which stems to keep. Clicking from "all selected" snaps to "only this one"; subsequent clicks add or remove.
+
+**"Original" backing track.** When you pick a subset, a 7th lane contains the complement (full song minus selected stems), perfect for A/B reference without doubling.
+
+**Downloadable selected mix.** A single `mix.wav` of just your selected stems, summed via ffmpeg amix.
+
+**Per-stem mixer** with volume fader, mute, solo, and "monitor" (solo-only) per stem. State syncs between the preview mixer and the stems sidebar.
+
+**Live VU meters** per stem. Post-gain RMS via Web Audio analysers with peak hold and slow falloff.
+
+**Song analysis** including BPM (librosa beat tracker), key, scale, and confidence (Albrecht-Shanahan profiles), integrated LUFS (BS.1770), and sample peak in dBFS.
+
+**Cancellable jobs.** Cancel mid-pipeline and the runner terminates the active subprocess immediately, deletes the partial job dir, and returns to ready.
+
+**Library panel** with folder-based track organisation, drag-and-drop, search, and trash.
 
 ---
 
@@ -81,26 +91,13 @@ Pre-built portable zips are attached to each [GitHub Release](https://github.com
 | `StemDeck-Windows-x64.zip` | CPU only | ~700 MB |
 | `StemDeck-Windows-x64.NVIDIA.zip` | NVIDIA CUDA | ~1.6 GB |
 
-**Running it:**
-1. Extract the zip anywhere.
-2. Run `StemDeck.exe`.
-3. On first launch the app verifies the bundled Python runtime, downloads FFmpeg and the Demucs model (~170 MB). Subsequent launches skip this and start in seconds.
-
-Everything is self-contained. No Python, no system dependencies required.
+Extract the zip anywhere, run `StemDeck.exe`. On first launch the app verifies the bundled Python runtime and downloads FFmpeg and the Demucs model (~170 MB). Subsequent launches skip this and start in seconds. Everything is self-contained; no Python or system dependencies required.
 
 ---
 
 ## Technologies
 
-- **[Python 3.10+](https://python.org)**: backend runtime, managed via [uv](https://github.com/astral-sh/uv).
-- **[FastAPI](https://fastapi.tiangolo.com)**: REST + Server-Sent Events API.
-- **[Demucs](https://github.com/facebookresearch/demucs)** (`htdemucs_6s`): Meta AI's neural network for 6-stem source separation.
-- **[yt-dlp](https://github.com/yt-dlp/yt-dlp)**: audio download from YouTube URLs.
-- **[FFmpeg](https://ffmpeg.org)**: audio transcoding, amix, and analysis.
-- **[librosa](https://librosa.org)**: BPM detection and chroma-based key analysis.
-- **[pyloudnorm](https://github.com/csteinmetz1/pyloudnorm)**: ITU-R BS.1770 integrated loudness (LUFS).
-- **[Tauri v2](https://tauri.app)**: Rust/WebView2 desktop shell for the Windows app.
-- **Vanilla JS + Web Audio API**: frontend with no framework and no build step. Waveforms are rendered on `<canvas>` using min/max sample rendering.
+StemDeck is built on **[Python 3.10+](https://python.org)** managed via **[uv](https://github.com/astral-sh/uv)**, with a **[FastAPI](https://fastapi.tiangolo.com)** backend serving REST and Server-Sent Events. Stem separation uses **[Demucs](https://github.com/facebookresearch/demucs)** (`htdemucs_6s`), Meta AI's open-source 6-stem neural network. YouTube audio is fetched via **[yt-dlp](https://github.com/yt-dlp/yt-dlp)**; transcoding and mixing use **[FFmpeg](https://ffmpeg.org)**. BPM detection and key analysis run on **[librosa](https://librosa.org)**; loudness measurement uses **[pyloudnorm](https://github.com/csteinmetz1/pyloudnorm)** (ITU-R BS.1770). The Windows desktop shell is **[Tauri v2](https://tauri.app)** (Rust/WebView2). The frontend is vanilla JS with the Web Audio API, no framework and no build step; waveforms are rendered on `<canvas>` using min/max sample rendering.
 
 *Thanks to the creators and maintainers of all the open-source libraries that make StemDeck possible.*
 
@@ -112,10 +109,7 @@ Everything is self-contained. No Python, no system dependencies required.
 
 ### Prerequisites
 
-- Python 3.10+
-- `ffmpeg` on `PATH`
-- [uv](https://github.com/astral-sh/uv)
-- ~170 MB free disk for the Demucs model (downloaded on first run)
+Python 3.10 or newer, `ffmpeg` on your PATH, and [uv](https://github.com/astral-sh/uv). Around 170 MB of free disk for the Demucs model, which downloads automatically on first run.
 
 ### macOS / Linux (one-shot)
 
@@ -163,12 +157,8 @@ Stems land in `./jobs/` on the host. Demucs weights are cached in a named volume
 2. Paste a YouTube URL **or** drop an MP3/WAV file, then click **Process**.
 3. Wait through `Uploading...` / `Downloading...` → `Analyzing...` → `Separating...` → `Mixing tracks...`.
 4. When done, the studio dashboard appears. If you picked a subset, the first lane is **Original** (full song minus your selection); the rest are your isolated stems.
-5. Mix:
-   - **Play / Pause / Stop**: master transport
-   - **M** mute · **S** solo (additive) · **Monitor**: solo-only this stem
-   - **Vol fader**: drag for 1:1; double-click resets to 0 dB; `Shift+wheel` coarse, `wheel` fine
-   - **Reset / Mute / Solo** toolbar buttons act on all stems at once
-6. Drag on the ruler to define a loop region; click `Loop` to enable. `+` / `-` / `Fit` or `Ctrl/Cmd+wheel` to zoom.
+5. Mix: **Play/Pause/Stop** controls the master transport. **M** mutes a stem, **S** solos it (additive; multiple solos stay audible), **Monitor** solos only that stem and clears others. The volume fader moves 1:1 with drag; double-click resets to 0 dB; `Shift+wheel` gives coarse adjustment and plain wheel gives fine. The **Reset**, **Mute**, and **Solo** toolbar buttons act on all stems at once.
+6. Drag on the ruler to define a loop region; click `Loop` to enable. Use `+` / `-` / `Fit` or `Ctrl/Cmd+wheel` to zoom.
 7. **Download Mix** in the footer gives you a WAV of your selected stems summed together.
 
 **Keyboard shortcuts:** `Space` play/pause · `[` seek -5s · `]` seek +5s · `L` loop · `I` loop in · `O` loop out
@@ -203,12 +193,17 @@ Stems land in `./jobs/` on the host. Demucs weights are cached in a named volume
 
 ## Troubleshooting
 
-- **`ffmpeg: command not found`**: install ffmpeg and restart (`./run.sh restart`).
-- **`WARNING: [youtube] No supported JavaScript runtime`**: install deno (`brew install deno` on macOS) and restart. Downloads still work without it but may pick suboptimal formats.
-- **First separation is very slow**: Demucs downloads `htdemucs_6s` weights (~170 MB) on first run; cached afterwards.
-- **Demucs runs on CPU only**: check the startup log for `device=mps` or `device=cuda`. If you see `cpu`, your torch install may be CPU-only.
-- **Page reloaded mid-job**: the job keeps running server-side. Wait for it to finish, then resubmit.
-- **`./run.sh: Permission denied`**: run `chmod +x run.sh`.
+**`ffmpeg: command not found`:** install ffmpeg and restart with `./run.sh restart`.
+
+**`WARNING: [youtube] No supported JavaScript runtime`:** install deno (`brew install deno` on macOS) and restart. Downloads still work without it but may pick suboptimal formats.
+
+**First separation is very slow:** Demucs downloads `htdemucs_6s` weights (~170 MB) on first run; cached afterwards.
+
+**Demucs runs on CPU only:** check the startup log for `device=mps` or `device=cuda`. If you see `cpu`, your torch install may be CPU-only.
+
+**Page reloaded mid-job:** the job keeps running server-side. Wait for it to finish, then resubmit.
+
+**`./run.sh: Permission denied`:** run `chmod +x run.sh`.
 
 ---
 

--- a/app/api/jobs.py
+++ b/app/api/jobs.py
@@ -1,14 +1,25 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
+import re
 import shutil
+import subprocess
 import uuid
+from pathlib import Path
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
-from app.core.config import JOB_ID_RE, JOBS_DIR, MAX_PENDING_JOBS, STEM_NAMES
+from app.core.config import (
+    JOB_ID_RE,
+    JOBS_DIR,
+    MAX_DURATION_SEC,
+    MAX_PENDING_JOBS,
+    STEM_NAMES,
+    ffprobe_executable,
+)
 from app.core.models import Job
 from app.core.registry import all_jobs as registry_all_jobs
 from app.core.registry import get as registry_get
@@ -16,11 +27,61 @@ from app.core.registry import get_proc as registry_get_proc
 from app.core.registry import persist as registry_persist
 from app.core.registry import register as registry_register
 from app.core.registry import remove as registry_remove
-from app.pipeline import run_pipeline
+from app.pipeline import run_local_pipeline, run_pipeline
 from app.pipeline.download import InvalidYouTubeURL, validate_youtube_url
 
 router = APIRouter(tags=["jobs"])
 logger = logging.getLogger("stemdeck.api")
+
+_ALLOWED_EXTS = frozenset((".mp3", ".wav"))
+_MAX_UPLOAD_BYTES = 100 * 1024 * 1024  # 100 MB
+_WS_RE = re.compile(r"\s+")
+
+
+def _sanitize_title(filename: str) -> str:
+    """Strip extension, normalize whitespace, cap at 120 chars."""
+    stem = Path(filename).stem
+    return _WS_RE.sub(" ", stem).strip()[:120]
+
+
+def _probe_duration(path: Path) -> float:
+    """Run ffprobe to get file duration in seconds."""
+    result = subprocess.run(
+        [
+            ffprobe_executable(),
+            "-v",
+            "quiet",
+            "-show_entries",
+            "format=duration",
+            "-of",
+            "default=noprint_wrappers=1:nokey=1",
+            str(path),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"ffprobe failed: {result.stderr.strip()}")
+    try:
+        return float(result.stdout.strip())
+    except ValueError as e:
+        raise RuntimeError(f"ffprobe returned non-numeric duration: {result.stdout!r}") from e
+
+
+def _check_file_size(file_obj: object) -> int:
+    """Seek to end, return size, rewind. Operates on the SpooledTemporaryFile
+    backing a starlette UploadFile — synchronous, suitable for to_thread."""
+    file_obj.seek(0, 2)  # type: ignore[union-attr]
+    size = file_obj.tell()  # type: ignore[union-attr]
+    file_obj.seek(0)  # type: ignore[union-attr]
+    return size
+
+
+def _copy_to_dest(src_file: object, dest: Path) -> None:
+    """Copy SpooledTemporaryFile contents to dest. Synchronous, run in thread."""
+    with dest.open("wb") as out:
+        shutil.copyfileobj(src_file, out)  # type: ignore[arg-type]
 
 
 def _rmtree_job(job_id: str) -> None:
@@ -52,19 +113,127 @@ class JobRequest(BaseModel):
 
 
 @router.post("")
-async def create_job(payload: JobRequest) -> dict[str, str]:
+async def create_job(request: Request) -> dict[str, str]:
+    ct = request.headers.get("content-type", "")
+    if "multipart/form-data" in ct:
+        return await _create_local_job(request)
+    return await _create_youtube_job(request)
+
+
+async def _create_youtube_job(request: Request) -> dict[str, str]:
+    try:
+        body = await request.json()
+    except Exception as e:
+        raise HTTPException(status_code=422, detail=f"Invalid JSON: {e}") from e
+    try:
+        payload = JobRequest(**body)
+    except Exception as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
+
     try:
         url = validate_youtube_url(payload.url)
     except InvalidYouTubeURL as e:
         raise HTTPException(status_code=422, detail=str(e)) from e
+
     pending = sum(1 for j in registry_all_jobs().values() if j.status == "queued")
     if pending >= MAX_PENDING_JOBS:
         raise HTTPException(status_code=503, detail="Server busy, please try again later")
+
     selected = [s for s in payload.stems if s in STEM_NAMES] if payload.stems else list(STEM_NAMES)
-    if not selected:  # everything was unknown -- treat as full set
+    if not selected:
         selected = list(STEM_NAMES)
+
     job = registry_register(Job(id=uuid.uuid4().hex[:12], selected_stems=selected))
     task = asyncio.create_task(run_pipeline(job, url, JOBS_DIR))
+    task.add_done_callback(_task_error_cb)
+    return {"job_id": job.id}
+
+
+async def _create_local_job(request: Request) -> dict[str, str]:
+    # Reject busy server BEFORE touching disk so no orphan dir is created.
+    pending = sum(1 for j in registry_all_jobs().values() if j.status == "queued")
+    if pending >= MAX_PENDING_JOBS:
+        raise HTTPException(status_code=503, detail="Server busy, please try again later")
+
+    # Quick pre-check on Content-Length to fail fast for obviously oversized
+    # uploads without buffering the whole body first.
+    cl_header = request.headers.get("content-length")
+    if cl_header:
+        try:
+            if int(cl_header) > _MAX_UPLOAD_BYTES + 4096:
+                raise HTTPException(status_code=422, detail="File exceeds 100 MB limit")
+        except ValueError:
+            pass
+
+    form = await request.form()
+    upload = form.get("file")
+    stems_raw = form.get("stems", "[]")
+
+    if upload is None or not hasattr(upload, "filename"):
+        raise HTTPException(status_code=422, detail="No file provided")
+
+    filename: str = getattr(upload, "filename", "") or ""
+    ext = Path(filename).suffix.lower()
+    if ext not in _ALLOWED_EXTS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Unsupported file type '{ext}': only .mp3 and .wav are accepted",
+        )
+
+    # Validate stems list from form field
+    try:
+        stems_list = json.loads(stems_raw)
+        if not isinstance(stems_list, list):
+            raise ValueError
+    except (json.JSONDecodeError, ValueError):
+        stems_list = []
+    selected = [s for s in stems_list if s in STEM_NAMES] or list(STEM_NAMES)
+
+    # Check actual file size (SpooledTemporaryFile is already buffered at this
+    # point; seek/tell are fast and don't re-read the body).
+    file_obj = upload.file  # type: ignore[union-attr]
+    file_size = await asyncio.to_thread(_check_file_size, file_obj)
+    if file_size == 0:
+        raise HTTPException(status_code=422, detail="Uploaded file is empty")
+    if file_size > _MAX_UPLOAD_BYTES:
+        raise HTTPException(status_code=422, detail="File exceeds 100 MB limit")
+
+    job_id = uuid.uuid4().hex[:12]
+    job_dir = JOBS_DIR / job_id
+    source_path = job_dir / f"source{ext}"
+
+    job_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        await asyncio.to_thread(_copy_to_dest, file_obj, source_path)
+
+        # Duration check before registering the job so a violation leaves no
+        # registered job and no leftover directory.
+        try:
+            duration = await asyncio.to_thread(_probe_duration, source_path)
+        except Exception as e:
+            raise HTTPException(status_code=422, detail=f"Could not read file duration: {e}") from e
+
+        if duration > MAX_DURATION_SEC:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"File is {int(duration // 60)} min — limit is {MAX_DURATION_SEC // 60} min"
+                ),
+            )
+    except HTTPException:
+        shutil.rmtree(job_dir, ignore_errors=True)
+        raise
+
+    title = _sanitize_title(filename)
+    job = registry_register(
+        Job(
+            id=job_id,
+            selected_stems=selected,
+            title=title,
+            duration_sec=duration,
+        )
+    )
+    task = asyncio.create_task(run_local_pipeline(job, source_path, JOBS_DIR))
     task.add_done_callback(_task_error_cb)
     return {"job_id": job.id}
 
@@ -92,11 +261,8 @@ def cancel_job(job_id: str) -> dict:
     if job is None:
         raise HTTPException(status_code=404, detail="job not found")
     if job.status in ("done", "error", "cancelled"):
-        # Already terminal -- return current state without touching anything.
         return job.to_state()
     job.cancel_requested = True
-    # If Demucs is the current stage, terminate it immediately so the read
-    # loop hits EOF and the runner translates that into a `cancelled` state.
     proc = registry_get_proc(job_id)
     if proc is not None and proc.poll() is None:
         proc.terminate()

--- a/app/api/jobs.py
+++ b/app/api/jobs.py
@@ -143,7 +143,7 @@ async def _create_youtube_job(request: Request) -> dict[str, str]:
     if not selected:
         selected = list(STEM_NAMES)
 
-    job = registry_register(Job(id=uuid.uuid4().hex[:12], selected_stems=selected))
+    job = registry_register(Job(id=uuid.uuid4().hex[:12], selected_stems=selected, source_url=url))
     task = asyncio.create_task(run_pipeline(job, url, JOBS_DIR))
     task.add_done_callback(_task_error_cb)
     return {"job_id": job.id}
@@ -225,12 +225,14 @@ async def _create_local_job(request: Request) -> dict[str, str]:
         raise
 
     title = _sanitize_title(filename)
+    local_source_url = f"local:{title}"
     job = registry_register(
         Job(
             id=job_id,
             selected_stems=selected,
             title=title,
             duration_sec=duration,
+            source_url=local_source_url,
         )
     )
     task = asyncio.create_task(run_local_pipeline(job, source_path, JOBS_DIR))

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -62,6 +62,10 @@ FFMPEG_BIN = _env_path(
     "STEMDECK_FFMPEG",
     FFMPEG_DIR / ("ffmpeg.exe" if sys.platform.startswith("win") else "ffmpeg"),
 )
+FFPROBE_BIN = _env_path(
+    "STEMDECK_FFPROBE",
+    FFMPEG_DIR / ("ffprobe.exe" if sys.platform.startswith("win") else "ffprobe"),
+)
 DEMUCS_MODEL = os.environ.get("STEMDECK_DEMUCS_MODEL", "htdemucs_6s").strip() or "htdemucs_6s"
 DEMUCS_DEVICE = _detect_device()
 MAX_DURATION_SEC = max(60, _env_int("STEMDECK_MAX_DURATION_SEC", 1200))  # 20 min default
@@ -77,6 +81,11 @@ def ffmpeg_executable() -> str:
     keep working exactly as before.
     """
     return str(FFMPEG_BIN) if FFMPEG_BIN.is_file() else "ffmpeg"
+
+
+def ffprobe_executable() -> str:
+    """Return the preferred ffprobe executable (same bundled dir as ffmpeg)."""
+    return str(FFPROBE_BIN) if FFPROBE_BIN.is_file() else "ffprobe"
 
 
 def configure_portable_environment() -> None:

--- a/app/core/models.py
+++ b/app/core/models.py
@@ -34,6 +34,7 @@ class Job:
     # download a single track containing just their chosen stems.
     selected_stems: list[str] = field(default_factory=list)
     mix_url: str | None = None  # populated when a strict subset was selected
+    source_url: str | None = None  # original URL or "local:<filename>" for file uploads
     error: str | None = None
     # Set by POST /api/jobs/{id}/cancel; consumed by pipeline stages.
     # Not surfaced via to_state() -- it's internal control state.
@@ -60,6 +61,7 @@ class Job:
             "stems": self.stems,
             "selected_stems": self.selected_stems,
             "mix_url": self.mix_url,
+            "source_url": self.source_url,
             "error": self.error,
         }
 

--- a/app/pipeline/__init__.py
+++ b/app/pipeline/__init__.py
@@ -1,4 +1,4 @@
 from app.core.config import STEM_NAMES
-from app.pipeline.runner import run_pipeline
+from app.pipeline.runner import run_local_pipeline, run_pipeline
 
-__all__ = ["run_pipeline", "STEM_NAMES"]
+__all__ = ["run_pipeline", "run_local_pipeline", "STEM_NAMES"]

--- a/app/pipeline/runner.py
+++ b/app/pipeline/runner.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import shutil
+import subprocess
 from pathlib import Path
 
 from app.core.models import Job, JobCancelled
@@ -34,30 +35,58 @@ def _check_cancel(job: Job) -> None:
         raise JobCancelled()
 
 
-def _run_blocking(job: Job, url: str, job_dir: Path) -> None:
-    _check_cancel(job)
-    source = download(job, url, job_dir)
+def _prepare_local_source(job: Job, source: Path, job_dir: Path) -> Path:
+    """Transcode an MP3 local upload to 16-bit 44.1 kHz stereo WAV before
+    handing it to Demucs. Avoids silent failures from VBR MP3, non-standard
+    sample rates, or unusual channel layouts. WAV uploads are used as-is.
+
+    Deletes the original source.mp3 after a successful transcode."""
+    if source.suffix.lower() != ".mp3":
+        return source
+
+    from app.core.config import ffmpeg_executable
+
+    dest = job_dir / "source.wav"
+    _set(job, stage="Preparing audio...")
+    cmd = [
+        ffmpeg_executable(),
+        "-nostdin",
+        "-loglevel",
+        "error",
+        "-i",
+        str(source),
+        "-ar",
+        "44100",
+        "-ac",
+        "2",
+        "-sample_fmt",
+        "s16",
+        "-y",
+        str(dest),
+    ]
+    result = subprocess.run(cmd, capture_output=True, timeout=300)
+    if result.returncode != 0:
+        raise RuntimeError(
+            "ffmpeg transcode failed: " + result.stderr.decode("utf-8", errors="replace").strip()
+        )
+    source.unlink(missing_ok=True)
+    return dest
+
+
+def _run_common(job: Job, source: Path, job_dir: Path) -> None:
+    """Analyze → separate → collect → mix. Shared by both YouTube and local
+    upload pipelines after their respective source acquisition steps."""
     _check_cancel(job)
     analyze(job, source)
     _check_cancel(job)
     stems_root = separate(job, source, job_dir)
     found = collect(job, stems_root, job_dir)
     stems_dir = job_dir / "stems"
-    # Source download (100-300 MB) is no longer used by anything below
-    # -- both the original-complement and the selected-mix are built
-    # from the demucs-emitted stems. Reclaim disk before the ffmpeg
-    # amix steps in case they need scratch space.
+    # Source (100-300 MB or the local upload) is no longer needed after
+    # collect; delete it before the ffmpeg amix steps in case scratch space
+    # is tight.
     cleanup_source(job_dir)
     job.stems = [{"name": name, "url": f"/api/jobs/{job.id}/stems/{name}.wav"} for name in found]
-    # Subset post-processing. When the user kept all 6 stems, both of
-    # these are skipped -- the original is the sum of the stems and a
-    # mix would equal the original. When a strict subset was chosen:
-    #   - original.wav: complement of the selection (sum of unselected
-    #     stems) so the studio can play it alongside the isolated
-    #     selected stems and reconstruct the full song without doubling.
-    #   - mix.wav: ffmpeg amix of the selected stems for download.
-    # Update stage so the import-progress UI doesn't keep saying
-    # "Separating stems..." for the extra ~5-30 s ffmpeg adds.
     _check_cancel(job)
     _set(job, stage="Mixing tracks...")
     original_path = make_original_track(job, job_dir, stems_dir)
@@ -72,11 +101,20 @@ def _run_blocking(job: Job, url: str, job_dir: Path) -> None:
     _check_cancel(job)
     mix_path = make_selected_mix(job, stems_dir, found)
     if mix_path is not None:
-        # mix_path may point at mix.wav (multi-stem amix) or directly at
-        # one of the existing stem WAVs (single-stem short-circuit).
-        # Either way, .name gives us the URL segment.
         job.mix_url = f"/api/jobs/{job.id}/stems/{mix_path.name}"
     _check_cancel(job)
+
+
+def _run_blocking(job: Job, url: str, job_dir: Path) -> None:
+    _check_cancel(job)
+    source = download(job, url, job_dir)
+    _run_common(job, source, job_dir)
+
+
+def _run_local_blocking(job: Job, source_path: Path, job_dir: Path) -> None:
+    _check_cancel(job)
+    source = _prepare_local_source(job, source_path, job_dir)
+    _run_common(job, source, job_dir)
 
 
 def _write_metadata(job: Job, job_dir: Path) -> None:
@@ -99,38 +137,62 @@ def _write_metadata(job: Job, job_dir: Path) -> None:
 
 async def run_pipeline(job: Job, url: str, jobs_dir: Path) -> None:
     job_dir = jobs_dir / job.id
-    # One try/except covers everything from directory creation through pipeline
-    # execution. If anything before the lock raises, the job would otherwise
-    # stay stuck on `queued` forever -- transition to `error` instead.
     try:
         job_dir.mkdir(parents=True, exist_ok=True)
         async with _pipeline_lock:
             await asyncio.to_thread(_run_blocking, job, url, job_dir)
-    except JobCancelled:
-        logger.info("pipeline cancelled for job %s", job.id)
+    except Exception as e:
+        if not isinstance(e, JobCancelled) and not job.cancel_requested:
+            logger.exception("pipeline failed for job %s: %s", job.id, e)
+            _set(
+                job,
+                status="error",
+                stage="Error: Processing failed",
+                error="Audio processing failed. Please try another video.",
+            )
+            persist_registry(jobs_dir)
+            return
+        logger.info(
+            "pipeline cancelled%s for job %s",
+            " (wrapped)" if not isinstance(e, JobCancelled) else "",
+            job.id,
+        )
         _set(job, status="cancelled", stage="Cancelled")
         persist_registry(jobs_dir)
-        # Drop partial files so the disk reclaim is immediate.
         _rmtree(job_dir)
         return
+    _set(job, status="done", progress=1.0, stage="Done")
+    _write_metadata(job, job_dir)
+    persist_registry(jobs_dir)
+
+
+async def run_local_pipeline(job: Job, source_path: Path, jobs_dir: Path) -> None:
+    """Run the stem-separation pipeline for a locally uploaded file.
+    The job directory and source file are already present on disk (created
+    by the API handler before this task is scheduled)."""
+    job_dir = jobs_dir / job.id
+    try:
+        async with _pipeline_lock:
+            await asyncio.to_thread(_run_local_blocking, job, source_path, job_dir)
     except Exception as e:
-        # yt-dlp wraps hook exceptions in DownloadError; if the user cancelled
-        # mid-download the underlying cause is JobCancelled but it arrives here
-        # as a generic exception. Detect via the flag and route to cancelled.
-        if job.cancel_requested:
-            logger.info("pipeline cancelled (wrapped) for job %s", job.id)
-            _set(job, status="cancelled", stage="Cancelled")
+        if not isinstance(e, JobCancelled) and not job.cancel_requested:
+            logger.exception("pipeline failed for job %s: %s", job.id, e)
+            _set(
+                job,
+                status="error",
+                stage="Error: Processing failed",
+                error="Audio processing failed. Please try again.",
+            )
             persist_registry(jobs_dir)
-            _rmtree(job_dir)
             return
-        logger.exception("pipeline failed for job %s: %s", job.id, e)
-        _set(
-            job,
-            status="error",
-            stage="Error: Processing failed",
-            error="Audio processing failed. Please try another video.",
+        logger.info(
+            "pipeline cancelled%s for job %s",
+            " (wrapped)" if not isinstance(e, JobCancelled) else "",
+            job.id,
         )
+        _set(job, status="cancelled", stage="Cancelled")
         persist_registry(jobs_dir)
+        _rmtree(job_dir)
         return
     _set(job, status="done", progress=1.0, stage="Done")
     _write_metadata(job, job_dir)

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stemdeck"
-version = "0.1.0-alpha.0"
+version = "0.3.0-alpha.1"
 description = "StemDeck desktop launcher"
 authors = ["StemDeck contributors"]
 edition = "2021"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ dependencies = [
     # post-analysis loudness card. Pure Python, depends on scipy which
     # librosa already pulls in.
     "pyloudnorm>=0.1.1",
+    # FastAPI multipart/form-data (file uploads) unconditionally require
+    # python-multipart — it is not an optional extra.
+    "python-multipart>=0.0.9",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stemdeck"
-version = "0.1.0"
+version = "0.3.0-alpha.1"
 description = "Paste a YouTube URL, get audio stems split into a DAW-style player."
 requires-python = ">=3.10"
 dependencies = [

--- a/static/js/catalog.js
+++ b/static/js/catalog.js
@@ -199,6 +199,7 @@ function stateMetadataToTrack(state, fallbackTrack) {
     keyConfidence: state.key_confidence ?? fallbackTrack.keyConfidence,
     lufs: state.lufs ?? fallbackTrack.lufs,
     peakDb: state.peak_db ?? fallbackTrack.peakDb,
+    sourceUrl: state.source_url || fallbackTrack.sourceUrl,
   };
 }
 
@@ -309,7 +310,11 @@ async function loadTrackIntoStudio(trackId) {
   setCurrentTrack(trackId);
 
   const urlInput = document.getElementById("url");
-  if (urlInput && track.sourceUrl) urlInput.value = track.sourceUrl;
+  if (urlInput && track.sourceUrl) {
+    urlInput.value = track.sourceUrl.startsWith("local:")
+      ? track.sourceUrl.slice(6)
+      : track.sourceUrl;
+  }
 
   applyTrackInfoToPanel(track);
   wireUpAudio(trackId, track.audioStems, track.duration || 0, track.thumb);

--- a/static/js/job.js
+++ b/static/js/job.js
@@ -305,6 +305,16 @@ async function cancelCurrentJob() {
   }
 }
 
+function sanitizeFilename(name) {
+  // Strip extension, collapse whitespace, cap at 120 chars — mirrors the
+  // backend _sanitize_title() so title and sourceUrl match on both sides.
+  return name
+    .replace(/\.[^.]+$/, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 120);
+}
+
 export function wireJobForm() {
   jobCancelBtn.addEventListener("click", cancelCurrentJob);
 
@@ -312,35 +322,63 @@ export function wireJobForm() {
     e.preventDefault();
     reset();
     setSubmitProcessing(true);
-    const postUrlText = document.getElementById("post-url-text");
-    if (postUrlText) postUrlText.textContent = urlInput.value;
 
-    let jobId;
-    try {
-      const res = await fetch("/api/jobs", {
+    const fileInput = document.getElementById("fileInput");
+    const file = fileInput?.files?.[0] ?? null;
+    const sanitized = file ? sanitizeFilename(file.name) : null;
+    const sourceUrl = file ? `local:${sanitized}` : urlInput.value;
+    const displayTitle = sanitized ?? (urlInput.value || "Processing track");
+
+    const postUrlText = document.getElementById("post-url-text");
+    if (postUrlText) postUrlText.textContent = displayTitle;
+
+    // Show progress box immediately for file uploads — the HTTP upload of a
+    // large file takes time and the UI would otherwise appear frozen.
+    if (file) {
+      jobBox.classList.remove("hidden");
+      jobCancelBtn.classList.add("hidden");
+      jobDetailEl.textContent = "Uploading…";
+      startPhraseRotation("queued");
+      lastStatus = "queued";
+    }
+
+    let fetchInit;
+    if (file) {
+      const fd = new FormData();
+      fd.append("file", file);
+      fd.append("stems", JSON.stringify([...selectedStems]));
+      fetchInit = { method: "POST", body: fd };
+    } else {
+      fetchInit = {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           url: urlInput.value,
           // Backend uses this to decide whether to ffmpeg-amix a
-          // "selected stems" track (mix.wav) at the end of the
-          // pipeline. Sent as an array of stem names.
+          // "selected stems" track (mix.wav) at the end of the pipeline.
           stems: [...selectedStems],
         }),
-      });
+      };
+    }
+
+    let jobId;
+    try {
+      const res = await fetch("/api/jobs", fetchInit);
       const data = await res.json();
       if (!res.ok) throw new Error(data.detail || res.statusText);
       jobId = data.job_id;
     } catch (err) {
+      if (file) jobBox.classList.add("hidden");
       showError(`Failed to start job: ${err.message}`);
       setSubmitProcessing(false);
       return;
     }
+
     setCurrentJobId(jobId);
-    jobSources.set(jobId, urlInput.value);
+    jobSources.set(jobId, sourceUrl);
     addTrackToLibrary({
       id: jobId,
-      title: urlInput.value || "Processing track",
+      title: displayTitle,
       channel: "Processing",
       thumb: "",
       stems: [...selectedStems],
@@ -353,14 +391,20 @@ export function wireJobForm() {
       keyConfidence: null,
       lufs: null,
       peakDb: null,
-      sourceUrl: urlInput.value,
+      sourceUrl,
     });
     setCurrentTrack(jobId);
 
-    jobBox.classList.add("hidden");
-    jobCancelBtn.classList.add("hidden");
-    startPhraseRotation("queued");
-    lastStatus = "queued";
+    if (!file) {
+      // YouTube path: keep progress box hidden until SSE events arrive.
+      jobBox.classList.add("hidden");
+      jobCancelBtn.classList.add("hidden");
+      startPhraseRotation("queued");
+      lastStatus = "queued";
+    } else {
+      // File path: clear the upload message — SSE will take over from here.
+      jobDetailEl.textContent = "";
+    }
 
     startJobPolling(jobId);
     connectEvents(jobId);

--- a/uv.lock
+++ b/uv.lock
@@ -1455,6 +1455,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.27"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1921,6 +1930,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "librosa" },
     { name = "pyloudnorm" },
+    { name = "python-multipart" },
     { name = "soundfile" },
     { name = "torch" },
     { name = "torchaudio" },
@@ -1945,6 +1955,7 @@ requires-dist = [
     { name = "pyloudnorm", specifier = ">=0.1.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
+    { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
     { name = "soundfile", specifier = ">=0.12" },
     { name = "torch", specifier = ">=2.6,<2.7" },


### PR DESCRIPTION
## Summary

- **Local file import** — users can now drag-and-drop or browse to upload a local `.mp3` or `.wav` file directly into the pipeline, without needing a YouTube URL. Files up to 100 MB are accepted; the selected stems and all downstream analysis (BPM, key, LUFS) work identically to the URL flow.
- **README overhaul** — reformatted with a centered header, badge row, enriched comparison table, and stronger legal framing up front.
- **Dependency**: added `python-multipart>=0.0.9` (required by FastAPI for multipart/form-data parsing).

## Changes

### Backend

**`app/api/jobs.py`**
- `create_job` now branches on `Content-Type`: JSON goes to the YouTube path (unchanged); `multipart/form-data` goes to the new local upload path.
- `_create_local_job()`: validates extension (`.mp3`/`.wav` only), enforces a 100 MB cap via Content-Length pre-check and post-buffer size check, copies the upload to `jobs/<id>/source.<ext>` via `asyncio.to_thread`, probes duration via `ffprobe` before registering the job.
- Helpers added: `_sanitize_title()`, `_probe_duration()`, `_check_file_size()`, `_copy_to_dest()`.

**`app/core/config.py`**
- Added `FFPROBE_BIN` constant and `ffprobe_executable()` — mirrors `ffmpeg_executable()` so the bundled Windows binary is preferred over PATH in portable mode.

**`app/pipeline/runner.py`**
- Refactored into `_run_common()` (shared analyze → separate → collect logic) called by both `_run_blocking()` (YouTube) and `_run_local_blocking()` (file upload).
- `_prepare_local_source()`: transcodes `.mp3` to `.wav` (16-bit, 44.1 kHz, stereo) before handing off to Demucs; `.wav` files pass through unchanged.
- `run_local_pipeline()`: async entry point with identical error/cancel/semaphore handling as `run_pipeline()`.

**`app/pipeline/__init__.py`**
- Exported `run_local_pipeline`.

**`pyproject.toml`**
- Added `python-multipart>=0.0.9`.

### Frontend

**`static/js/job.js`**
- Submit handler detects `fileInput.files[0]`; builds `FormData` for file uploads instead of JSON.
- Shows `jobBox` immediately during upload with "Uploading..." detail text; hides it on upload error.
- Sets `sourceUrl = local:<sanitized-filename>` for duplicate detection.
- `sanitizeFilename()` strips extension, collapses whitespace, caps at 120 chars — mirrors backend `_sanitize_title()`.
- YouTube path unchanged.

### Documentation

**`README.md`**
- Centered header with logo, title, tagline, and badge row (Stars, Downloads, Latest Release, License, CI, Platform, Demucs model).
- Section emojis removed.
- Em dashes replaced throughout.
- Enriched "Honest Comparison" table: added Internet required, Data retention, Stem count, Input formats, Processing speed, Batch processing, Mobile app rows.
- Intro updated to lead with local file import; opening blockquote frames StemDeck as a stem separator rather than a downloader.
- Disclaimer expanded: covers tool nature (separator, not downloader), YouTube ToS, dependency licenses (yt-dlp, Demucs, FFmpeg, PyTorch), and no-warranty language.
- Legal framing added at the top: states no content is stored, cached, or redistributed by the tool itself.

## Test plan

- [ ] Submit a `.wav` file — stems appear, BPM/key/LUFS surface in now-playing card
- [ ] Submit a `.mp3` file — same as above
- [ ] Submit a file larger than 100 MB — rejected with a clear error before processing starts
- [ ] Submit an unsupported extension (`.flac`, `.ogg`) — rejected with a clear error
- [ ] Submit a YouTube URL — existing behavior unchanged
- [ ] Cancel a mid-upload job — job cleans up and returns to ready state
- [ ] CI passes (ruff lint/format, pytest, bandit, pip-audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)