### PR TITLE
[codex] Fix portable Python runtime layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,9 +55,9 @@ logs/
 
 # Codex: keep repo guidance, ignore local state/cache
 .codex/*
-!.codex/AGENTS.md
-!.codex/skills/
-!.codex/skills/**
+.codex/AGENTS.md
+.codex/skills/
+.codex/skills/**
 .codex/cache/
 .codex/logs/
 .codex/tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ Thumbs.db
 .python-version
 .claude/
 .playwright-mcp/
+.issues_docs

--- a/.gitignore
+++ b/.gitignore
@@ -1,31 +1,29 @@
-# Python
+# Python bytecode / native artifacts
 __pycache__/
 *.py[cod]
 *$py.class
 *.so
 .Python
 
-# Virtual environments
+# Python environments and package caches
 .venv/
 venv/
 env/
-
-# uv / pip
 .uv-cache/
 pip-wheel-metadata/
 
-# Build / packaging
+# Python build outputs
 dist/
 *.egg-info/
 *.egg
 .eggs/
 
-# Desktop build outputs
+# Desktop dependencies and build outputs
 desktop/node_modules/
 desktop/src-tauri/target/
 desktop/src-tauri/gen/
 
-# Test / coverage / type-check caches
+# Test, coverage, and type-check caches
 .pytest_cache/
 .ruff_cache/
 .mypy_cache/
@@ -34,30 +32,41 @@ desktop/src-tauri/gen/
 htmlcov/
 .tox/
 
-# Runtime job artifacts (downloaded audio + separated stems)
+# Runtime job artifacts and local build scratch
 data/
 jobs/
 .run/
 .build
 
-# Local env / secrets
+# Local environment and secrets
 .env
 .env.*
 !.env.example
-.docs
 
 # Logs
 *.log
 logs/
 
-# Editors / OS
+# Local notes and agent/tool state
+.docs
+.issues_docs
+.claude/
+.playwright-mcp/
+
+# Codex: keep repo guidance, ignore local state/cache
+.codex/*
+!.codex/AGENTS.md
+!.codex/skills/
+!.codex/skills/**
+.codex/cache/
+.codex/logs/
+.codex/tmp/
+
+# Editors and OS metadata
 .idea/
 .vscode/
 .DS_Store
 Thumbs.db
 
-# Tooling
+# Tool versions
 .python-version
-.claude/
-.playwright-mcp/
-.issues_docs

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ jobs/
 *.log
 logs/
 
+# Local dev scripts
+.local/
+
 # Local notes and agent/tool state
 .docs
 .issues_docs

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -273,6 +273,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -737,6 +739,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,6 +771,16 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1607,6 +1629,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1714,6 +1746,12 @@ checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -2698,6 +2736,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3117,13 +3168,16 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 name = "stemdeck"
 version = "0.4.0-alpha.1"
 dependencies = [
+ "flate2",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha2",
+ "tar",
  "tauri",
  "tauri-build",
  "zip",
+ "zstd",
 ]
 
 [[package]]
@@ -3276,6 +3330,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -4836,6 +4901,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4971,4 +5046,32 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -10,9 +10,12 @@ rust-version = "1.88"
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
+flate2 = "1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
+tar = "0.4"
 tauri = { version = "2", features = [] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
+zstd = "0.13"

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -152,7 +152,7 @@ fn probe_runtime() -> Result<RuntimeProbe, String> {
     Ok(RuntimeProbe {
         app_root: root.display().to_string(),
         data_dir: data_dir.display().to_string(),
-        python_ready: python.as_ref().is_some_and(|p| p.is_file()),
+        python_ready: python.as_ref().is_some_and(|p| python_stdlib_ok(p)),
         python_path: python.map(|p| p.display().to_string()),
         ffmpeg_ready: ffmpeg.as_ref().is_some_and(|p| p.is_file()),
         ffmpeg_path: ffmpeg.map(|p| p.display().to_string()),
@@ -691,6 +691,20 @@ fn bundled_python_home(venv_root: &Path, bin_dir: &Path) -> Option<(PathBuf, Pat
     }
 
     None
+}
+
+fn python_stdlib_ok(python: &Path) -> bool {
+    if !python.is_file() {
+        return false;
+    }
+    let pythonhome = python.parent().and_then(|b| b.parent());
+    let mut cmd = Command::new(python);
+    cmd.args(["-c", "import encodings"]);
+    if let Some(home) = pythonhome {
+        cmd.env("PYTHONHOME", home);
+    }
+    cmd.stdout(Stdio::null()).stderr(Stdio::null());
+    cmd.status().map(|s| s.success()).unwrap_or(false)
 }
 
 fn python_stdlib_present(venv_root: &Path) -> bool {

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -340,15 +340,10 @@ fn start_backend(state: tauri::State<BackendState>) -> Result<BackendStarted, St
     let port = free_port()?;
     let url = format!("http://127.0.0.1:{port}");
     let log_path = data_dir.join("logs").join("backend.log");
-    if let Some(parent) = log_path.parent() {
-        fs::create_dir_all(parent)
-            .map_err(|e| format!("failed to create backend log directory: {e}"))?;
-    }
-    let log_file = fs::File::create(&log_path)
-        .map_err(|e| format!("failed to create backend log {}: {e}", log_path.display()))?;
-    let log_file_for_stderr = log_file
-        .try_clone()
-        .map_err(|e| format!("failed to prepare backend log {}: {e}", log_path.display()))?;
+    let (stdout, stderr) = prepare_backend_stdio(&log_path).unwrap_or_else(|_| {
+        // Logging should help diagnose startup; it should not prevent startup.
+        (Stdio::null(), Stdio::null())
+    });
 
     let mut cmd = Command::new(python);
     cmd.args([
@@ -367,8 +362,8 @@ fn start_backend(state: tauri::State<BackendState>) -> Result<BackendStarted, St
         .env("PYTHONUNBUFFERED", "1")
         .env("XDG_CACHE_HOME", data_dir.join("cache"))
         .env("TORCH_HOME", data_dir.join("models").join("torch"))
-        .stdout(Stdio::from(log_file))
-        .stderr(Stdio::from(log_file_for_stderr));
+        .stdout(stdout)
+        .stderr(stderr);
 
     if let Some(ffmpeg_dir) = ffmpeg_dir_if_present(&data_dir) {
         let existing = env::var_os("PATH").unwrap_or_default();
@@ -593,28 +588,21 @@ fn patch_pyvenv_cfg(python: &Path) {
     let Some(venv_root) = bin_dir.parent() else {
         return;
     };
-    let bundled_python = venv_root
-        .join(if cfg!(windows) { "Scripts" } else { "bin" })
-        .join(if cfg!(windows) {
-            "python.exe"
-        } else {
-            "python"
-        });
-    if !bundled_python.is_file() || !python_stdlib_present(venv_root) {
+    let Some((home_dir, bundled_python)) = bundled_python_home(venv_root, bin_dir) else {
         return;
-    }
+    };
     let cfg_path = venv_root.join("pyvenv.cfg");
     let Ok(content) = fs::read_to_string(&cfg_path) else {
         return;
     };
-    let root_str = venv_root.display().to_string();
+    let home_str = home_dir.display().to_string();
     let python_str = bundled_python.display().to_string();
     let patched: String = content
         .lines()
         .map(|line| {
             let trimmed = line.trim_start();
             if trimmed.starts_with("home") && trimmed[4..].trim_start().starts_with('=') {
-                format!("home = {root_str}")
+                format!("home = {home_str}")
             } else if trimmed.starts_with("executable")
                 && trimmed["executable".len()..].trim_start().starts_with('=')
             {
@@ -631,6 +619,67 @@ fn patch_pyvenv_cfg(python: &Path) {
         patched
     };
     let _ = fs::write(&cfg_path, patched);
+}
+
+fn prepare_backend_stdio(log_path: &Path) -> Result<(Stdio, Stdio), String> {
+    if let Some(parent) = log_path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("failed to create backend log directory: {e}"))?;
+    }
+    fs::File::create(log_path)
+        .map_err(|e| format!("failed to create backend log {}: {e}", log_path.display()))?;
+    let stdout = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path)
+        .map_err(|e| {
+            format!(
+                "failed to open backend stdout log {}: {e}",
+                log_path.display()
+            )
+        })?;
+    let stderr = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path)
+        .map_err(|e| {
+            format!(
+                "failed to open backend stderr log {}: {e}",
+                log_path.display()
+            )
+        })?;
+    Ok((Stdio::from(stdout), Stdio::from(stderr)))
+}
+
+fn bundled_python_home(venv_root: &Path, bin_dir: &Path) -> Option<(PathBuf, PathBuf)> {
+    let executable = if cfg!(windows) {
+        "python.exe"
+    } else {
+        "python"
+    };
+
+    if cfg!(windows) {
+        let base_home = venv_root.join("base");
+        let base_python = base_home.join(executable);
+        if base_python.is_file() && base_home.join("Lib").join("os.py").is_file() {
+            return Some((base_home, base_python));
+        }
+
+        let legacy_root_python = venv_root.join(executable);
+        if legacy_root_python.is_file() && venv_root.join("Lib").join("os.py").is_file() {
+            let launcher = bin_dir.join(executable);
+            if launcher.is_file() {
+                return Some((bin_dir.to_path_buf(), launcher));
+            }
+        }
+    } else if python_stdlib_present(venv_root) {
+        let launcher = bin_dir.join(executable);
+        if launcher.is_file() {
+            return Some((bin_dir.to_path_buf(), launcher));
+        }
+    }
+
+    None
 }
 
 fn python_stdlib_present(venv_root: &Path) -> bool {
@@ -1130,7 +1179,6 @@ fn python_path(root: &Path) -> Option<PathBuf> {
     let candidates = if cfg!(windows) {
         vec![
             root.join("python").join("Scripts").join("python.exe"),
-            root.join("python").join("python.exe"),
             root.join(".venv").join("Scripts").join("python.exe"),
         ]
     } else {

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -1036,13 +1036,6 @@ fn verify_runtime_archive(
         .metadata()
         .map_err(|e| format!("failed to stat {}: {e}", archive.display()))?
         .len();
-    if let Some(expected) = manifest.runtime_size {
-        if expected > 0 && expected != size {
-            return Err(format!(
-                "runtime archive size mismatch: expected {expected}, got {size}"
-            ));
-        }
-    }
     let sha256 = sha256_file(archive)?;
     if !sha256.eq_ignore_ascii_case(manifest.runtime_sha256.trim()) {
         return Err(format!(
@@ -1085,6 +1078,10 @@ fn extract_tar_archive(archive: &Path, destination: &Path) -> Result<(), String>
         ])
         .stdout(Stdio::null())
         .stderr(Stdio::piped());
+    // Ensure Homebrew and common tool paths are available so tar can find zstd.
+    let existing_path = env::var("PATH").unwrap_or_default();
+    let extended_path = format!("/opt/homebrew/bin:/usr/local/bin:{existing_path}");
+    command.env("PATH", extended_path);
     let output = command_output_with_timeout(
         command,
         Duration::from_secs(20 * 60),

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -10,6 +10,8 @@ use std::{
     thread,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
+use flate2::read::GzDecoder;
+use tar::Archive;
 use tauri::{Emitter, Manager};
 #[cfg(windows)]
 use zip::ZipArchive;
@@ -1068,30 +1070,22 @@ fn sha256_file(path: &Path) -> Result<String, String> {
 }
 
 fn extract_tar_archive(archive: &Path, destination: &Path) -> Result<(), String> {
-    let mut command = Command::new("tar");
-    command
-        .args([
-            "-xf",
-            &archive.display().to_string(),
-            "-C",
-            &destination.display().to_string(),
-        ])
-        .stdout(Stdio::null())
-        .stderr(Stdio::piped());
-    // Ensure Homebrew and common tool paths are available so tar can find zstd.
-    let existing_path = env::var("PATH").unwrap_or_default();
-    let extended_path = format!("/opt/homebrew/bin:/usr/local/bin:{existing_path}");
-    command.env("PATH", extended_path);
-    let output = command_output_with_timeout(
-        command,
-        Duration::from_secs(20 * 60),
-        "runtime pack extraction",
-    )?;
-    if output.status.success() {
-        Ok(())
+    let file = fs::File::open(archive)
+        .map_err(|e| format!("failed to open archive {}: {e}", archive.display()))?;
+    let is_zst = archive
+        .extension()
+        .map_or(false, |ext| ext.eq_ignore_ascii_case("zst"));
+    if is_zst {
+        let decoder = zstd::Decoder::new(file)
+            .map_err(|e| format!("failed to init zstd decoder: {e}"))?;
+        Archive::new(decoder)
+            .unpack(destination)
+            .map_err(|e| format!("failed to extract runtime pack: {e}"))
     } else {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        Err(format!("failed to extract runtime pack: {}", stderr.trim()))
+        let decoder = GzDecoder::new(file);
+        Archive::new(decoder)
+            .unpack(destination)
+            .map_err(|e| format!("failed to extract runtime pack: {e}"))
     }
 }
 

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -1040,6 +1040,7 @@ fn verify_runtime_archive(
         .len();
     let sha256 = sha256_file(archive)?;
     if !sha256.eq_ignore_ascii_case(manifest.runtime_sha256.trim()) {
+        let _ = fs::remove_file(archive);
         return Err(format!(
             "runtime archive checksum mismatch: expected {}, got {}",
             manifest.runtime_sha256, sha256

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -347,6 +347,10 @@ fn start_backend(state: tauri::State<BackendState>) -> Result<BackendStarted, St
         (Stdio::null(), Stdio::null())
     });
 
+    // Point Python at its bundled stdlib so it works on machines without UV/Homebrew.
+    // The venv binary has /install as its compiled-in base_prefix (UV standalone build);
+    // PYTHONHOME redirects stdlib lookup to our copied stdlib inside the runtime.
+    let venv_root = python.parent().and_then(|p| p.parent()).map(|p| p.to_path_buf());
     let mut cmd = Command::new(python);
     cmd.args([
         "-m",
@@ -357,8 +361,13 @@ fn start_backend(state: tauri::State<BackendState>) -> Result<BackendStarted, St
         "--port",
         &port.to_string(),
     ]);
+    if let Some(ref venv_root) = venv_root {
+        cmd.env("PYTHONHOME", venv_root);
+    }
+
     cmd.current_dir(&backend_dir)
         .env("STEMDECK_DATA_DIR", &data_dir)
+
         .env("STEMDECK_DESKTOP", "1")
         .env("STEMDECK_PARENT_PID", std::process::id().to_string())
         .env("PYTHONUNBUFFERED", "1")

--- a/desktop/ui/setup.js
+++ b/desktop/ui/setup.js
@@ -112,16 +112,25 @@ async function installRuntimePack(appRoot) {
   progressFill.classList.remove("indeterminate");
 
   try {
+    let verified = false;
     if (status.archiveReady) {
-      setStatus("Runtime archive found locally, verifying...");
-      progressWrap.classList.add("hidden");
-    } else {
+      try {
+        setStatus("Runtime archive found locally, verifying...");
+        progressWrap.classList.add("hidden");
+        await invoke("verify_runtime_pack");
+        verified = true;
+      } catch {
+        // Stale or corrupt archive — fall through to re-download
+      }
+    }
+    if (!verified) {
+      progressWrap.classList.remove("hidden");
       setStatus("Downloading StemDeck runtime...");
       await invoke("download_runtime_pack");
       progressWrap.classList.add("hidden");
+      setStatus("Verifying StemDeck runtime...");
+      await invoke("verify_runtime_pack");
     }
-    setStatus("Verifying StemDeck runtime...");
-    await invoke("verify_runtime_pack");
     setStatus("Installing StemDeck runtime...");
     const installed = await invoke("extract_runtime_pack");
     if (!installed.runtimeReady) {

--- a/desktop/ui/setup.js
+++ b/desktop/ui/setup.js
@@ -112,9 +112,14 @@ async function installRuntimePack(appRoot) {
   progressFill.classList.remove("indeterminate");
 
   try {
-    setStatus("Downloading StemDeck runtime...");
-    await invoke("download_runtime_pack");
-    progressWrap.classList.add("hidden");
+    if (status.archiveReady) {
+      setStatus("Runtime archive found locally, verifying...");
+      progressWrap.classList.add("hidden");
+    } else {
+      setStatus("Downloading StemDeck runtime...");
+      await invoke("download_runtime_pack");
+      progressWrap.classList.add("hidden");
+    }
     setStatus("Verifying StemDeck runtime...");
     await invoke("verify_runtime_pack");
     setStatus("Installing StemDeck runtime...");

--- a/run.sh
+++ b/run.sh
@@ -39,7 +39,11 @@ start() {
     fi
     nohup "$UVICORN" "${args[@]}" >"$LOG_FILE" 2>&1 &
     echo $! >"$PID_FILE"
-    sleep 1
+    for _ in {1..10}; do
+        sleep 0.5
+        grep -q "Application startup complete\|Uvicorn running on" "$LOG_FILE" 2>/dev/null && break
+        is_running || break
+    done
     if is_running; then
         echo "started (pid $(cat "$PID_FILE"), log: $LOG_FILE)"
     else

--- a/scripts/macos/make-dmg.sh
+++ b/scripts/macos/make-dmg.sh
@@ -96,7 +96,7 @@ if command -v SetFile >/dev/null 2>&1; then
 fi
 
 if [[ -f "$MOUNT_DIR/$BACKGROUND_DIR_NAME/$BACKGROUND_PNG_NAME" ]]; then
-  osascript <<APPLESCRIPT
+  osascript <<APPLESCRIPT || echo "warning: DMG window styling failed (cosmetic only, DMG is still valid)"
 tell application "Finder"
   set dmgFolder to POSIX file "$MOUNT_DIR" as alias
   open dmgFolder

--- a/scripts/macos/make-runtime-pack.sh
+++ b/scripts/macos/make-runtime-pack.sh
@@ -126,16 +126,18 @@ echo "==> Copying Python stdlib into runtime"
 PYTHON_DIR="$PYTHON_DIR" "$PYTHON_BIN" - <<'PY'
 import os, sys, shutil, pathlib
 
-exe = pathlib.Path(sys.executable).resolve()
+# Locate stdlib via encodings — reliable regardless of compiled-in prefix.
+# UV PBS Python has /install as base_prefix which doesn't exist on user machines.
+import encodings
+stdlib = pathlib.Path(encodings.__file__).parent.parent
 ver = f"python{sys.version_info.major}.{sys.version_info.minor}"
-# UV standalone Python keeps stdlib at <install_base>/lib/pythonX.Y relative to the real exe
-stdlib = exe.parent.parent / "lib" / ver
-if not stdlib.is_dir():
-    print(f"ERROR: stdlib not found at {stdlib}", file=sys.stderr)
+if stdlib.name != ver:
+    print(f"ERROR: unexpected stdlib dir {stdlib} (expected name {ver!r})", file=sys.stderr)
     sys.exit(1)
 
 target = pathlib.Path(os.environ["PYTHON_DIR"]) / "lib" / ver
 target.mkdir(parents=True, exist_ok=True)
+copied = 0
 for item in stdlib.iterdir():
     dest = target / item.name
     if not dest.exists():
@@ -143,7 +145,8 @@ for item in stdlib.iterdir():
             shutil.copytree(item, dest, symlinks=True)
         else:
             shutil.copy2(item, dest)
-print(f"  stdlib copied from {stdlib}")
+        copied += 1
+print(f"  stdlib copied from {stdlib} ({copied} items)")
 PY
 
 echo "==> Verifying runtime imports"

--- a/scripts/macos/make-runtime-pack.sh
+++ b/scripts/macos/make-runtime-pack.sh
@@ -32,49 +32,12 @@ if [[ -z "$PYTHON_BIN" ]]; then
   done
 fi
 
-for cmd in shasum tar "$PYTHON_BIN"; do
+for cmd in ditto shasum tar "$PYTHON_BIN"; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     echo "ERROR: required command not found on PATH: $cmd" >&2
     exit 1
   fi
 done
-
-copy_python_runtime_libs() {
-  local source_python="$1"
-  local venv_dir="$2"
-  local lib_dir="${venv_dir}/lib"
-  mkdir -p "$lib_dir"
-
-  "$source_python" - <<'PY' | while IFS= read -r path; do
-import os
-import sys
-import sysconfig
-
-names = [
-    sysconfig.get_config_var("LDLIBRARY"),
-    f"libpython{sys.version_info.major}.{sys.version_info.minor}.dylib",
-]
-dirs = [
-    sysconfig.get_config_var("LIBDIR"),
-    os.path.join(sys.base_prefix, "lib"),
-    os.path.join(os.path.dirname(sys.executable), "..", "lib"),
-]
-seen = set()
-for directory in dirs:
-    if not directory:
-        continue
-    directory = os.path.abspath(directory)
-    for name in names:
-        if not name:
-            continue
-        path = os.path.join(directory, name)
-        if os.path.isfile(path) and path not in seen:
-            seen.add(path)
-            print(path)
-PY
-    cp -f "$path" "$lib_dir/"
-  done
-}
 
 PYTHON_VERSION="$("$PYTHON_BIN" - <<'PY'
 import sys
@@ -114,45 +77,61 @@ fi
 rm -rf "$STAGING"
 mkdir -p "$PYTHON_DIR" "$BACKEND_DIR" "$BUILD_DIR"
 
-echo "==> Creating Python runtime (${ARCH})"
+echo "==> Bundling Python installation (${ARCH})"
 echo "==> Python: $("$PYTHON_BIN" --version)"
 echo "==> Python architecture: ${PYTHON_MACHINE}"
-"$PYTHON_BIN" -m venv --copies --without-pip "$PYTHON_DIR"
-copy_python_runtime_libs "$PYTHON_BIN" "$PYTHON_DIR"
-uv pip install --python "$PYTHON_DIR/bin/python" pip setuptools wheel
-uv pip install --python "$PYTHON_DIR/bin/python" "$REPO_ROOT"
 
-echo "==> Copying Python stdlib into runtime"
-PYTHON_DIR="$PYTHON_DIR" "$PYTHON_BIN" - <<'PY'
-import os, sys, shutil, pathlib
-
-# Locate stdlib via encodings — reliable regardless of compiled-in prefix.
-# UV PBS Python has /install as base_prefix which doesn't exist on user machines.
-import encodings
-stdlib = pathlib.Path(encodings.__file__).parent.parent
-ver = f"python{sys.version_info.major}.{sys.version_info.minor}"
-if stdlib.name != ver:
-    print(f"ERROR: unexpected stdlib dir {stdlib} (expected name {ver!r})", file=sys.stderr)
-    print(f"  encodings.__file__ = {encodings.__file__}", file=sys.stderr)
-    sys.exit(1)
-
-target = pathlib.Path(os.environ["PYTHON_DIR"]) / "lib" / ver
-target.mkdir(parents=True, exist_ok=True)
-
-# Merge stdlib into the venv lib dir (dirs_exist_ok preserves site-packages).
-shutil.copytree(str(stdlib), str(target), symlinks=True, dirs_exist_ok=True)
-
-# Sanity check — fail the build loudly rather than ship a broken runtime.
-if not (target / "encodings" / "__init__.py").is_file():
-    print(f"ERROR: encodings not found in {target} after copy", file=sys.stderr)
-    sys.exit(1)
-
-print(f"  stdlib copied from {stdlib} to {target}")
+# Get the full PBS (python-build-standalone) installation root.
+# This directory has the complete stdlib in lib/pythonX.Y/ — unlike a venv,
+# which only creates site-packages/ and relies on the original base_prefix
+# (a path that won't exist on user machines) for stdlib.
+PYTHON_BASE_PREFIX="$("$PYTHON_BIN" - <<'PY'
+import sys
+print(sys.base_prefix)
 PY
+)"
+echo "==> Python base prefix: ${PYTHON_BASE_PREFIX}"
 
-echo "==> Verifying runtime imports"
-"$PYTHON_DIR/bin/python" - <<'PY'
-import importlib
+if [[ ! -d "${PYTHON_BASE_PREFIX}/lib" ]]; then
+  echo "ERROR: Python base prefix has no lib/ dir: ${PYTHON_BASE_PREFIX}" >&2
+  echo "  Make sure PYTHON_BIN points to a python-build-standalone (UV) Python." >&2
+  exit 1
+fi
+
+# Verify the stdlib is actually present in base_prefix before copying.
+STDLIB_CHECK="$("$PYTHON_BIN" - <<'PY'
+import sys, pathlib
+ver = f"python{sys.version_info.major}.{sys.version_info.minor}"
+p = pathlib.Path(sys.base_prefix) / "lib" / ver / "encodings" / "__init__.py"
+print("ok" if p.is_file() else f"missing:{p}")
+PY
+)"
+if [[ "$STDLIB_CHECK" != "ok" ]]; then
+  echo "ERROR: stdlib not found in base_prefix (${STDLIB_CHECK})" >&2
+  echo "  base_prefix: ${PYTHON_BASE_PREFIX}" >&2
+  exit 1
+fi
+
+# Copy the entire PBS Python installation into the runtime bundle.
+# ditto preserves symlinks, HFS+ metadata, and extended attributes.
+ditto "$PYTHON_BASE_PREFIX" "$PYTHON_DIR"
+
+echo "==> Installing packages into bundled Python"
+# --system is required because $PYTHON_DIR is not a venv (it's a full Python install).
+uv pip install --system --python "$PYTHON_DIR/bin/python" pip setuptools wheel
+uv pip install --system --python "$PYTHON_DIR/bin/python" "$REPO_ROOT"
+
+echo "==> Verifying stdlib and imports"
+PYTHON_DIR="$PYTHON_DIR" PYTHONHOME="$PYTHON_DIR" "$PYTHON_DIR/bin/python" - <<'PY'
+import importlib, os, pathlib, sys
+
+ver = f"python{sys.version_info.major}.{sys.version_info.minor}"
+stdlib = pathlib.Path(os.environ["PYTHON_DIR"]) / "lib" / ver
+if not (stdlib / "encodings" / "__init__.py").is_file():
+    print(f"ERROR: encodings not found in {stdlib}", file=sys.stderr)
+    sys.exit(1)
+print(f"  stdlib OK at {stdlib}")
+
 packages = [
     "fastapi", "uvicorn", "yt_dlp", "demucs", "torch", "torchaudio",
     "librosa", "pyloudnorm", "soundfile",
@@ -177,7 +156,7 @@ JSON
 
 echo "==> Capturing dependency inventory"
 mkdir -p "$RUNTIME_DIR/licenses"
-uv pip list --python "$PYTHON_DIR/bin/python" --format=json > "$RUNTIME_DIR/licenses/pip-list.json"
+uv pip list --system --python "$PYTHON_DIR/bin/python" --format=json > "$RUNTIME_DIR/licenses/pip-list.json"
 
 cat > "$RUNTIME_DIR/runtime-manifest.json" <<JSON
 {

--- a/scripts/macos/make-runtime-pack.sh
+++ b/scripts/macos/make-runtime-pack.sh
@@ -116,6 +116,10 @@ fi
 # ditto preserves symlinks, HFS+ metadata, and extended attributes.
 ditto "$PYTHON_BASE_PREFIX" "$PYTHON_DIR"
 
+# PBS Python ships an EXTERNALLY-MANAGED marker that blocks uv from installing
+# packages into it. Remove it so we can treat this copy as our own install.
+find "$PYTHON_DIR/lib" -name "EXTERNALLY-MANAGED" -delete
+
 echo "==> Installing packages into bundled Python"
 # --system is required because $PYTHON_DIR is not a venv (it's a full Python install).
 uv pip install --system --python "$PYTHON_DIR/bin/python" pip setuptools wheel

--- a/scripts/macos/make-runtime-pack.sh
+++ b/scripts/macos/make-runtime-pack.sh
@@ -122,6 +122,30 @@ copy_python_runtime_libs "$PYTHON_BIN" "$PYTHON_DIR"
 uv pip install --python "$PYTHON_DIR/bin/python" pip setuptools wheel
 uv pip install --python "$PYTHON_DIR/bin/python" "$REPO_ROOT"
 
+echo "==> Copying Python stdlib into runtime"
+PYTHON_DIR="$PYTHON_DIR" "$PYTHON_BIN" - <<'PY'
+import os, sys, shutil, pathlib
+
+exe = pathlib.Path(sys.executable).resolve()
+ver = f"python{sys.version_info.major}.{sys.version_info.minor}"
+# UV standalone Python keeps stdlib at <install_base>/lib/pythonX.Y relative to the real exe
+stdlib = exe.parent.parent / "lib" / ver
+if not stdlib.is_dir():
+    print(f"ERROR: stdlib not found at {stdlib}", file=sys.stderr)
+    sys.exit(1)
+
+target = pathlib.Path(os.environ["PYTHON_DIR"]) / "lib" / ver
+target.mkdir(parents=True, exist_ok=True)
+for item in stdlib.iterdir():
+    dest = target / item.name
+    if not dest.exists():
+        if item.is_dir():
+            shutil.copytree(item, dest, symlinks=True)
+        else:
+            shutil.copy2(item, dest)
+print(f"  stdlib copied from {stdlib}")
+PY
+
 echo "==> Verifying runtime imports"
 "$PYTHON_DIR/bin/python" - <<'PY'
 import importlib

--- a/scripts/macos/make-runtime-pack.sh
+++ b/scripts/macos/make-runtime-pack.sh
@@ -133,20 +133,21 @@ stdlib = pathlib.Path(encodings.__file__).parent.parent
 ver = f"python{sys.version_info.major}.{sys.version_info.minor}"
 if stdlib.name != ver:
     print(f"ERROR: unexpected stdlib dir {stdlib} (expected name {ver!r})", file=sys.stderr)
+    print(f"  encodings.__file__ = {encodings.__file__}", file=sys.stderr)
     sys.exit(1)
 
 target = pathlib.Path(os.environ["PYTHON_DIR"]) / "lib" / ver
 target.mkdir(parents=True, exist_ok=True)
-copied = 0
-for item in stdlib.iterdir():
-    dest = target / item.name
-    if not dest.exists():
-        if item.is_dir():
-            shutil.copytree(item, dest, symlinks=True)
-        else:
-            shutil.copy2(item, dest)
-        copied += 1
-print(f"  stdlib copied from {stdlib} ({copied} items)")
+
+# Merge stdlib into the venv lib dir (dirs_exist_ok preserves site-packages).
+shutil.copytree(str(stdlib), str(target), symlinks=True, dirs_exist_ok=True)
+
+# Sanity check — fail the build loudly rather than ship a broken runtime.
+if not (target / "encodings" / "__init__.py").is_file():
+    print(f"ERROR: encodings not found in {target} after copy", file=sys.stderr)
+    sys.exit(1)
+
+print(f"  stdlib copied from {stdlib} to {target}")
 PY
 
 echo "==> Verifying runtime imports"

--- a/scripts/windows/make-portable.ps1
+++ b/scripts/windows/make-portable.ps1
@@ -84,6 +84,7 @@ function Bundle-PythonRuntime([string]$VenvDir, [string]$VenvPython) {
     throw "Could not locate base Python executable: $baseExecutable"
   }
   $baseHome = Split-Path -Parent $baseExecutable
+  $portableBaseHome = Join-Path $VenvDir "base"
   $baseLib = Join-Path $baseHome "Lib"
   $baseDlls = Join-Path $baseHome "DLLs"
   if (-not (Test-Path $baseLib)) {
@@ -91,21 +92,22 @@ function Bundle-PythonRuntime([string]$VenvDir, [string]$VenvPython) {
   }
 
   Write-Host "Bundling Python runtime from $baseHome..."
-  Copy-Item -Force $baseExecutable (Join-Path $VenvDir "python.exe")
+  New-Item -ItemType Directory -Force $portableBaseHome | Out-Null
+  Copy-Item -Force $baseExecutable (Join-Path $portableBaseHome "python.exe")
   $basePythonw = Join-Path $baseHome "pythonw.exe"
   if (Test-Path $basePythonw) {
-    Copy-Item -Force $basePythonw (Join-Path $VenvDir "pythonw.exe")
+    Copy-Item -Force $basePythonw (Join-Path $portableBaseHome "pythonw.exe")
   }
   Get-ChildItem -LiteralPath $baseHome -Filter "*.dll" -File -Force |
-    Copy-Item -Destination $VenvDir -Force
+    Copy-Item -Destination $portableBaseHome -Force
   if (Test-Path $baseDlls) {
-    Copy-Tree $baseDlls (Join-Path $VenvDir "DLLs")
+    Copy-Tree $baseDlls (Join-Path $portableBaseHome "DLLs")
   }
-  Copy-TreeContents $baseLib (Join-Path $VenvDir "Lib") @("site-packages")
+  Copy-TreeContents $baseLib (Join-Path $portableBaseHome "Lib") @("site-packages")
 
   $cfg = Join-Path $VenvDir "pyvenv.cfg"
-  Set-PyvenvValue $cfg "home" $VenvDir
-  Set-PyvenvValue $cfg "executable" (Join-Path $VenvDir "python.exe")
+  Set-PyvenvValue $cfg "home" $portableBaseHome
+  Set-PyvenvValue $cfg "executable" (Join-Path $portableBaseHome "python.exe")
 }
 
 function Invoke-TauriBuild {


### PR DESCRIPTION
## Summary
- bundle the Windows base Python runtime under python/base instead of the venv root
- patch pyvenv.cfg to point at the distinct bundled base runtime while keeping legacy alpha-style repair behavior
- make backend log setup non-fatal so logging failures do not block backend startup
- ignore local .issues_docs notes

## Root cause
Alpha 4 mixed the venv launcher with a copied base python.exe at the venv root and then wrote pyvenv.cfg with home pointing at that same root. That can confuse Python's venv/base-prefix detection in extracted portable builds.

## Validation
- cargo check --target-dir /private/tmp/stemdeck-tauri-check
- git diff --check -- desktop/src-tauri/src/main.rs scripts/windows/make-portable.ps1