### PR TITLE
feat: export mix, footer waveform, tag search, pipeline fix

### DIFF
--- a/app/api/stems.py
+++ b/app/api/stems.py
@@ -50,10 +50,16 @@ async def get_stem_mp3(job_id: str, name: str) -> StreamingResponse:
     async def _stream():
         proc = await asyncio.create_subprocess_exec(
             ffmpeg_executable(),
-            "-nostdin", "-loglevel", "error",
-            "-i", str(wav_path),
-            "-q:a", "2",  # VBR ~190 kbps
-            "-f", "mp3", "pipe:1",
+            "-nostdin",
+            "-loglevel",
+            "error",
+            "-i",
+            str(wav_path),
+            "-q:a",
+            "2",  # VBR ~190 kbps
+            "-f",
+            "mp3",
+            "pipe:1",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.DEVNULL,
         )

--- a/app/pipeline/analyze.py
+++ b/app/pipeline/analyze.py
@@ -232,7 +232,7 @@ def compute_stem_presence(stems_dir: Path, selected_stems: list[str]) -> dict[st
         if loaded is None:
             continue
         y, _ = loaded
-        rms_values[name] = float(np.sqrt(np.mean(y ** 2)))
+        rms_values[name] = float(np.sqrt(np.mean(y**2)))
 
     if not rms_values:
         return result
@@ -303,6 +303,7 @@ def analyze(job: Job, source: Path) -> tuple[int | None, str | None]:
         # CV = std/mean of inter-beat intervals; CV=0 is perfectly metronomic.
         tempo_stability: int | None = None
         import numpy as np
+
         beat_times = librosa.frames_to_time(beat_frames, sr=sr)
         if len(beat_times) > 2:
             intervals = np.diff(beat_times)

--- a/app/pipeline/collect.py
+++ b/app/pipeline/collect.py
@@ -153,8 +153,8 @@ def make_selected_mix(job: Job, stems_dir: Path, found: list[str]) -> Path | Non
     sum back to (close to) the original signal, so a 2-stem subset
     fits comfortably below 0 dBFS without normalization headroom."""
     selected = [s for s in job.selected_stems if s in found]
-    if not selected or set(selected) == set(found):
-        return None  # no subset -> "mix" would just be the original
+    if not selected:
+        return None
     if len(selected) == 1:
         return stems_dir / f"{selected[0]}.wav"
     inputs = [stems_dir / f"{name}.wav" for name in selected]

--- a/static/css/daw.css
+++ b/static/css/daw.css
@@ -435,6 +435,7 @@ input, textarea { font-family: inherit; }
   color: var(--muted);
   font-size: 12px;
   flex-shrink: 0;
+  position: relative;
 }
 .daw-search svg { flex-shrink: 0; }
 .daw-search input {
@@ -1803,6 +1804,34 @@ input, textarea { font-family: inherit; }
 }
 
 /* Tag chips */
+/* ── Tag autocomplete dropdown ── */
+.tag-suggest {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0; right: 0;
+  z-index: 50;
+  background: var(--panel-2);
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  padding: 4px;
+  list-style: none;
+  margin: 0;
+  box-shadow: var(--shadow-panel);
+}
+.tag-suggest:empty { display: none; }
+.tag-suggest-item {
+  padding: 7px 10px;
+  border-radius: 5px;
+  font-size: 13px;
+  color: var(--fg-2);
+  cursor: pointer;
+}
+.tag-suggest-item:hover,
+.tag-suggest-item.focused {
+  background: var(--panel-3);
+  color: var(--fg);
+}
+
 .lib-tags-row {
   display: flex;
   flex-wrap: wrap;
@@ -1861,6 +1890,13 @@ input, textarea { font-family: inherit; }
 .daw.no-track .daw-section-ribbon,
 .daw.no-track .daw-wave-header,
 .daw.no-track .daw-content { opacity: 0.3; pointer-events: none; }
+
+.app.no-track #t-export-btn,
+.app.is-import #t-export-btn {
+  opacity: 0.35;
+  pointer-events: none;
+  cursor: default;
+}
 
 /* When track is playing */
 .daw-play-btn .pause-icon { display: none; }

--- a/static/index.html
+++ b/static/index.html
@@ -181,7 +181,8 @@
               <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
                 <circle cx="11" cy="11" r="7"/><path d="m20 20-3.5-3.5"/>
               </svg>
-              <input id="catalogSearch" type="search" placeholder="Search library…" autocomplete="off" spellcheck="false" />
+              <input id="catalogSearch" type="search" placeholder="Search or #tag…" autocomplete="off" spellcheck="false" />
+              <ul class="tag-suggest" id="tagSuggest" role="listbox" aria-label="Tag suggestions"></ul>
               <span class="search-kbd" aria-hidden="true">⌘K</span>
             </div>
 

--- a/static/js/catalog.js
+++ b/static/js/catalog.js
@@ -80,7 +80,8 @@ function trackMatchesSearch(track) {
   if (!q) return true;
   if (q.startsWith("#")) {
     const tag = q.slice(1);
-    return (track?.tags ?? []).some((t) => String(t).toLowerCase() === tag);
+    if (!tag) return true;
+    return (track?.tags ?? []).some((t) => String(t).toLowerCase().includes(tag));
   }
   return [
     track?.title,
@@ -468,7 +469,7 @@ async function loadTrackIntoStudio(trackId) {
   }
 
   applyTrackInfoToPanel(track);
-  wireUpAudio(trackId, track.audioStems, track.duration || 0, track.thumb, track.mixUrl ?? null);
+  wireUpAudio(trackId, track.audioStems, track.duration || 0, track.thumb, track.mixUrl ?? null, track.title || "");
   initSections(trackId, track.sections, track.duration || 0);
 }
 
@@ -1281,9 +1282,68 @@ function wireCatalogSearch() {
   const input = document.getElementById("catalogSearch");
   if (!input || input.dataset.searchReady === "1") return;
   input.dataset.searchReady = "1";
+
+  const suggest = document.getElementById("tagSuggest");
+
+  function hideSuggest() {
+    if (suggest) suggest.innerHTML = "";
+  }
+
+  function showTagSuggestions(prefix) {
+    if (!suggest) return;
+    suggest.innerHTML = "";
+    if (!prefix) { hideSuggest(); return; }
+    const trashIds = new Set(folders.find((f) => f.id === TRASH_ID)?.items || []);
+    const all = getAllTags(trashIds);
+    const matches = all.filter(([t]) => t.toLowerCase().includes(prefix));
+    if (!matches.length) { hideSuggest(); return; }
+    for (const [tag] of matches.slice(0, 8)) {
+      const li = document.createElement("li");
+      li.className = "tag-suggest-item";
+      li.setAttribute("role", "option");
+      li.textContent = `#${tag}`;
+      li.addEventListener("mousedown", (e) => {
+        e.preventDefault();
+        input.value = `#${tag}`;
+        catalogSearchQuery = `#${tag}`;
+        hideSuggest();
+        render();
+      });
+      suggest.appendChild(li);
+    }
+  }
+
   input.addEventListener("input", () => {
     catalogSearchQuery = normalizeSearch(input.value);
     render();
+    const val = input.value;
+    if (val.startsWith("#")) {
+      showTagSuggestions(val.slice(1).toLowerCase());
+    } else {
+      hideSuggest();
+    }
+  });
+
+  input.addEventListener("blur", () => setTimeout(hideSuggest, 150));
+  input.addEventListener("keydown", (e) => {
+    if (!suggest?.children.length) return;
+    if (e.key === "Escape") { hideSuggest(); return; }
+    const items = [...suggest.querySelectorAll(".tag-suggest-item")];
+    const active = suggest.querySelector(".tag-suggest-item.focused");
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      const next = active ? (items[items.indexOf(active) + 1] || items[0]) : items[0];
+      active?.classList.remove("focused");
+      next.classList.add("focused");
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      const prev = active ? (items[items.indexOf(active) - 1] || items[items.length - 1]) : items[items.length - 1];
+      active?.classList.remove("focused");
+      prev.classList.add("focused");
+    } else if (e.key === "Enter" && active) {
+      e.preventDefault();
+      active.dispatchEvent(new MouseEvent("mousedown"));
+    }
   });
 }
 

--- a/static/js/job.js
+++ b/static/js/job.js
@@ -225,6 +225,7 @@ function applyState(state) {
         state.duration || 0,
         state.thumbnail,
         state.mix_url ?? null,
+        state.title || "",
       );
       initSections(state.job_id, state.sections, state.duration || 0);
     }

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -617,6 +617,7 @@ let _loadingShownAt = 0;
 const _LOADING_MIN_MS = 900;
 let _currentStems = [];
 let _mixUrl = null;
+let _currentTitle = "";
 
 export function setWaveformLoading(loading) {
   const el = document.getElementById("waveLoadingOverlay");
@@ -666,7 +667,7 @@ function _applyLaneHeight(count) {
   return laneH;
 }
 
-export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null) {
+export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, title = "") {
   const app = document.querySelector(".app");
   app?.classList.remove("is-import");
   app?.classList.remove("no-track");
@@ -713,14 +714,18 @@ export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null) {
   stems = stems.filter((s) => s.name === "original" || selectedStems.has(s.name));
   _currentStems = stems;
   _mixUrl = mixUrl || null;
+  _currentTitle = title || "";
   applyStemSelectionFilter(new Set(stems.map((s) => s.name)));
   updateFooterTrack({ thumbnail, stemCount: stems.filter((s) => s.name !== "original").length });
 
-  // Reset and re-init footer waveform from the mix/original stem
+  // Reset and re-init footer waveform — prefer the full selected-stems mix,
+  // fall back to the complement "original" track, then first available stem.
   _footerWavePeaks = null;
   setFooterWaveDrawFn(null);
-  const mixStem = stems.find((s) => s.name === "original") || stems[0];
-  if (mixStem?.url) initFooterWaveform(mixStem.url);
+  const waveformUrl = _mixUrl
+    || stems.find((s) => s.name === "original")?.url
+    || stems[0]?.url;
+  if (waveformUrl) initFooterWaveform(waveformUrl);
 
   for (const stem of stems) {
     const row = mixerEl.querySelector(`.lane-header[data-stem="${stem.name}"]`);
@@ -1020,16 +1025,25 @@ function _exportMixUrl() {
   return orig?.url ?? null;
 }
 
+function _exportFilename(ext) {
+  const safe = _currentTitle
+    .replace(/[^a-zA-Z0-9]+/g, "_")
+    .replace(/_{2,}/g, "_")
+    .slice(0, 80)
+    .replace(/^_+|_+$/g, "");
+  return safe ? `${safe}_exported_mix.${ext}` : `exported_mix.${ext}`;
+}
+
 export function downloadCurrentMix() {
   const url = _exportMixUrl();
   if (!url) return;
-  _triggerDownload(url, "mix.wav");
+  _triggerDownload(url, _exportFilename("wav"));
 }
 
 export function downloadCurrentMixMp3() {
   const url = _exportMixUrl();
   if (!url) return;
-  _triggerDownload(url.replace(/\.wav$/, ".mp3"), "mix.mp3");
+  _triggerDownload(url.replace(/\.wav$/, ".mp3"), _exportFilename("mp3"));
 }
 
 export function downloadCurrentStems() {


### PR DESCRIPTION
## Summary

Post-merge fixes that were committed locally after PR #67 was squash-merged.

- **Export Mix**: WAV and MP3 download working, files named `{title}_exported_mix.{ext}` (alphanumeric + underscores), grayed out when no track loaded, Tauri uses `open_url` instead of `<a download>`
- **Pipeline**: `mix.wav` always produced regardless of stem selection — previously skipped when all 6 stems selected, causing silent exports
- **Footer waveform**: uses `mix_url` as source instead of `stems[0]` (which could be a silent vocal stem on instrumental sections)
- **Tag search**: `#tag` syntax in library search with partial-match autocomplete dropdown (up to 8 suggestions, keyboard navigable)

Closes #68.