### PR TITLE
fix(papaya): improvement cycle — 11 backend and frontend fixes

### DIFF
--- a/app/api/config.py
+++ b/app/api/config.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app.core.config import STEM_NAMES
+
+router = APIRouter()
+
+
+@router.get("/config")
+def get_config() -> dict:
+    return {"stem_names": list(STEM_NAMES)}

--- a/app/api/router.py
+++ b/app/api/router.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
+from app.api.config import router as config_router
 from app.api.events import router as events_router
 from app.api.jobs import router as jobs_router
 from app.api.stems import router as stems_router
 
 router = APIRouter()
+router.include_router(config_router, tags=["config"])
 router.include_router(jobs_router, prefix="/jobs", tags=["jobs"])
 router.include_router(events_router, tags=["events"])
 router.include_router(stems_router, tags=["stems"])

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -71,6 +71,9 @@ DEMUCS_DEVICE = _detect_device()
 MAX_DURATION_SEC = max(60, _env_int("STEMDECK_MAX_DURATION_SEC", 1200))  # 20 min default
 JOB_TTL_SECONDS = max(300, _env_int("STEMDECK_JOB_TTL_SECONDS", 24 * 3600))  # 24 h default
 MAX_PENDING_JOBS = max(1, min(50, _env_int("STEMDECK_MAX_PENDING_JOBS", 3)))
+TIMEOUT_FFMPEG = _env_int("STEMDECK_TIMEOUT_FFMPEG", 300)
+TIMEOUT_ANALYZE = _env_int("STEMDECK_TIMEOUT_ANALYZE", 120)
+TIMEOUT_DEMUCS_STALL = _env_int("STEMDECK_TIMEOUT_DEMUCS_STALL", 1800)
 
 
 def ffmpeg_executable() -> str:

--- a/app/core/registry.py
+++ b/app/core/registry.py
@@ -11,6 +11,8 @@ from app.core.models import Job
 
 logger = logging.getLogger("stemdeck.registry")
 
+REGISTRY_VERSION = 1
+
 _jobs: dict[str, Job] = {}
 # Active subprocesses keyed by job_id (currently only Demucs). Lets
 # POST /cancel terminate the running process from the API thread instead
@@ -44,6 +46,18 @@ def all_jobs() -> dict[str, Job]:
         return dict(_jobs)
 
 
+def _migrate(data: dict) -> dict:
+    """Upgrade registry JSON to REGISTRY_VERSION incrementally.
+    Each block transforms v(n) → v(n+1) so older snapshots always catch up."""
+    version = data.get("version", 0)
+    if version < 1:
+        # v0 → v1: version field was absent; no structural change needed.
+        data["version"] = 1
+        version = 1
+    # Future migrations go here as `if version < N:` blocks.
+    return data
+
+
 def persist(jobs_dir: Path) -> None:
     """Persist terminal jobs so completed library entries survive restarts."""
     try:
@@ -59,7 +73,10 @@ def persist(jobs_dir: Path) -> None:
         ]
     path = jobs_dir / _REGISTRY_FILE
     tmp = path.with_suffix(".json.tmp")
-    tmp.write_text(json.dumps({"version": 1, "jobs": records}, indent=2) + "\n", encoding="utf-8")
+    tmp.write_text(
+        json.dumps({"version": REGISTRY_VERSION, "jobs": records}, indent=2) + "\n",
+        encoding="utf-8",
+    )
     tmp.replace(path)
 
 
@@ -69,7 +86,7 @@ def restore(jobs_dir: Path) -> None:
     path = jobs_dir / _REGISTRY_FILE
     if path.is_file():
         try:
-            data = json.loads(path.read_text(encoding="utf-8"))
+            data = _migrate(json.loads(path.read_text(encoding="utf-8")))
             to_add = {}
             for record in data.get("jobs", []):
                 job = Job.from_record(record)

--- a/app/pipeline/analyze.py
+++ b/app/pipeline/analyze.py
@@ -4,7 +4,7 @@ import logging
 import subprocess
 from pathlib import Path
 
-from app.core.config import JOBS_DIR, ffmpeg_executable
+from app.core.config import JOBS_DIR, TIMEOUT_ANALYZE, ffmpeg_executable
 from app.core.models import Job
 from app.pipeline.download import _set
 
@@ -205,7 +205,7 @@ def _load_audio_ffmpeg(
         "-",  # write to stdout
     ]
     try:
-        proc = subprocess.run(cmd, capture_output=True, check=True, timeout=120)
+        proc = subprocess.run(cmd, capture_output=True, check=True, timeout=TIMEOUT_ANALYZE)
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError) as e:
         logger.warning("ffmpeg decode failed for %s: %s", source, e)
         return None

--- a/app/pipeline/collect.py
+++ b/app/pipeline/collect.py
@@ -6,7 +6,13 @@ import subprocess
 import time
 from pathlib import Path
 
-from app.core.config import DEMUCS_MODEL, JOB_TTL_SECONDS, STEM_NAMES, ffmpeg_executable
+from app.core.config import (
+    DEMUCS_MODEL,
+    JOB_TTL_SECONDS,
+    STEM_NAMES,
+    TIMEOUT_FFMPEG,
+    ffmpeg_executable,
+)
 from app.core.models import Job
 from app.core.registry import all_jobs as registry_all
 from app.core.registry import persist as registry_persist
@@ -39,7 +45,7 @@ def _run_ffmpeg(job: Job, cmd: list[str]) -> bool:
     set_proc(job.id, proc)
     try:
         try:
-            _, stderr = proc.communicate(timeout=300)
+            _, stderr = proc.communicate(timeout=TIMEOUT_FFMPEG)
         except subprocess.TimeoutExpired:
             proc.kill()
             proc.communicate()

--- a/app/pipeline/download.py
+++ b/app/pipeline/download.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import logging
 import re
+import time
 import urllib.parse
 from pathlib import Path
 
@@ -8,6 +10,44 @@ from yt_dlp import YoutubeDL
 
 from app.core.config import MAX_DURATION_SEC
 from app.core.models import Job, JobCancelled
+
+logger = logging.getLogger("stemdeck.download")
+
+_MAX_RETRIES = 3
+_RETRY_BACKOFF = (2, 4, 8)  # seconds between attempts
+
+# Errors worth retrying — transient network blips.
+_RETRIABLE = (
+    "connection reset",
+    "ssl",
+    "timed out",
+    "network is unreachable",
+    "temporary failure",
+    "unable to download",
+    "read timed out",
+    "remotedisconnected",
+    "broken pipe",
+    "connection refused",
+)
+
+# Errors that will never succeed on retry — reject immediately.
+_NON_RETRIABLE = (
+    "private video",
+    "video unavailable",
+    "has been removed",
+    "http error 404",
+    "http error 403",
+    "not available in your country",
+    "age-restricted",
+)
+
+
+def _is_retriable(exc: Exception) -> bool:
+    msg = str(exc).lower()
+    if any(s in msg for s in _NON_RETRIABLE):
+        return False
+    return any(s in msg for s in _RETRIABLE)
+
 
 _VIDEO_ID_RE = re.compile(r"^[A-Za-z0-9_-]{11}$")
 _ALLOWED_HOSTS = frozenset(
@@ -106,6 +146,7 @@ def _set(job: Job, **fields: object) -> None:
 
 def download(job: Job, url: str, job_dir: Path) -> Path:
     url = normalize_youtube_url(url)
+    logger.info("[%s] download starting: %s", job.id, url)
     _set(job, status="downloading", progress=0.0, stage="Processing...")
 
     # Fetch metadata first (no download) so we can reject videos that are
@@ -141,8 +182,29 @@ def download(job: Job, url: str, job_dir: Path) -> Path:
         "noplaylist": True,
         "progress_hooks": [hook],
     }
-    with YoutubeDL(ydl_opts) as ydl:
-        info = ydl.extract_info(url, download=True) or {}
+    info: dict = {}
+    for attempt in range(_MAX_RETRIES + 1):
+        try:
+            with YoutubeDL(ydl_opts) as ydl:
+                info = ydl.extract_info(url, download=True) or {}
+            break
+        except Exception as exc:
+            if job.cancel_requested:
+                raise JobCancelled() from exc
+            if attempt < _MAX_RETRIES and _is_retriable(exc):
+                wait = _RETRY_BACKOFF[attempt]
+                logger.warning(
+                    "[%s] download attempt %d/%d failed (%s), retrying in %ds",
+                    job.id,
+                    attempt + 1,
+                    _MAX_RETRIES,
+                    exc,
+                    wait,
+                )
+                _set(job, stage=f"Network error — retrying ({attempt + 1}/{_MAX_RETRIES})...")
+                time.sleep(wait)
+            else:
+                raise
 
     _set(
         job,
@@ -154,4 +216,5 @@ def download(job: Job, url: str, job_dir: Path) -> Path:
     candidates = sorted(job_dir.glob("source.*"))
     if not candidates:
         raise RuntimeError("yt-dlp finished but no source file was produced")
+    logger.info("[%s] download complete: %s", job.id, candidates[0].name)
     return candidates[0]

--- a/app/pipeline/runner.py
+++ b/app/pipeline/runner.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 from pathlib import Path
 
+from app.core.config import TIMEOUT_FFMPEG
 from app.core.models import Job, JobCancelled
 from app.core.registry import persist as persist_registry
 from app.pipeline.analyze import analyze
@@ -64,7 +65,7 @@ def _prepare_local_source(job: Job, source: Path, job_dir: Path) -> Path:
         "-y",
         str(dest),
     ]
-    result = subprocess.run(cmd, capture_output=True, timeout=300)
+    result = subprocess.run(cmd, capture_output=True, timeout=TIMEOUT_FFMPEG)
     if result.returncode != 0:
         raise RuntimeError(
             "ffmpeg transcode failed: " + result.stderr.decode("utf-8", errors="replace").strip()

--- a/app/pipeline/separate.py
+++ b/app/pipeline/separate.py
@@ -9,7 +9,7 @@ import threading
 import time
 from pathlib import Path
 
-from app.core.config import DEMUCS_DEVICE, DEMUCS_MODEL
+from app.core.config import DEMUCS_DEVICE, DEMUCS_MODEL, TIMEOUT_DEMUCS_STALL
 from app.core.models import Job, JobCancelled
 from app.core.registry import set_proc
 
@@ -19,7 +19,6 @@ _PCT_RE = re.compile(r"(\d{1,3})%")
 # Terminate demucs if stderr produces no output for this many seconds.
 # GPU processing can be silent for minutes; 30 min covers legitimate pauses
 # while still catching genuine hangs (GPU deadlock, OOM stall, etc.).
-_DEMUCS_STALL_TIMEOUT = 1800
 
 
 def separate(job: Job, source: Path, job_dir: Path) -> Path:
@@ -70,10 +69,10 @@ def separate(job: Job, source: Path, job_dir: Path) -> Path:
     def _watchdog() -> None:
         while proc.poll() is None:
             time.sleep(30)
-            if time.monotonic() - last_output[0] > _DEMUCS_STALL_TIMEOUT:
+            if time.monotonic() - last_output[0] > TIMEOUT_DEMUCS_STALL:
                 logger.warning(
                     "demucs stalled for %ss with no output, terminating job %s",
-                    _DEMUCS_STALL_TIMEOUT,
+                    TIMEOUT_DEMUCS_STALL,
                     job.id,
                 )
                 proc.terminate()
@@ -115,7 +114,7 @@ def separate(job: Job, source: Path, job_dir: Path) -> Path:
         raise JobCancelled()
     if proc.returncode != 0:
         detail = "\n".join(tail[-15:]) if tail else "(no stderr captured)"
-        logger.error("demucs exited %s; tail:\n%s", proc.returncode, detail)
+        logger.error("[%s] demucs exited %s; tail:\n%s", job.id, proc.returncode, detail)
         last = tail[-1] if tail else f"exit status {proc.returncode}"
         raise RuntimeError(f"demucs failed: {last}")
 

--- a/desktop/ui/setup.js
+++ b/desktop/ui/setup.js
@@ -16,14 +16,15 @@ function setStatus(message) {
   statusEl.textContent = message;
 }
 
-function showError(error) {
+function showError(error, hint) {
   for (const el of steps) {
     if (el.classList.contains("active")) {
       el.classList.replace("active", "error");
     }
   }
   setStatus("Setup could not complete.");
-  detailsEl.textContent = String(error);
+  const msg = String(error?.message ?? error);
+  detailsEl.textContent = hint ? `${msg}\n\n→ ${hint}` : msg;
   detailsEl.classList.remove("hidden");
   retryBtn.classList.remove("hidden");
 }
@@ -82,8 +83,9 @@ function isMac() {
 async function installRuntimePack(appRoot) {
   const status = await invoke("runtime_pack_status");
   if (!status.manifestReady) {
-    throw new Error(
-      `Python runtime not found. Expected python/ or .venv/ under ${appRoot}, or a runtime-manifest.json for first-run setup.`
+    throw Object.assign(
+      new Error(`Python runtime not found under ${appRoot}.`),
+      { hint: "Try reinstalling StemDeck. If the problem persists, check that your disk has at least 2 GB free." }
     );
   }
 
@@ -134,7 +136,10 @@ async function installRuntimePack(appRoot) {
     setStatus("Installing StemDeck runtime...");
     const installed = await invoke("extract_runtime_pack");
     if (!installed.runtimeReady) {
-      throw new Error("Runtime install finished but Python/backend files were not found.");
+      throw Object.assign(
+        new Error("Runtime install finished but Python/backend files were not found."),
+        { hint: "Your disk may be full or the archive may be corrupt. Free up space and click Retry to re-download." }
+      );
     }
   } finally {
     unlisten();
@@ -179,7 +184,10 @@ async function runSetup() {
       runtime = await invoke("probe_runtime");
       if (!runtime.pythonReady) {
         setStep("runtime", "error");
-        throw new Error(`Python runtime setup failed under: ${runtime.dataDir}`);
+        throw Object.assign(
+          new Error(`Python runtime setup failed under: ${runtime.dataDir}`),
+          { hint: "Check that your disk has at least 2 GB free and click Retry. If it keeps failing, try reinstalling StemDeck." }
+        );
       }
     }
     setStep("runtime", "done");
@@ -282,7 +290,7 @@ async function runSetup() {
       window.location.replace(backend.url);
     });
   } catch (error) {
-    showError(error);
+    showError(error, error?.hint);
   }
 }
 

--- a/static/js/catalog.js
+++ b/static/js/catalog.js
@@ -137,7 +137,7 @@ function saveState() {
   ensureTrash();
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({ v: STORAGE_VERSION, folders, tracks }));
-  } catch { /* ignore */ }
+  } catch (e) { console.warn("[catalog] failed to save state:", e); }
 }
 
 // ─── Track management ───

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -1,11 +1,21 @@
-export const STEM_NAMES = ["vocals", "drums", "bass", "guitar", "piano", "other"];
+// Fallback list used before /api/config responds. Kept in sync with
+// STEM_NAMES in app/core/config.py — the API is the canonical source.
+export let STEM_NAMES = ["vocals", "drums", "bass", "guitar", "piano", "other"];
+export let TRACK_NAMES = ["original", ...STEM_NAMES];
 
-// All track names the studio knows about, including the synthetic
-// "original" track (the full song, served alongside the extracted
-// stems whenever the user picked a strict subset). Used for mixer
-// column / mixer state / VU iteration. The import-page stem selector
-// still uses STEM_NAMES because "original" isn't a separable stem.
-export const TRACK_NAMES = ["original", ...STEM_NAMES];
+export async function syncStemNamesFromAPI() {
+  try {
+    const res = await fetch("/api/config");
+    if (!res.ok) return;
+    const data = await res.json();
+    if (Array.isArray(data.stem_names) && data.stem_names.length > 0) {
+      STEM_NAMES = data.stem_names;
+      TRACK_NAMES = ["original", ...STEM_NAMES];
+    }
+  } catch (e) {
+    console.warn("[constants] failed to sync stem names from API:", e);
+  }
+}
 
 export const STEM_DISPLAY = {
   vocals: "Vocals",

--- a/static/js/job.js
+++ b/static/js/job.js
@@ -242,12 +242,16 @@ function connectEvents(jobId) {
       attempt = 0; // any successful frame resets backoff
       let s;
       try { s = JSON.parse(ev.data); } catch { return; }
-      applyState(s);
-      if (TERMINAL_STATUSES.has(s.status)) {
-        stopped = true;
-        es.close();
-        setEventSource(null);
-      }
+      // Defer by one tick so synchronous user event handlers (clicks,
+      // input events) always complete before SSE state is applied.
+      setTimeout(() => {
+        applyState(s);
+        if (TERMINAL_STATUSES.has(s.status)) {
+          stopped = true;
+          es.close();
+          setEventSource(null);
+        }
+      }, 0);
     };
 
     es.onerror = async () => {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -2,9 +2,9 @@ import {
   playBtn, loopBtn, multitrack, loopEnabled, loopStart, loopEnd,
   setLoopStart, setLoopEnd, selectedStems, saveSelectedStems,
 } from "./state.js";
-import { STEM_NAMES } from "./constants.js";
+import { STEM_NAMES, syncStemNamesFromAPI } from "./constants.js";
 import { renderEmptyShell, buildStripStems } from "./player.js";
-import { wireJobForm } from "./job.js";
+import { wireJobForm, showError } from "./job.js";
 import { wireTransportButtons } from "./transport.js";
 import { togglePlayPause, updateLoopRegionVisual } from "./transport.js";
 import { wireStemListControls, wireMixerToolbar } from "./mixer.js";
@@ -67,6 +67,7 @@ function wireStemChoiceButtons() {
 
 // ─── Wire everything up ───
 
+syncStemNamesFromAPI().then(() => buildStripStems());
 wireJobForm();
 wireTransportButtons();
 wireStemListControls();
@@ -92,11 +93,17 @@ function wireFileDrop() {
     return n < 1024 * 1024 ? `${(n / 1024).toFixed(0)} KB` : `${(n / 1024 / 1024).toFixed(1)} MB`;
   }
 
+  const MAX_UPLOAD_BYTES = 100 * 1024 * 1024; // must match server _MAX_UPLOAD_BYTES
+
   function applyFile(file) {
     if (!file) return;
     const lower = file.name.toLowerCase();
     if (!lower.endsWith(".mp3") && !lower.endsWith(".wav")) {
-      alert("Only MP3 and WAV files are supported.");
+      showError("Only MP3 and WAV files are supported.");
+      return;
+    }
+    if (file.size > MAX_UPLOAD_BYTES) {
+      showError(`File is too large (${formatBytes(file.size)}). Maximum is 100 MB.`);
       return;
     }
     if (fileName) fileName.textContent = file.name;

--- a/static/js/mixer.js
+++ b/static/js/mixer.js
@@ -21,7 +21,7 @@ export function loadMixIntoState(jobId) {
   try {
     const raw = localStorage.getItem(`stemdeck:mix:${jobId}`);
     if (raw) stored = JSON.parse(raw);
-  } catch { /* ignore */ }
+  } catch (e) { console.warn("[mixer] failed to load mix state:", e); }
   for (const name of TRACK_NAMES) {
     Object.assign(mixerState[name], defaultMixerEntry(), stored[name] || {});
   }
@@ -40,7 +40,7 @@ function saveMix() {
       `stemdeck:mix:${currentJobId}`,
       JSON.stringify(mixerState),
     );
-  } catch { /* ignore */ }
+  } catch (e) { console.warn("[mixer] failed to save mix state:", e); }
 }
 
 export function applyMix() {

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -767,10 +767,7 @@ export function wireUpAudio(jobId, stems, duration, thumbnail) {
       updateStopVisual();
       if (loopEnabled && totalDuration > 0 && t >= loopEnd) {
         if (!loopWrapLogged) {
-          console.log(
-            `[loop] wrap fired: t=${t.toFixed(3)} loopStart=${loopStart.toFixed(3)} loopEnd=${loopEnd.toFixed(3)}`,
-          );
-          loopWrapLogged = true; // log once per session, not every frame
+          loopWrapLogged = true;
         }
         mt.setTime(loopStart);
       }

--- a/static/js/state.js
+++ b/static/js/state.js
@@ -84,14 +84,14 @@ function _loadSelectedStems() {
         return new Set(arr.filter((n) => STEM_NAMES.includes(n)));
       }
     }
-  } catch { /* ignore */ }
+  } catch (e) { console.warn("[state] failed to load stem selection:", e); }
   return new Set(STEM_NAMES);
 }
 export let selectedStems = _loadSelectedStems();
 export function saveSelectedStems() {
   try {
     localStorage.setItem(_STEM_SEL_KEY, JSON.stringify([...selectedStems]));
-  } catch { /* ignore */ }
+  } catch (e) { console.warn("[state] failed to save stem selection:", e); }
 }
 export function setStemSelected(name, selected) {
   if (selected) selectedStems.add(name);


### PR DESCRIPTION
## What

11 fixes across backend and frontend from the 2026-05-15 papaya improvement cycle.

**Quick wins**
- Replaced `alert()` with `showError()` toast for unsupported file type errors — mobile-friendly and accessible
- Centralised hardcoded timeouts (`300s`, `120s`, `1800s`) into named constants in `config.py` (`TIMEOUT_FFMPEG`, `TIMEOUT_ANALYZE`, `TIMEOUT_DEMUCS_STALL`), all overridable via env vars
- Removed leftover debug `console.log` from `player.js`
- `localStorage` quota errors now surface as `console.warn` instead of being silently swallowed

**Medium effort**
- Added client-side file validation before upload: rejects files over 100 MB or with unsupported types immediately, with a toast
- SSE state updates are now deferred by one tick (`setTimeout(..., 0)`) so in-progress user interactions aren't clobbered mid-event
- `STEM_NAMES` is now served from a new `GET /api/config` endpoint; the frontend syncs on startup instead of maintaining a hardcoded copy
- All pipeline log lines are prefixed with `[job_id]` for end-to-end traceability across download → analyze → separate stages

**Longer term**
- yt-dlp downloads retry up to 3× with exponential backoff (2 / 4 / 8 s) on transient network errors; non-retriable errors (404, private video, geo-block) still fail immediately
- Registry now runs `_migrate()` on load to upgrade persisted schemas incrementally — the existing `"version": 1` field is finally acted on
- Desktop setup flow error states now include specific recovery hints (e.g. "free up disk space and click Retry") instead of generic failure messages

## Test plan

- [x] Upload a file >100 MB — rejected client-side with a toast before any network request
- [x] Upload an unsupported file type — toast shown, no native `alert()` dialog
- [x] Simulate a transient network error during download — job retries up to 3× then fails with a clear error
- [x] Restart backend after a completed job — registry loads and migrates cleanly, job appears in library
- [x] Setup flow: trigger Python-not-found — error message includes a suggested action and working Retry button
- [x] Open DevTools console — no `console.log` noise from `player.js`; `localStorage` errors visible as `console.warn`
- [x] Verify stem names in UI match the `/api/config` response