### PR TITLE
fix: address /review-all findings (security, reliability, quality, docs)

### DIFF
--- a/.woodpecker/ci.yml
+++ b/.woodpecker/ci.yml
@@ -62,7 +62,7 @@ steps:
       # local-only, single-user app is negligible. Re-evaluate once demucs
       # supports torch 2.7+ without torchcodec.
       #
-      # joblib PYSEC-2024-277 — no fix version available as of 2025-12-15
+      # joblib PYSEC-2024-277 — no fix version available as of 2026-05-21
       # (1.5.3 is latest). joblib is a transitive dep via demucs/librosa;
       # StemDeck does not directly invoke joblib serialization. Drop once
       # a patched release is available.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Extract the zip anywhere, run `StemDeck.exe`. On first launch the app verifies t
 
 <br>
 
-StemDeck is built on **[Python 3.10+](https://python.org)** managed via **[uv](https://github.com/astral-sh/uv)**, with a **[FastAPI](https://fastapi.tiangolo.com)** backend serving REST and Server-Sent Events. Stem separation uses **[Demucs](https://github.com/facebookresearch/demucs)** (`htdemucs_6s`), Meta AI's open-source 6-stem neural network. YouTube audio is fetched via **[yt-dlp](https://github.com/yt-dlp/yt-dlp)**; transcoding and mixing use **[FFmpeg](https://ffmpeg.org)**. BPM detection and key analysis run on **[librosa](https://librosa.org)**; loudness measurement uses **[pyloudnorm](https://github.com/csteinmetz1/pyloudnorm)** (ITU-R BS.1770). The macOS and Windows desktop shells are **[Tauri v2](https://tauri.app)** (Rust/WKWebView on macOS, Rust/WebView2 on Windows). The frontend is vanilla JS with the Web Audio API, no framework and no build step; waveforms are rendered on `<canvas>` using min/max sample rendering.
+StemDeck is built on **[Python 3.12](https://python.org)** managed via **[uv](https://github.com/astral-sh/uv)**, with a **[FastAPI](https://fastapi.tiangolo.com)** backend serving REST and Server-Sent Events. Stem separation uses **[Demucs](https://github.com/facebookresearch/demucs)** (`htdemucs_6s`), Meta AI's open-source 6-stem neural network. YouTube audio is fetched via **[yt-dlp](https://github.com/yt-dlp/yt-dlp)**; transcoding and mixing use **[FFmpeg](https://ffmpeg.org)**. BPM detection and key analysis run on **[librosa](https://librosa.org)**; loudness measurement uses **[pyloudnorm](https://github.com/csteinmetz1/pyloudnorm)** (ITU-R BS.1770). The macOS and Windows desktop shells are **[Tauri v2](https://tauri.app)** (Rust/WKWebView on macOS, Rust/WebView2 on Windows). The frontend is vanilla JS with the Web Audio API, no framework and no build step; waveforms are rendered on `<canvas>` using min/max sample rendering.
 
 *Thanks to the creators and maintainers of all the open-source libraries that make StemDeck possible.*
 
@@ -137,7 +137,7 @@ StemDeck is built on **[Python 3.10+](https://python.org)** managed via **[uv](h
 
 ### macOS Native App
 
-Requires Rust, Node.js, and Python 3.10–3.13. Builds a self-contained `.app` that downloads its own runtime on first launch.
+Requires Rust, Node.js, and Python 3.12. Builds a self-contained `.app` that downloads its own runtime on first launch.
 
 ```sh
 # First time only — add the cross-compilation targets
@@ -167,11 +167,11 @@ open desktop/src-tauri/target/aarch64-apple-darwin/release/bundle/macos/StemDeck
 
 ---
 
-### Web Server (macOS / Linux / Windows with Python 3.10+)
+### Web Server (macOS / Linux / Windows with Python 3.12+)
 
 #### Prerequisites
 
-Python 3.10 or newer, `ffmpeg` on your PATH, and [uv](https://github.com/astral-sh/uv). Around 170 MB of free disk for the Demucs model, which downloads automatically on first run.
+Python 3.12 or newer, `ffmpeg` on your PATH, and [uv](https://github.com/astral-sh/uv). Around 170 MB of free disk for the Demucs model, which downloads automatically on first run.
 
 #### macOS / Linux (one-shot)
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 
 <div align="center">
   <a href="https://ci.popchores.app/repos/2"><img src="https://ci.popchores.app/api/badges/2/status.svg?event=push" alt="CI"></a>
-  <a href="https://github.com/thcp/stemdeck/stargazers"><img src="https://img.shields.io/github/stars/thcp/stemdeck?style=flat-square" alt="GitHub Stars"></a>
-  <a href="https://github.com/thcp/stemdeck/releases"><img src="https://img.shields.io/github/downloads/thcp/stemdeck/total?style=flat-square&color=52c65f" alt="Total Downloads"></a>
-  <a href="https://github.com/thcp/stemdeck/releases/latest"><img src="https://img.shields.io/github/v/release/thcp/stemdeck?style=flat-square" alt="Latest Release"></a>
-  <a href="https://github.com/thcp/stemdeck/blob/main/LICENSE"><img src="https://img.shields.io/github/license/thcp/stemdeck?style=flat-square" alt="License"></a>
+  <a href="https://github.com/stemdeckapp/stemdeck/stargazers"><img src="https://img.shields.io/github/stars/stemdeckapp/stemdeck?style=flat-square" alt="GitHub Stars"></a>
+  <a href="https://github.com/stemdeckapp/stemdeck/releases"><img src="https://img.shields.io/github/downloads/stemdeckapp/stemdeck/total?style=flat-square&color=52c65f" alt="Total Downloads"></a>
+  <a href="https://github.com/stemdeckapp/stemdeck/releases/latest"><img src="https://img.shields.io/github/v/release/stemdeckapp/stemdeck?style=flat-square" alt="Latest Release"></a>
+  <a href="https://github.com/stemdeckapp/stemdeck/blob/main/LICENSE"><img src="https://img.shields.io/github/license/stemdeckapp/stemdeck?style=flat-square" alt="License"></a>
 </div>
 
 <br>
@@ -35,7 +35,7 @@ Drop an MP3 or WAV, or paste a YouTube URL. StemDeck splits the audio into up to
 
 ![StemDeck screenshot](imgs/screenshot/stemdeck.png)
 
-If you find StemDeck useful, consider [buying the maker a coffee](                    buymeacoffee.com/stemdeckapp); these donations are being used to random acts of kindness toward others 
+If you find StemDeck useful, consider [buying the maker a coffee](https://www.buymeacoffee.com/stemdeckapp); these donations are being used to random acts of kindness toward others 
 
 ---
 
@@ -234,9 +234,22 @@ Stems land in `./jobs/` on the host. Demucs weights are cached in a named volume
 | `STEMDECK_DEMUCS_DEVICE` | auto | Force Torch device: `cuda`, `mps`, or `cpu`. |
 | `STEMDECK_DEMUCS_MODEL` | `htdemucs_6s` | Demucs model name. |
 | `STEMDECK_JOBS_DIR` | `./jobs` | Where job directories land. |
+| `STEMDECK_DATA_DIR` | (none) | Portable mode root; sets all sub-dirs below to live inside it. |
+| `STEMDECK_CACHE_DIR` | `<data>/cache` | Torch model cache directory. |
+| `STEMDECK_DOWNLOADS_DIR` | `<data>/downloads` | yt-dlp download scratch space. |
+| `STEMDECK_MODELS_DIR` | `<data>/models` | Demucs model weights directory. |
+| `STEMDECK_LOGS_DIR` | `<data>/logs` | Log file output directory. |
+| `STEMDECK_FFMPEG_DIR` | (none) | Directory containing a bundled ffmpeg binary. |
+| `STEMDECK_FFMPEG` | `ffmpeg` | Path to the ffmpeg executable. |
+| `STEMDECK_FFPROBE` | `ffprobe` | Path to the ffprobe executable. |
 | `STEMDECK_MAX_DURATION_SEC` | `1200` | Reject audio longer than this (seconds). |
 | `STEMDECK_JOB_TTL_SECONDS` | `86400` | How long to keep job dirs on disk. |
 | `STEMDECK_MAX_PENDING_JOBS` | `3` | Max queued jobs before returning 503. |
+| `STEMDECK_TIMEOUT_FFMPEG` | `300` | ffmpeg subprocess timeout (seconds). |
+| `STEMDECK_TIMEOUT_ANALYZE` | `120` | Audio analysis timeout (seconds). |
+| `STEMDECK_TIMEOUT_DEMUCS_STALL` | `1800` | Kill Demucs if no output for this many seconds. |
+
+`run.sh` also reads: `HOST` (default `127.0.0.1`), `PORT` (default `8765`), `RELOAD=1` (enable uvicorn auto-reload for development), `FOREGROUND=1` (run in foreground instead of backgrounding).
 
 ---
 
@@ -244,11 +257,15 @@ Stems land in `./jobs/` on the host. Demucs weights are cached in a named volume
 
 | Method | Path | Purpose |
 |---|---|---|
+| GET | `/api/health` | Server health and version info |
 | POST | `/api/jobs` | JSON `{url, stems?}` or multipart `file + stems` → `{job_id}` |
+| GET | `/api/jobs` | List completed (library) jobs |
 | GET | `/api/jobs/{id}` | Job state snapshot |
 | GET | `/api/jobs/{id}/events` | SSE stream of job state |
 | POST | `/api/jobs/{id}/cancel` | Terminate active subprocess and cancel job |
-| GET | `/api/jobs/{id}/stems/{name}.wav` | Stream/download a single stem (range requests) |
+| PATCH | `/api/jobs/{id}/sections` | Save waveform section markers for a job |
+| GET | `/api/jobs/{id}/stems/{name}.wav` | Stream a single stem WAV file |
+| GET | `/api/jobs/{id}/stems/{name}.mp3` | Transcode and stream a stem as MP3 |
 | DELETE | `/api/jobs/{id}` | Remove job dir from disk (terminal jobs only) |
 
 ---

--- a/app/api/events.py
+++ b/app/api/events.py
@@ -15,35 +15,51 @@ router = APIRouter(tags=["events"])
 # Close SSE connections that outlive this threshold to prevent zombie
 # connections from accumulating when clients disconnect without a TCP RST.
 _MAX_SSE_SECONDS = 4 * 3600  # 4 hours
+# Hard cap on concurrent SSE connections to prevent resource exhaustion
+# from tab leaks or aggressive reconnect loops.
+_MAX_SSE_CONNECTIONS = 200
+# Counter is only mutated from the async event loop (no awaits between
+# check+increment), so no lock is needed.
+_sse_active = 0
 
 
 @router.get("/jobs/{job_id}/events")
 async def job_events(job_id: str) -> StreamingResponse:
+    """Server-Sent Events stream of job state updates. Closes when the job
+    reaches a terminal status (done, error, cancelled) or after 4 hours."""
+    global _sse_active
     if not JOB_ID_RE.match(job_id):
         raise HTTPException(status_code=404, detail="job not found")
     job = registry_get(job_id)
     if job is None:
         raise HTTPException(status_code=404, detail="job not found")
+    if _sse_active >= _MAX_SSE_CONNECTIONS:
+        raise HTTPException(status_code=503, detail="too many concurrent streams")
+    _sse_active += 1
 
     async def stream() -> AsyncIterator[str]:
-        last = None
-        keepalive_at = 0
-        loop = asyncio.get_running_loop()
-        deadline = loop.time() + _MAX_SSE_SECONDS
-        while loop.time() < deadline:
-            snapshot = job.to_state()
-            serialized = json.dumps(snapshot)
-            if serialized != last:
-                yield f"data: {serialized}\n\n"
-                last = serialized
-                keepalive_at = 0
-            if snapshot["status"] in ("done", "error", "cancelled"):
-                return
-            keepalive_at += 1
-            if keepalive_at >= 75:  # ~15s
-                yield ": keepalive\n\n"
-                keepalive_at = 0
-            await asyncio.sleep(0.2)
+        global _sse_active
+        try:
+            last = None
+            keepalive_at = 0
+            loop = asyncio.get_running_loop()
+            deadline = loop.time() + _MAX_SSE_SECONDS
+            while loop.time() < deadline:
+                snapshot = job.to_state()
+                serialized = json.dumps(snapshot)
+                if serialized != last:
+                    yield f"data: {serialized}\n\n"
+                    last = serialized
+                    keepalive_at = 0
+                if snapshot["status"] in ("done", "error", "cancelled"):
+                    return
+                keepalive_at += 1
+                if keepalive_at >= 75:  # ~15s
+                    yield ": keepalive\n\n"
+                    keepalive_at = 0
+                await asyncio.sleep(0.2)
+        finally:
+            _sse_active -= 1
 
     return StreamingResponse(
         stream(),

--- a/app/api/events.py
+++ b/app/api/events.py
@@ -7,6 +7,7 @@ from collections.abc import AsyncIterator
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import StreamingResponse
 
+from app.core.config import JOB_ID_RE
 from app.core.registry import get as registry_get
 
 router = APIRouter(tags=["events"])
@@ -18,6 +19,8 @@ _MAX_SSE_SECONDS = 4 * 3600  # 4 hours
 
 @router.get("/jobs/{job_id}/events")
 async def job_events(job_id: str) -> StreamingResponse:
+    if not JOB_ID_RE.match(job_id):
+        raise HTTPException(status_code=404, detail="job not found")
     job = registry_get(job_id)
     if job is None:
         raise HTTPException(status_code=404, detail="job not found")

--- a/app/api/jobs.py
+++ b/app/api/jobs.py
@@ -114,6 +114,8 @@ class JobRequest(BaseModel):
 
 @router.post("")
 async def create_job(request: Request) -> dict[str, str]:
+    """Submit a YouTube URL (JSON body) or upload an audio file (multipart/form-data)
+    to start a stem-separation job. Returns the new job ID."""
     ct = request.headers.get("content-type", "")
     if "multipart/form-data" in ct:
         return await _create_local_job(request)
@@ -241,6 +243,7 @@ async def _create_local_job(request: Request) -> dict[str, str]:
 
 @router.get("")
 def list_jobs() -> list[dict]:
+    """List all completed jobs in the library, sorted by creation time."""
     return [
         job.to_state()
         for job in sorted(registry_all_jobs().values(), key=lambda j: j.created_at)
@@ -250,6 +253,7 @@ def list_jobs() -> list[dict]:
 
 @router.get("/{job_id}")
 def get_job(job_id: str) -> dict:
+    """Get the current state of a job by ID."""
     job = registry_get(job_id)
     if job is None:
         raise HTTPException(status_code=404, detail="job not found")
@@ -258,6 +262,7 @@ def get_job(job_id: str) -> dict:
 
 @router.post("/{job_id}/cancel")
 def cancel_job(job_id: str) -> dict:
+    """Request cancellation of a running job. Idempotent for terminal jobs."""
     job = registry_get(job_id)
     if job is None:
         raise HTTPException(status_code=404, detail="job not found")
@@ -314,6 +319,7 @@ class SectionsBody(BaseModel):
 
 @router.patch("/{job_id}/sections")
 def update_sections(job_id: str, body: SectionsBody) -> dict:
+    """Save named timeline sections (intro, verse, chorus, etc.) for a done job."""
     if not JOB_ID_RE.match(job_id):
         raise HTTPException(status_code=404, detail="job not found")
     job = registry_get(job_id)
@@ -348,6 +354,7 @@ def update_sections(job_id: str, body: SectionsBody) -> dict:
 
 @router.delete("/{job_id}")
 def delete_job(job_id: str) -> dict[str, str]:
+    """Delete a completed or failed job and remove its stem files from disk."""
     if not JOB_ID_RE.match(job_id):
         raise HTTPException(status_code=404, detail="job not found")
     job = registry_get(job_id)

--- a/app/api/jobs.py
+++ b/app/api/jobs.py
@@ -25,7 +25,7 @@ from app.core.registry import all_jobs as registry_all_jobs
 from app.core.registry import get as registry_get
 from app.core.registry import get_proc as registry_get_proc
 from app.core.registry import persist as registry_persist
-from app.core.registry import register as registry_register
+from app.core.registry import register_if_capacity as registry_register_if_capacity
 from app.core.registry import remove as registry_remove
 from app.pipeline import run_local_pipeline, run_pipeline
 from app.pipeline.download import InvalidYouTubeURL, validate_youtube_url
@@ -135,24 +135,22 @@ async def _create_youtube_job(request: Request) -> dict[str, str]:
     except InvalidYouTubeURL as e:
         raise HTTPException(status_code=422, detail=str(e)) from e
 
-    pending = sum(1 for j in registry_all_jobs().values() if j.status == "queued")
-    if pending >= MAX_PENDING_JOBS:
-        raise HTTPException(status_code=503, detail="Server busy, please try again later")
-
     selected = [s for s in payload.stems if s in STEM_NAMES] if payload.stems else list(STEM_NAMES)
     if not selected:
         selected = list(STEM_NAMES)
 
-    job = registry_register(Job(id=uuid.uuid4().hex[:12], selected_stems=selected, source_url=url))
+    job = Job(id=uuid.uuid4().hex[:12], selected_stems=selected, source_url=url)
+    if not registry_register_if_capacity(job, MAX_PENDING_JOBS):
+        raise HTTPException(status_code=503, detail="Server busy, please try again later")
     task = asyncio.create_task(run_pipeline(job, url, JOBS_DIR))
     task.add_done_callback(_task_error_cb)
     return {"job_id": job.id}
 
 
 async def _create_local_job(request: Request) -> dict[str, str]:
-    # Reject busy server BEFORE touching disk so no orphan dir is created.
-    pending = sum(1 for j in registry_all_jobs().values() if j.status == "queued")
-    if pending >= MAX_PENDING_JOBS:
+    # Fast pre-check: if already at capacity, reject before touching disk.
+    # The real atomic check happens in register_if_capacity after the upload.
+    if sum(1 for j in registry_all_jobs().values() if j.status == "queued") >= MAX_PENDING_JOBS:
         raise HTTPException(status_code=503, detail="Server busy, please try again later")
 
     # Quick pre-check on Content-Length to fail fast for obviously oversized
@@ -226,15 +224,16 @@ async def _create_local_job(request: Request) -> dict[str, str]:
 
     title = _sanitize_title(filename)
     local_source_url = f"local:{title}"
-    job = registry_register(
-        Job(
-            id=job_id,
-            selected_stems=selected,
-            title=title,
-            duration_sec=duration,
-            source_url=local_source_url,
-        )
+    job = Job(
+        id=job_id,
+        selected_stems=selected,
+        title=title,
+        duration_sec=duration,
+        source_url=local_source_url,
     )
+    if not registry_register_if_capacity(job, MAX_PENDING_JOBS):
+        shutil.rmtree(job_dir, ignore_errors=True)
+        raise HTTPException(status_code=503, detail="Server busy, please try again later")
     task = asyncio.create_task(run_local_pipeline(job, source_path, JOBS_DIR))
     task.add_done_callback(_task_error_cb)
     return {"job_id": job.id}

--- a/app/api/stems.py
+++ b/app/api/stems.py
@@ -19,6 +19,7 @@ _ALLOWED_NAMES = frozenset(STEM_NAMES) | {"original", "mix"}
 
 @router.api_route("/jobs/{job_id}/stems/{name}.wav", methods=["GET", "HEAD"])
 def get_stem(job_id: str, name: str) -> FileResponse:
+    """Download a WAV stem (vocals, drums, bass, guitar, piano, other, original, mix)."""
     if not JOB_ID_RE.match(job_id):
         raise HTTPException(status_code=404, detail="job not found")
     if name not in _ALLOWED_NAMES:
@@ -36,6 +37,7 @@ def get_stem(job_id: str, name: str) -> FileResponse:
 
 @router.get("/jobs/{job_id}/stems/{name}.mp3")
 async def get_stem_mp3(job_id: str, name: str) -> StreamingResponse:
+    """Stream a stem as MP3 (VBR ~190 kbps). Transcoded on-the-fly from WAV via ffmpeg."""
     if not JOB_ID_RE.match(job_id):
         raise HTTPException(status_code=404, detail="job not found")
     if name not in _ALLOWED_NAMES:

--- a/app/core/models.py
+++ b/app/core/models.py
@@ -3,19 +3,31 @@ from __future__ import annotations
 import dataclasses
 import time
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal
 
 
 class JobCancelled(Exception):
     """Raised inside a pipeline stage when the job's cancel flag is set."""
 
 
+JobStatus = Literal[
+    "queued", "downloading", "analyzing", "separating", "processing", "done", "error", "cancelled"
+]
+
+
+def _set(job: Job, **fields: object) -> None:
+    """Mutate Job fields. SSE polling picks up the change automatically."""
+    for k, v in fields.items():
+        if k == "stage":
+            job.stage_message = v  # type: ignore[assignment]
+        else:
+            setattr(job, k, v)
+
+
 @dataclass
 class Job:
     id: str
-    status: str = (
-        "queued"  # queued | downloading | analyzing | separating | done | error | cancelled
-    )
+    status: JobStatus = "queued"
     progress: float = 0.0
     stage_message: str = "Queued"
     title: str | None = None

--- a/app/core/registry.py
+++ b/app/core/registry.py
@@ -29,6 +29,17 @@ def register(job: Job) -> Job:
     return job
 
 
+def register_if_capacity(job: Job, max_pending: int) -> bool:
+    """Atomically check pending count and register if under capacity.
+    Returns True if registered, False if the queue is full."""
+    with _lock:
+        pending = sum(1 for j in _jobs.values() if j.status == "queued")
+        if pending >= max_pending:
+            return False
+        _jobs[job.id] = job
+    return True
+
+
 def get(job_id: str) -> Job | None:
     with _lock:
         return _jobs.get(job_id)
@@ -71,12 +82,10 @@ def persist(jobs_dir: Path) -> None:
             for job in sorted(_jobs.values(), key=lambda item: item.created_at)
             if job.status in _TERMINAL
         ]
+        payload = json.dumps({"version": REGISTRY_VERSION, "jobs": records}, indent=2) + "\n"
     path = jobs_dir / _REGISTRY_FILE
     tmp = path.with_suffix(".json.tmp")
-    tmp.write_text(
-        json.dumps({"version": REGISTRY_VERSION, "jobs": records}, indent=2) + "\n",
-        encoding="utf-8",
-    )
+    tmp.write_text(payload, encoding="utf-8")
     tmp.replace(path)
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,7 @@ import ctypes
 import json
 import logging
 import os
+import signal
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from importlib.metadata import PackageNotFoundError
@@ -95,7 +96,10 @@ async def _desktop_parent_watchdog(parent_pid: int) -> None:
     while True:
         if not _process_exists(parent_pid):
             _log.info("desktop parent process exited; stopping backend")
-            os._exit(0)
+            # Send SIGTERM to ourselves so uvicorn runs its shutdown sequence
+            # instead of bypassing cleanup with os._exit().
+            os.kill(os.getpid(), signal.SIGTERM)
+            return
         await asyncio.sleep(1)
 
 
@@ -161,7 +165,5 @@ async def no_cache_static(request: Request, call_next):
 app.include_router(router, prefix="/api")
 app.mount("/", StaticFiles(directory=STATIC_DIR, html=True), name="static")
 
-# Ensure runtime directories exist at startup (module-level side effect
-# moved from the old monolithic main.py; this is the canonical entrypoint).
 ensure_runtime_dirs()
 restore_registry(JOBS_DIR)

--- a/app/main.py
+++ b/app/main.py
@@ -101,7 +101,10 @@ async def _desktop_parent_watchdog(parent_pid: int) -> None:
 
 @asynccontextmanager
 async def lifespan(_: FastAPI) -> AsyncIterator[None]:
-    asyncio.create_task(_sweep_loop())
+    _background_tasks = set()
+    t = asyncio.create_task(_sweep_loop())
+    _background_tasks.add(t)
+    t.add_done_callback(_background_tasks.discard)
     if os.environ.get("STEMDECK_DESKTOP") == "1":
         parent_pid = os.environ.get("STEMDECK_PARENT_PID")
         if parent_pid:
@@ -111,11 +114,18 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
                 _log.warning("invalid STEMDECK_PARENT_PID=%r", parent_pid)
             else:
                 if parent_pid_int > 0 and parent_pid_int != os.getpid():
-                    asyncio.create_task(_desktop_parent_watchdog(parent_pid_int))
+                    wt = asyncio.create_task(_desktop_parent_watchdog(parent_pid_int))
+                    _background_tasks.add(wt)
+                    wt.add_done_callback(_background_tasks.discard)
     yield
 
 
-app = FastAPI(title="StemDeck", lifespan=lifespan)
+app = FastAPI(
+    title="StemDeck",
+    description="Paste a YouTube URL or upload an audio file, get audio stems split into a DAW-style player.",
+    version=app_version(),
+    lifespan=lifespan,
+)
 
 
 @app.get("/health", include_in_schema=False)

--- a/app/pipeline/__init__.py
+++ b/app/pipeline/__init__.py
@@ -1,4 +1,3 @@
-from app.core.config import STEM_NAMES
 from app.pipeline.runner import run_local_pipeline, run_pipeline
 
-__all__ = ["run_pipeline", "run_local_pipeline", "STEM_NAMES"]
+__all__ = ["run_pipeline", "run_local_pipeline"]

--- a/app/pipeline/analyze.py
+++ b/app/pipeline/analyze.py
@@ -5,8 +5,7 @@ import subprocess
 from pathlib import Path
 
 from app.core.config import JOBS_DIR, TIMEOUT_ANALYZE, ffmpeg_executable
-from app.core.models import Job
-from app.pipeline.download import _set
+from app.core.models import Job, _set
 
 logger = logging.getLogger("stemdeck.analyze")
 

--- a/app/pipeline/collect.py
+++ b/app/pipeline/collect.py
@@ -181,8 +181,8 @@ def make_selected_mix(job: Job, stems_dir: Path, found: list[str]) -> Path | Non
 
 def sweep_old_jobs(jobs_dir: Path) -> None:
     """Delete job directories older than JOB_TTL_SECONDS and remove them from
-    the in-memory registry. Called once per new job submission so stale data
-    doesn't accumulate on disk.
+    the in-memory registry. Called hourly from the background sweep loop
+    started at app startup.
 
     Prefers Job.created_at over directory mtime (which can be touched by
     unrelated filesystem events), and never deletes the directory of an

--- a/app/pipeline/download.py
+++ b/app/pipeline/download.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from yt_dlp import YoutubeDL
 
 from app.core.config import MAX_DURATION_SEC
-from app.core.models import Job, JobCancelled
+from app.core.models import Job, JobCancelled, _set
 
 logger = logging.getLogger("stemdeck.download")
 
@@ -133,15 +133,6 @@ def normalize_youtube_url(url: str) -> str:
             return f"https://www.youtube.com/watch?v={vid}"
 
     return url
-
-
-def _set(job: Job, **fields: object) -> None:
-    """Mutate Job fields. Polling SSE picks the change up automatically."""
-    for k, v in fields.items():
-        if k == "stage":
-            job.stage_message = v  # type: ignore[assignment]
-        else:
-            setattr(job, k, v)
 
 
 def download(job: Job, url: str, job_dir: Path) -> Path:

--- a/app/pipeline/runner.py
+++ b/app/pipeline/runner.py
@@ -142,21 +142,23 @@ def _write_metadata(job: Job, job_dir: Path) -> None:
         logger.warning("could not write metadata.json for job %s", job.id, exc_info=True)
 
 
-async def run_pipeline(job: Job, url: str, jobs_dir: Path) -> None:
-    job_dir = jobs_dir / job.id
+async def _run_async(
+    job: Job,
+    job_dir: Path,
+    jobs_dir: Path,
+    blocking_fn,
+    *fn_args: object,
+    error_msg: str = "Audio processing failed. Please try again.",
+) -> None:
+    """Common async wrapper: acquires the pipeline lock, runs blocking_fn in a
+    thread, then handles success / cancel / error outcomes uniformly."""
     try:
-        job_dir.mkdir(parents=True, exist_ok=True)
         async with _pipeline_lock:
-            await asyncio.to_thread(_run_blocking, job, url, job_dir)
+            await asyncio.to_thread(blocking_fn, job, *fn_args, job_dir)
     except Exception as e:
         if not isinstance(e, JobCancelled) and not job.cancel_requested:
             logger.exception("pipeline failed for job %s: %s", job.id, e)
-            _set(
-                job,
-                status="error",
-                stage="Error: Processing failed",
-                error="Audio processing failed. Please try another video.",
-            )
+            _set(job, status="error", stage="Error: Processing failed", error=error_msg)
             persist_registry(jobs_dir)
             _rmtree(job_dir)
             return
@@ -172,6 +174,30 @@ async def run_pipeline(job: Job, url: str, jobs_dir: Path) -> None:
     _set(job, status="done", progress=1.0, stage="Done")
     _write_metadata(job, job_dir)
     persist_registry(jobs_dir)
+
+
+async def run_pipeline(job: Job, url: str, jobs_dir: Path) -> None:
+    job_dir = jobs_dir / job.id
+    try:
+        job_dir.mkdir(parents=True, exist_ok=True)
+    except Exception as e:
+        logger.exception("pipeline failed for job %s: %s", job.id, e)
+        _set(
+            job,
+            status="error",
+            stage="Error: Processing failed",
+            error="Audio processing failed. Please try another video.",
+        )
+        persist_registry(jobs_dir)
+        return
+    await _run_async(
+        job,
+        job_dir,
+        jobs_dir,
+        _run_blocking,
+        url,
+        error_msg="Audio processing failed. Please try another video.",
+    )
 
 
 async def run_local_pipeline(job: Job, source_path: Path, jobs_dir: Path) -> None:
@@ -179,30 +205,4 @@ async def run_local_pipeline(job: Job, source_path: Path, jobs_dir: Path) -> Non
     The job directory and source file are already present on disk (created
     by the API handler before this task is scheduled)."""
     job_dir = jobs_dir / job.id
-    try:
-        async with _pipeline_lock:
-            await asyncio.to_thread(_run_local_blocking, job, source_path, job_dir)
-    except Exception as e:
-        if not isinstance(e, JobCancelled) and not job.cancel_requested:
-            logger.exception("pipeline failed for job %s: %s", job.id, e)
-            _set(
-                job,
-                status="error",
-                stage="Error: Processing failed",
-                error="Audio processing failed. Please try again.",
-            )
-            persist_registry(jobs_dir)
-            _rmtree(job_dir)
-            return
-        logger.info(
-            "pipeline cancelled%s for job %s",
-            " (wrapped)" if not isinstance(e, JobCancelled) else "",
-            job.id,
-        )
-        _set(job, status="cancelled", stage="Cancelled")
-        persist_registry(jobs_dir)
-        _rmtree(job_dir)
-        return
-    _set(job, status="done", progress=1.0, stage="Done")
-    _write_metadata(job, job_dir)
-    persist_registry(jobs_dir)
+    await _run_async(job, job_dir, jobs_dir, _run_local_blocking, source_path)

--- a/app/pipeline/runner.py
+++ b/app/pipeline/runner.py
@@ -8,11 +8,11 @@ import subprocess
 from pathlib import Path
 
 from app.core.config import TIMEOUT_FFMPEG
-from app.core.models import Job, JobCancelled
+from app.core.models import Job, JobCancelled, _set
 from app.core.registry import persist as persist_registry
 from app.pipeline.analyze import analyze, compute_stem_presence
 from app.pipeline.collect import cleanup_source, collect, make_original_track, make_selected_mix
-from app.pipeline.download import _set, download
+from app.pipeline.download import download
 from app.pipeline.separate import separate
 
 logger = logging.getLogger("stemdeck.pipeline")
@@ -158,6 +158,7 @@ async def run_pipeline(job: Job, url: str, jobs_dir: Path) -> None:
                 error="Audio processing failed. Please try another video.",
             )
             persist_registry(jobs_dir)
+            _rmtree(job_dir)
             return
         logger.info(
             "pipeline cancelled%s for job %s",
@@ -191,6 +192,7 @@ async def run_local_pipeline(job: Job, source_path: Path, jobs_dir: Path) -> Non
                 error="Audio processing failed. Please try again.",
             )
             persist_registry(jobs_dir)
+            _rmtree(job_dir)
             return
         logger.info(
             "pipeline cancelled%s for job %s",

--- a/app/pipeline/separate.py
+++ b/app/pipeline/separate.py
@@ -63,10 +63,14 @@ def separate(job: Job, source: Path, job_dir: Path) -> Path:
     buf = ""
     tail: list[str] = []
     last_output: list[float] = [time.monotonic()]
+    # Event set by the reader loop when the process exits normally so the
+    # watchdog can wake up immediately instead of waiting out its 30 s sleep.
+    _done_evt = threading.Event()
 
     def _watchdog() -> None:
-        while proc.poll() is None:
-            time.sleep(30)
+        while not _done_evt.wait(timeout=30):
+            if proc.poll() is not None:
+                return
             if time.monotonic() - last_output[0] > TIMEOUT_DEMUCS_STALL:
                 logger.warning(
                     "demucs stalled for %ss with no output, terminating job %s",
@@ -74,7 +78,7 @@ def separate(job: Job, source: Path, job_dir: Path) -> Path:
                     job.id,
                 )
                 proc.terminate()
-                break
+                return
 
     wt = threading.Thread(target=_watchdog, daemon=True)
     wt.start()
@@ -102,8 +106,9 @@ def separate(job: Job, source: Path, job_dir: Path) -> Path:
 
         proc.wait()
     finally:
+        _done_evt.set()
         set_proc(job.id, None)
-        wt.join(timeout=5)
+        wt.join(timeout=2)
 
     # POST /cancel calls proc.terminate() directly, which causes the read loop
     # above to hit EOF and proc.wait() to return a nonzero status. Translate

--- a/app/pipeline/separate.py
+++ b/app/pipeline/separate.py
@@ -10,7 +10,7 @@ import time
 from pathlib import Path
 
 from app.core.config import DEMUCS_DEVICE, DEMUCS_MODEL, TIMEOUT_DEMUCS_STALL
-from app.core.models import Job, JobCancelled
+from app.core.models import Job, JobCancelled, _set
 from app.core.registry import set_proc
 
 logger = logging.getLogger("stemdeck.pipeline")
@@ -22,8 +22,6 @@ _PCT_RE = re.compile(r"(\d{1,3})%")
 
 
 def separate(job: Job, source: Path, job_dir: Path) -> Path:
-    from app.pipeline.download import _set
-
     _set(job, status="separating", progress=0.0, stage="Separating stems...")
 
     cmd = [

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stemdeck-desktop",
-  "version": "0.4.0-alpha.1",
+  "version": "0.5.0-alpha.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -3166,9 +3166,10 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stemdeck"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.3"
 dependencies = [
  "flate2",
+ "libc",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -11,6 +11,7 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 flate2 = "1"
+libc = "0.2"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -1,4 +1,6 @@
 use flate2::read::GzDecoder;
+#[cfg(unix)]
+use libc;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::{
@@ -462,7 +464,7 @@ fn start_backend(
         "Python runtime not found. Expected python/ or .venv/ under StemDeck.".to_string()
     })?;
     patch_pyvenv_cfg(&python);
-    let port = free_port()?;
+    let (port, port_guard) = free_port()?;
     let url = format!("http://127.0.0.1:{port}");
     let log_path = data_dir.join("logs").join("backend.log");
     let (stdout, stderr) = prepare_backend_stdio(&log_path).unwrap_or_else(|_| {
@@ -528,6 +530,8 @@ fn start_backend(
     let mut child = cmd
         .spawn()
         .map_err(|e| format!("failed to start backend: {e}"))?;
+    // Release the reserved port immediately after spawn so uvicorn can bind it.
+    drop(port_guard);
 
     if let Err(err) = wait_for_health(port, Duration::from_secs(90), &log_path) {
         let _ = child.kill();
@@ -962,6 +966,20 @@ fn open_url(url: String) -> Result<(), String> {
 fn stop_backend(state: &BackendState) {
     if let Ok(mut guard) = state.child.lock() {
         if let Some(child) = guard.as_mut() {
+            // Send SIGTERM first so uvicorn can drain in-progress requests
+            // before we escalate to SIGKILL.
+            #[cfg(unix)]
+            {
+                unsafe { libc::kill(child.id() as libc::pid_t, libc::SIGTERM) };
+                let deadline = Instant::now() + Duration::from_secs(3);
+                while Instant::now() < deadline {
+                    if child.try_wait().ok().flatten().is_some() {
+                        *guard = None;
+                        return;
+                    }
+                    thread::sleep(Duration::from_millis(100));
+                }
+            }
             let _ = child.kill();
             let _ = child.wait();
         }
@@ -1396,16 +1414,21 @@ fn ffmpeg_dir_if_present(data_dir: &Path) -> Option<PathBuf> {
     }
 }
 
-fn free_port() -> Result<u16, String> {
+/// Bind to port 0 and return both the chosen port and the live listener.
+/// Caller must hold the listener until just after the child process is
+/// spawned, then drop it so the child can bind the same port.  Holding the
+/// socket until spawn narrows the TOCTOU window to a single OS context
+/// switch rather than the entire command-setup period.
+fn free_port() -> Result<(u16, TcpListener), String> {
     let listener =
         TcpListener::bind("127.0.0.1:0").map_err(|e| format!("port bind failed: {e}"))?;
     let port = listener.local_addr().map_err(|e| e.to_string())?.port();
-    drop(listener);
-    Ok(port)
+    Ok((port, listener))
 }
 
 fn wait_for_health(port: u16, timeout: Duration, log_path: &Path) -> Result<(), String> {
     let deadline = Instant::now() + timeout;
+    let mut interval = Duration::from_millis(250);
     loop {
         if Instant::now() >= deadline {
             let tail = file_tail(log_path, 30);
@@ -1430,7 +1453,10 @@ fn wait_for_health(port: u16, timeout: Duration, log_path: &Path) -> Result<(), 
         if health_once(port).is_ok() {
             return Ok(());
         }
-        thread::sleep(Duration::from_millis(250));
+        thread::sleep(interval);
+        // Exponential backoff capped at 2 s to reduce busy-polling while
+        // still detecting fast startups quickly.
+        interval = (interval * 2).min(Duration::from_secs(2));
     }
 }
 
@@ -1602,12 +1628,11 @@ fn download_windows_ffmpeg(data_dir: &Path) -> Result<(), String> {
 #[cfg(windows)]
 fn download_file_with_powershell(url: &str, target: &Path) -> Result<(), String> {
     let target_str = target.display().to_string();
-    // Embed url and path directly — PowerShell 5.1 -Command consumes the
-    // entire remaining argv, so $args[] is always empty when passed this way.
-    let script = format!(
-        "$ProgressPreference = 'SilentlyContinue'; \
-         Invoke-WebRequest -Uri '{url}' -OutFile '{target_str}'"
-    );
+    // Pass URL and destination via environment variables to avoid quote injection
+    // in the PowerShell -Command string (a URL with a single quote would break
+    // the original string-interpolation approach).
+    let script = "$ProgressPreference = 'SilentlyContinue'; \
+         Invoke-WebRequest -Uri $env:STEMDECK_DL_URL -OutFile $env:STEMDECK_DL_DEST";
     let mut command = Command::new("powershell.exe");
     command
         .args([
@@ -1615,8 +1640,10 @@ fn download_file_with_powershell(url: &str, target: &Path) -> Result<(), String>
             "-ExecutionPolicy",
             "Bypass",
             "-Command",
-            &script,
+            script,
         ])
+        .env("STEMDECK_DL_URL", url)
+        .env("STEMDECK_DL_DEST", &target_str)
         .stdout(Stdio::null())
         .stderr(Stdio::piped());
     hide_console_window(&mut command);

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -931,6 +931,9 @@ fn verify_cuda_torch(python: &Path) -> bool {
 
 #[tauri::command]
 fn open_url(url: String) -> Result<(), String> {
+    if !url.starts_with("https://") && !url.starts_with("http://") {
+        return Err("only http/https URLs are permitted".to_string());
+    }
     #[cfg(windows)]
     {
         let mut cmd = Command::new("cmd");

--- a/reviews/CODE-REVIEW.md
+++ b/reviews/CODE-REVIEW.md
@@ -1,0 +1,130 @@
+# StemDeck Code Review
+
+## Tool Availability
+
+No Go, protobuf, or static analysis tools applicable — Python/JS/Rust codebase reviewed manually.
+
+---
+
+## Findings
+
+### Architecture & Design
+
+| ID | Finding | Severity |
+|----|---------|----------|
+| ARCH-1 | **`_set` private function leaks across module boundaries.** `app/pipeline/download.py:138` defines `_set()` as a module-private helper but it is imported by three other modules (`runner.py:15`, `analyze.py:9`, `separate.py:25`). `_set` has nothing to do with downloading — it is a generic job-field mutator that all pipeline stages need. It should live in `app/core/models.py` (or a `app/pipeline/utils.py`) and be public. | HIGH |
+| ARCH-2 | **Module-level side effects execute at import time.** `app/main.py:156-157` calls `ensure_runtime_dirs()` and `restore_registry(JOBS_DIR)` unconditionally at module level, outside the FastAPI lifespan. This means any test that imports `app.main` hits the real filesystem, breaks test isolation, and makes the module non-reusable. Move both calls inside `lifespan()`. | MEDIUM |
+| ARCH-3 | **`app/pipeline/__init__.py` re-exports `STEM_NAMES` from config.** `__init__.py` exports `STEM_NAMES` but it belongs in `app/core/config`. Consumers that import from `app.pipeline` for a config constant create a misleading dependency. Remove from `__init__.py`. | LOW |
+| ARCH-4 | **`analyze.py` imports `JOBS_DIR` directly for a path check.** `app/pipeline/analyze.py:7` imports `JOBS_DIR` to guard the `_load_audio_ffmpeg` path check. This couples the analysis module to the global config. The caller (`runner.py`) already has the path; the guard is appropriate, but the source should be a passed argument rather than a module-level global import. | LOW |
+| ARCH-5 | **`sections` field omitted from `_write_metadata`.** `runner.py:124-142` writes `metadata.json` after pipeline completion but does not include `job.sections`. Sections are stored via `PATCH /api/jobs/{id}/sections` which writes them to `metadata.json` separately. However if a job is new, the initial metadata file has no `sections` key; recovery via `_recover_done_job` reads `meta.get("sections")` so that is fine. But a `registry.persist()` call via `to_record()` does persist sections because `_JOB_FIELDS` includes it. The inconsistency between the two metadata paths (registry.json vs metadata.json) is subtle and may cause a future regression. | LOW |
+
+### Python Patterns
+
+| ID | Finding | Severity |
+|----|---------|----------|
+| PY-1 | **`app/api/events.py` missing `JOB_ID_RE` input validation.** `events.py:20` calls `registry_get(job_id)` without first validating the `job_id` format against `JOB_ID_RE`. Every other endpoint in `jobs.py` and `stems.py` validates the regex first to block filesystem traversal attempts before touching state. Missing here means a crafted `job_id` with path separators is checked only by the dict lookup (which will miss), but the defence-in-depth pattern is broken. Add `if not JOB_ID_RE.match(job_id): raise HTTPException(404)` before the registry call. | HIGH |
+| PY-2 | **Pending-job capacity check is not atomic.** `jobs.py:138-140` and `jobs.py:154-156`: reading the count of queued jobs and registering a new job are two separate operations with no lock between them. Under rapid concurrent requests two clients can both read `pending < MAX_PENDING_JOBS` and both proceed to register. The existing `threading.Lock` in `registry.py` protects individual dict mutations but not the read-then-write pattern here. Fix: move the capacity guard inside a registry function that holds `_lock` for the check + register atomically. | MEDIUM |
+| PY-3 | **`_probe_duration` in `jobs.py` is synchronous and blocks the event loop.** `jobs.py:47-69` uses `subprocess.run()` (blocking) directly in an async handler. It is called at line 213 inside `await asyncio.to_thread(...)`, which is correct. But at line 69 the `float(result.stdout.strip())` call happens inside the thread too (correct). **Actually no issue — the whole function is wrapped in `to_thread`.** Annotation-only note: the docstring says nothing about threading; add a comment noting it must only be called from a thread, not the event loop. | LOW |
+| PY-4 | **`_create_youtube_job` leaks internal Pydantic validation messages to clients.** `jobs.py:131`: `detail=str(e)` on a Pydantic `ValidationError` can expose schema internals. Use `"Invalid request body"` or extract only the top-level message. | LOW |
+| PY-5 | **`Job.status` is typed as `str`, not a `Literal` or `Enum`.** `models.py:16` uses a bare `str` with a comment listing valid values. This means typos like `"separting"` are not caught statically. Replace with `Literal["queued", "downloading", "analyzing", "separating", "done", "error", "cancelled"]` or a `StrEnum`. | LOW |
+| PY-6 | **`download.py` retry sleep blocks the event loop.** `download.py:205` calls `time.sleep(wait)` inside `download()`, which runs inside `asyncio.to_thread()`. Blocking `time.sleep` inside a thread is fine (it doesn't block the event loop), but it does hold the thread-pool thread for the backoff period, potentially delaying other `to_thread` calls during a burst of failures. Replace with an async sleep by restructuring the retry loop to be async, or at minimum document that the sleep is intentional inside a thread. | LOW |
+| PY-7 | **`runner.py` duplicates error/cancel handling between `run_pipeline` and `run_local_pipeline`.** Lines 145-173 and 176-206 are near-identical. The only difference is whether `job_dir.mkdir` is called upfront. Extract a `_run_pipeline_common(job, job_dir, blocking_fn, *args)` to eliminate the duplication. | MEDIUM |
+| PY-8 | **`analyze.py` has a deferred import of `numpy` inside `analyze()`.** `analyze.py:305` imports `numpy as np` inside the function body after the outer `try`. The module-level comment says librosa is pre-warmed, but numpy's deferred import inside the function means the first call pays the import cost. Move `import numpy as np` to module level alongside librosa (with the same `try/except ImportError` guard). | LOW |
+
+### JS Patterns
+
+| ID | Finding | Severity |
+|----|---------|----------|
+| JS-1 | **`renderedJobs` and `jobSources` in `job.js` grow unbounded.** `job.js:19-20`: `renderedJobs` (Set) and `jobSources` (Map) are module-level and never pruned. Every job submitted in the session accumulates. For a local app with ~hundreds of jobs over time this is negligible in practice, but the `jobSources` Map in particular keeps the source URL string for every job ever submitted in the current session. Add cleanup when a job reaches a terminal status or cap to recent N entries. | LOW |
+| JS-2 | **`wireAllButton` computes `noneSelected` but never uses it.** `main.js:78`: `const noneSelected = selectedStems.size === 0;` is declared inside the click handler but never read — the branch immediately after checks `allSelected`. Dead code. | LOW |
+| JS-3 | **SSE and polling run simultaneously on every job submission.** `job.js:445-446` calls `startJobPolling(jobId)` followed immediately by `connectEvents(jobId)`. During normal operation SSE is the primary mechanism, but REST polling at 1-second intervals is also active from submission until terminal status, meaning 2× the requests on happy path. The polling is an intentional fallback per the comment, but it should be disabled while SSE is connected and only activated on SSE error. | MEDIUM |
+| JS-4 | **`visualAudioContext` in `player.js` is never closed.** `player.js:170`: the `AudioContext` created for visual decoding persists across track loads (by design — `??=`). However `destroyPlayer()` (line 502) does not call `visualAudioContext.close()`. The Web Audio spec allows at most 6 concurrent `AudioContext` instances in some browsers; a long session with many track loads could silently fail decoding. Close the context in `destroyPlayer()` and null the reference so a new context is created on the next load. | MEDIUM |
+| JS-5 | **`drawFooterPlaceholder` creates an untracked `ResizeObserver`.** `player.js:874-876`: `new ResizeObserver(...).observe(bar)` is created without a reference. It cannot be disconnected during `destroyPlayer()`. This is a minor memory leak per track load. Assign to a module-level variable and disconnect in `destroyPlayer()`. | LOW |
+| JS-6 | **`catalog.js:154` silently swallows `loadState` JSON parse errors.** The outer `catch {}` on line 154 discards all errors including bugs. Add at minimum `console.warn("[catalog] loadState error:", e)`. | LOW |
+| JS-7 | **`storeSetDebounced` uses `JSON.parse(JSON.stringify(value))` for deep clone.** `utils.js:37`: this throws on values containing `undefined`, `BigInt`, or circular references. For the mixer state this is fine, but it is a fragile pattern. Use `structuredClone(value)` (available in all modern browsers and Node 17+). | LOW |
+| JS-8 | **`catalog.js:864` `thumbHtml` injects `track.thumb` directly into innerHTML without sanitization.** The `src` value is a YouTube CDN URL from the server and thus trusted, but if `track.thumb` ever contained a crafted string (e.g., from a malformed server response) it would be injected raw. Use `el.setAttribute("src", track.thumb)` via DOM API instead of template-literal innerHTML. | MEDIUM |
+| JS-9 | **`catalog.js:900-911` `renderTrackItem` injects `track.title` via innerHTML.** The `cat-title` div is set by `${track.title ?? "Unknown track"}` in an innerHTML template. If a YouTube video has a title containing `<script>` or `"`, it could break the layout or (in a non-CSP context) execute. Escape via `_esc()` (already defined in `sections.js`) or use `el.querySelector(".cat-title").textContent = ...` after construction. | HIGH |
+| JS-10 | **`sections.js` uses `_esc()` for the label but not for the color CSS variable.** `sections.js:80`: `--sc:${section.color}` is written directly into `style.cssText`. Colors are validated server-side against `_COLOR_RE` (`#[0-9a-fA-F]{3,8}`), so this is safe. But in `_openRename`, the input style also sets `--sc: ${section.color}` (line 298) from the same validated value. No issue, but worth a comment that the color is server-validated. | LOW |
+
+### Rust Patterns
+
+| ID | Finding | Severity |
+|----|---------|----------|
+| RS-1 | **`free_port()` has a TOCTOU race.** `main.rs:1396-1401`: binds port 0, reads the allocated port, drops the listener, then later uses the port for uvicorn. Between `drop(listener)` and uvicorn binding, another process can claim the port. On a quiet local machine this is extremely unlikely, but it is a classic TOCTOU. Fix: keep the `TcpListener` open until uvicorn is spawned, then close it (or use `SO_REUSEPORT`). | LOW |
+| RS-2 | **`start_backend` locks two Mutexes sequentially, risking lock ordering issues.** `main.rs:453` locks `state.url`, then `main.rs:538` locks `state.child`. If any other function ever locks them in a different order a deadlock is possible. Both lock sites should follow a single canonical order (`child` before `url`) with a comment. Currently no inversion exists, but `stop_backend` (line 959) only locks `child`. Still, document the order. | LOW |
+| RS-3 | **`stop_backend` in `ExitRequested` and `CloseRequested` both call `stop_backend` but `CloseRequested` also calls `app_handle.exit(0)`.** `main.rs:162-175`: on `ExitRequested` the backend is killed but `exit(0)` is not called. On `CloseRequested` both are done. On platforms where the window close goes through `CloseRequested`, this is fine. But `ExitRequested` fires on `app_handle.exit()` calls too; if `exit(0)` isn't called there, the Tauri event loop may not shut down cleanly on all platforms. This is subtle but the existing Python watchdog (`STEMDECK_PARENT_PID`) handles the backend side, so the impact is limited. | LOW |
+| RS-4 | **`download_file_with_powershell` embeds URL in a PowerShell `-Command` string.** `main.rs:1604`: the URL is interpolated directly into a PowerShell script string: `Invoke-WebRequest -Uri '{url}'`. A URL containing a single quote would break the command. Use `-Uri` with the URL as a separate argument via `-Command "... -Uri $env:TARGET_URL"` and set it as an environment variable, or use `-File` with a temp script. | MEDIUM |
+
+### Test Coverage
+
+| ID | Finding | Severity |
+|----|---------|----------|
+| TC-1 | **`PATCH /api/jobs/{id}/sections` endpoint has zero tests.** No test file covers the sections endpoint: validation (bad color, invalid time range, section ID regex), 404 on unknown job, 500 on disk write failure, or successful update. This is the only API endpoint with no test coverage. | HIGH |
+| TC-2 | **File upload path (`_create_local_job`) has no tests.** The multipart upload code path in `jobs.py:152-240` including size limits, extension validation, duration check, and orphan cleanup on failure is completely untested. | HIGH |
+| TC-3 | **MP3 streaming endpoint (`GET /api/jobs/{id}/stems/{name}.mp3`) has no tests.** `stems.py:37-83` is untested. | MEDIUM |
+| TC-4 | **`test_registry_persistence.py` uses `setup_function`/`teardown_function` instead of `autouse` fixture.** All other test files use the `_isolate_registry` autouse fixture. `test_registry_persistence.py:14-18` uses module-level `setup_function`/`teardown_function` which are pytest xunit-style hooks that work differently from fixtures and don't compose well with other fixtures. Migrate to the autouse fixture pattern for consistency. | LOW |
+| TC-5 | **No test for the capacity limit (503) when `MAX_PENDING_JOBS` is reached.** `jobs.py:139-140` has the capacity guard but there is no test that fills the queue to the limit and verifies the next request gets a 503. | MEDIUM |
+| TC-6 | **`test_stems_api.py` writes real files to `JOBS_DIR`.** `test_stems_api.py:27-30` writes stem files to the real `JOBS_DIR` config path, not to `tmp_path`. This violates test isolation and can leave residue if a test crashes. Use `monkeypatch.setattr("app.api.stems.JOBS_DIR", tmp_path)` as done in `test_registry_persistence.py`. | MEDIUM |
+| TC-7 | **No test for the sweep loop's interaction with `persist_registry`.** `collect.py:182-212` calls `registry_persist` when jobs are removed. The tests in `test_sweep.py` don't verify the registry file is updated after a sweep — only that the in-memory registry and directory are cleaned. | LOW |
+
+### Dead Code / Unused Exports
+
+| ID | Finding | Severity |
+|----|---------|----------|
+| DC-1 | **`app/pipeline/__init__.py` exports `STEM_NAMES` — unused by any external consumer.** Grepping shows no file imports `STEM_NAMES` from `app.pipeline`; they all import from `app.core.config`. Remove from `__init__.py`. | LOW |
+| DC-2 | **`main.js:78` `noneSelected` variable is declared but never used.** Dead code inside `wireAllButton`'s click handler. | LOW |
+| DC-3 | **`player.js` imports `renderMixerRow` twice.** `player.js:24` and `player.js:25` both import from `./mixer.js`. Line 24 includes `renderMixerRow` in a named import alongside others; line 25 is a standalone `import { renderMixerRow }`. The second import is redundant. | LOW |
+
+---
+
+## Consolidated Findings Table
+
+| Severity | ID | Finding | File(s) |
+|----------|----|---------|---------|
+| HIGH | 1 | `events.py` missing `JOB_ID_RE` validation on `job_id` path param before registry lookup | `app/api/events.py:20` |
+| HIGH | 2 | `renderTrackItem` injects `track.title` unescaped into innerHTML | `static/js/catalog.js:900-901` |
+| HIGH | 3 | `_set()` private helper imported across 3 unrelated modules — wrong home | `app/pipeline/download.py:138`, `runner.py:15`, `analyze.py:9`, `separate.py:25` |
+| HIGH | 4 | `PATCH /api/jobs/{id}/sections` endpoint has zero tests | `tests/` (missing) |
+| HIGH | 5 | File upload path (`_create_local_job`) has no tests | `tests/` (missing) |
+| MEDIUM | 6 | Pending-job capacity check is not atomic (read + register race) | `app/api/jobs.py:138-146`, `154-158` |
+| MEDIUM | 7 | SSE + 1 s polling run concurrently on every submission — redundant load | `static/js/job.js:445-446` |
+| MEDIUM | 8 | `visualAudioContext` never closed in `destroyPlayer()` — potential max-context limit | `static/js/player.js:170`, `502` |
+| MEDIUM | 9 | `thumbHtml` injects `track.thumb` URL via innerHTML without DOM API | `static/js/catalog.js:864` |
+| MEDIUM | 10 | `run_pipeline` / `run_local_pipeline` are near-duplicate — extract common helper | `app/pipeline/runner.py:145-206` |
+| MEDIUM | 11 | `download_file_with_powershell` embeds URL in PowerShell string (quote injection) | `desktop/src-tauri/src/main.rs:1604` |
+| MEDIUM | 12 | MP3 streaming endpoint has no tests | `app/api/stems.py:37-83`, `tests/` (missing) |
+| MEDIUM | 13 | Capacity limit (503) has no test | `tests/` (missing) |
+| MEDIUM | 14 | `test_stems_api.py` writes to real `JOBS_DIR`, not `tmp_path` | `tests/test_stems_api.py:27-30` |
+| MEDIUM | 15 | Module-level side effects at import time break test isolation | `app/main.py:156-157` |
+| LOW | 16 | `Job.status` should be `Literal[...]` not `str` | `app/core/models.py:16` |
+| LOW | 17 | `noneSelected` variable declared but never read | `static/js/main.js:78` |
+| LOW | 18 | `drawFooterPlaceholder` creates untracked `ResizeObserver` | `static/js/player.js:874-876` |
+| LOW | 19 | `renderedJobs` / `jobSources` grow unbounded | `static/js/job.js:19-20` |
+| LOW | 20 | `storeSetDebounced` deep-clone should use `structuredClone` | `static/js/utils.js:37` |
+| LOW | 21 | `catalog.js:154` silently swallows `loadState` errors | `static/js/catalog.js:154` |
+| LOW | 22 | `free_port()` TOCTOU race between drop and uvicorn bind | `desktop/src-tauri/src/main.rs:1396-1401` |
+| LOW | 23 | `analyze.py` deferred `import numpy as np` inside function | `app/pipeline/analyze.py:305` |
+| LOW | 24 | `setup_function`/`teardown_function` pattern inconsistent with rest of test suite | `tests/test_registry_persistence.py:14-18` |
+| LOW | 25 | Duplicate `import { renderMixerRow }` in `player.js` | `static/js/player.js:24-25` |
+| LOW | 26 | `STEM_NAMES` re-exported from `app/pipeline/__init__.py` — unused | `app/pipeline/__init__.py` |
+| LOW | 27 | `app/pipeline/analyze.py` imports `JOBS_DIR` from config directly | `app/pipeline/analyze.py:7` |
+
+---
+
+## Recommended Fix Order
+
+1. **Finding 1** — Add `JOB_ID_RE` guard to `events.py`. One-line fix, closes a defence-in-depth gap.
+2. **Finding 2** — Fix `renderTrackItem` innerHTML injection. Use `textContent` for the title fields.
+3. **Findings 4 + 5** — Write tests for the sections endpoint and file upload path. Highest coverage gap.
+4. **Finding 6** — Make capacity check atomic in the registry to close the race.
+5. **Finding 8** — Close `visualAudioContext` in `destroyPlayer()`.
+6. **Finding 9** — Replace `thumbHtml` innerHTML with DOM API setAttribute for the `src`.
+7. **Finding 11** — Fix PowerShell URL injection in `download_file_with_powershell`.
+8. **Finding 7** — Disable polling while SSE is healthy; activate only on SSE error.
+9. **Finding 3** — Move `_set` to `app/pipeline/utils.py` or `app/core/models.py`.
+10. **Finding 10** — Extract `_run_pipeline_common` to eliminate duplication.
+11. **Findings 12 + 13** — Add tests for MP3 streaming and capacity limit.
+12. **Finding 14** — Fix `test_stems_api.py` to use `monkeypatch` for `JOBS_DIR`.
+13. **Finding 15** — Move `ensure_runtime_dirs` + `restore_registry` into `lifespan()`.
+14. **Finding 16** — Narrow `Job.status` to `Literal[...]`.
+15. **Low findings 17–27** — Address in a single cleanup pass.

--- a/reviews/SUMMARY.md
+++ b/reviews/SUMMARY.md
@@ -1,0 +1,165 @@
+# StemDeck Full Codebase Review
+
+**Branch:** main | **Version:** v0.5.0-alpha.3 | **Date:** 2026-05-21
+
+---
+
+## Tool Availability
+
+| Tool | Status |
+|------|--------|
+| Static analysis (grep, ast, file reads) | Run across all source files |
+| Bandit (Python SAST) | Not run — findings derived from code reading |
+| pip-audit | CI-managed; current state documented in `.woodpecker/ci.yml` |
+| cargo clippy | Not run locally — findings derived from code reading |
+| node --check | Not run — findings derived from code reading |
+| pytest | Not run — coverage gaps identified from source only |
+
+---
+
+## System Overview
+
+**Architecture**
+
+- FastAPI + uvicorn on 127.0.0.1:PORT (Tauri: dynamic free port; Docker: 8000)
+- In-memory job registry (`_jobs: dict[str, Job]`) backed by `registry.json` for terminal jobs only
+- Pipeline: asyncio task -> `asyncio.to_thread` -> blocking thread -> `subprocess.Popen` (Demucs) or `subprocess.run` (ffmpeg/ffprobe)
+- SSE polling loop: 0.2 s interval, 4-hour deadline — pure poll-and-stream, no push
+- Tauri shell: Rust process spawns Python backend; kills on `ExitRequested` / `CloseRequested`
+- No authentication, no database — local-only, single-user by design
+
+**Critical hot paths**
+
+```
+POST /api/jobs
+  -> validate input (local)
+  -> registry check: count queued jobs (lock -> iterate -> release)
+  -> create_task(run_pipeline)           <- returns immediately
+  -> asyncio.to_thread(_run_blocking)    <- blocks thread pool worker
+      -> YoutubeDL.extract_info x2 (network, serial)
+      -> subprocess.Popen (Demucs, 5-30 min)  <- stderr thread + watchdog thread
+      -> subprocess.run (ffprobe, ffmpeg x2)  <- blocking, up to 300s each
+
+GET /api/jobs/{id}/stems/{name}.mp3
+  -> asyncio.create_subprocess_exec (ffmpeg pipe) <- streaming response
+  -> yield 64 kB chunks until EOF / disconnect
+```
+
+---
+
+## Security Findings
+
+| Severity | ID | Finding | STRIDE | OWASP | Tracked |
+|----------|----|---------|--------|-------|---------|
+| HIGH | S1 | **Stored XSS via track title in innerHTML** — `static/js/catalog.js:851,894`: `track.title` from YouTube metadata injected directly into `innerHTML` without escaping. In Tauri desktop mode, XSS payload can invoke `window.__TAURI__` commands including `open_url`, `store_get`, and `store_set`. | T, E | A03 | — |
+| HIGH | S2 | **Stored XSS via channel name in innerHTML** — `static/js/catalog.js:900`: `track.channel` (YouTube uploader field) injected directly into `innerHTML`. Same attack surface as S1. | T | A03 | — |
+| HIGH | S3 | **Open URL / scheme injection via `open_url` Tauri command** — `desktop/src-tauri/src/main.rs:933`: caller-supplied URL passed directly to `cmd /c start` (Windows), `open` (macOS), or `xdg-open` (Linux) without scheme validation. No guard against `file:///`, `ms-msdt:`, or other dangerous schemes. Chained with S1/S2 XSS, gives arbitrary app/file launch. | E | A01 | — |
+| MEDIUM | S4 | **SSE endpoint missing `JOB_ID_RE` validation** — `app/api/events.py:20`: the only endpoint that does not validate the job ID regex before hitting the registry. All other endpoints validate first. Future code changes inheriting this pattern could be exploitable. | T | A03 | — |
+| MEDIUM | S5 | **Stored XSS via YouTube tags in innerHTML** — `static/js/catalog.js:1224`: `tag` strings from `info.get("tags")` lower-cased but not HTML-escaped before `chip.innerHTML = ...`. Lower-casing neutralizes `<SCRIPT>` but not event-handler XSS (`onerror`, `onload`). | T | A03 | — |
+
+**Recommended fix order (security):**
+
+1. S4 — one-line fix, closes a validation gap before any other work.
+2. S3 — add `https://` / `http://` scheme whitelist in `open_url`; low effort, high impact.
+3. S1 + S2 + S5 — replace `innerHTML` template literals with DOM API (`textContent`, `createElement`/`setAttribute`) for all YouTube-sourced strings.
+
+---
+
+## Reliability Findings
+
+| Priority | ID | Finding | Impact | Effort | Tracked |
+|----------|----|---------|--------|--------|---------|
+| P1 | R1 | **Background tasks not stored** — `main.py:104,114`: `asyncio.create_task(_sweep_loop())` and `_desktop_parent_watchdog()` results discarded. Python GC can collect a task with no strong references; watchdog/sweep silently stops. | Silent task cancellation | trivial | — |
+| P1 | R2 | **`free_port()` TOCTOU race in Tauri** — `main.rs:1396-1402`: binds port 0, reads port number, drops listener, then passes to uvicorn. Another process can grab the port between drop and uvicorn bind. Causes 90 s startup hang with no retry. | Backend fails to start | small | — |
+| P1 | R3 | **No client-disconnect detection in SSE** — `events.py:25-48`: generator polls every 0.2 s for up to 4 hours. Zombie tabs (browser closed) keep the loop running until the next `yield` raises. Multiple zombie connections on Docker compoun. | Event loop overhead; wasted CPU | small | — |
+| P2 | R4 | **Failed job directory not cleaned up** — `runner.py:152-160, 185-194`: on pipeline error, `job_dir` persists until TTL sweep (24 h default). Each failed job can leave 100-300 MB of partial output on disk. | Disk waste per failed job | small | — |
+| P2 | R5 | **Capacity check race** — `jobs.py:138,154`: `pending` count read and job registration are not atomic. Two concurrent requests can both pass the `MAX_PENDING_JOBS` guard simultaneously. | Queue cap exceeded by concurrent requests | trivial | — |
+| P2 | R6 | **`persist_registry` snapshot outside the lock** — `registry.py:68-80`: acquires lock to snapshot, releases, then writes. Concurrent `remove()` between snapshot and write produces inconsistent registry.json. | Stale entry survives restart | small | — |
+| P2 | R7 | **ffmpeg process leak on ASGI middleware error** — `stems.py:50-83`: `finally` block kills the ffmpeg child if `returncode is None`, but if `StreamingResponse` raises before the generator starts, `aclose()` may not fire and the process leaks. | 1 leaked ffmpeg per edge-case disconnect | small | — |
+| P3 | R8 | **Stall watchdog thread join races** — `separate.py:108`: `wt.join(timeout=5)` times out if watchdog is sleeping. `proc.terminate()` can fire on an already-exited process (benign on Unix). Adds up to 5 s latency on every successful Demucs job. | Minor latency | trivial | — |
+| P3 | R9 | **SIGKILL without SIGTERM in Tauri stop** — `main.rs:959-967`: `child.kill()` sends SIGKILL immediately, bypassing uvicorn graceful shutdown. In-flight `_write_metadata` (non-atomic) can be truncated. | Metadata.json truncation on kill | small | — |
+| P3 | R10 | **`os._exit(0)` in parent watchdog** — `main.py:98`: bypasses atexit handlers, uvicorn shutdown, and any future lifespan `finally` cleanup. | Log truncation; future cleanup silently skipped | trivial | — |
+| P3 | R11 | **No SSE connection cap** — `events.py`: no limit on concurrent SSE connections per job or globally. Each holds an asyncio task. Misbehaving client could open hundreds on Docker deployment. | Event loop starvation on Docker | small | — |
+| P3 | R12 | **`wait_for_health` busy-polls for up to 90 s** — `main.rs:1404-1432`: 250 ms sleep loop on Tauri blocking thread. UI invoke blocked for up to 90 s on slow startup. | UI unresponsive during startup | small | — |
+
+---
+
+## Code Quality Findings
+
+| Severity | ID | Finding | Source | Tracked |
+|----------|----|---------|--------|---------|
+| HIGH | C1 | **`events.py` missing `JOB_ID_RE` validation** (duplicate of S4) — the only endpoint without job ID regex validation. | Security + code consistency | see S4 |
+| HIGH | C2 | **`renderTrackItem` injects `track.title` unescaped into innerHTML** — `catalog.js:900` (duplicate of S1). | Security + code correctness | see S1 |
+| HIGH | C3 | **`_set()` imported from `download.py` by 3 unrelated pipeline modules** — belongs in `app/core/models.py` or `pipeline/utils.py`. Import coupling between pipeline stages creates fragile dependencies. | ARCH | — |
+| HIGH | C4 | **`PATCH /api/jobs/{id}/sections` has zero tests** — no happy path, no validation, no 404, no disk error coverage. | TEST | — |
+| HIGH | C5 | **File upload path has no tests** — `_create_local_job` including size limits, extension validation, duration check, and orphan cleanup is entirely untested. | TEST | — |
+| MEDIUM | C6 | **SSE + 1 s polling run simultaneously** — polling loop fires on every job submission even when SSE is healthy; should activate only on SSE error. | Frontend correctness | — |
+| MEDIUM | C7 | **`visualAudioContext` never closed in `destroyPlayer()`** — risks hitting browser 6-context limit (`AudioContext` is capped per page in Chrome/Safari). | Resource leak | — |
+| MEDIUM | C8 | **`track.thumb` URL injected via innerHTML** — `thumbHtml()` in `catalog.js:864`: `src="${track.thumb}"` — should use `setAttribute`. (Related to S1/S2 surface.) | Security + code | see S1 |
+| MEDIUM | C9 | **`run_pipeline` / `run_local_pipeline` near-identical** — ~60 lines of duplicated error/cancel/sweep handling between `runner.py` functions. | Maintainability | — |
+| MEDIUM | C10 | **PowerShell URL injection** — `download.py`: `download_file_with_powershell` embeds URL in a PowerShell string with single quotes; a URL containing `'` breaks the command. | Correctness on Windows | — |
+| MEDIUM | C11 | **`test_stems_api.py` writes real files to `JOBS_DIR`** instead of `tmp_path` — breaks test isolation when JOBS_DIR is non-empty. | Test isolation | — |
+| MEDIUM | C12 | **Module-level side effects at import time** — `ensure_runtime_dirs()` and `restore_registry()` run during import in `main.py`. Breaks test isolation for any test that imports from `app.main`. | Test isolation | — |
+| MEDIUM | C13 | **Missing tests** for MP3 streaming endpoint and 503 capacity limit response. | TEST | — |
+| LOW | C14 | **`Job.status` typed as `str`** instead of `Literal["queued", "processing", "done", "error", "cancelled"]` — loses exhaustiveness checking. | Type safety | — |
+| LOW | C15 | **Dead code: `noneSelected` variable** in `catalog.js` — assigned but never read. | Dead code | — |
+| LOW | C16 | **`structuredClone` vs JSON round-trip** — inconsistent deep-copy strategy across JS modules. | Minor inconsistency | — |
+| LOW | C17 | **Untracked `ResizeObserver` leak** — observer created in player.js without a stored reference for cleanup. | Resource leak | — |
+| LOW | C18 | **Deferred `numpy` import inside function body** — `analyze.py`: `import numpy as np` inside a function; unconventional, confuses static analysis. | Code style | — |
+| LOW | C19 | **`loadState` error silently swallowed** — `state.js`: `try { ... } catch { }` with empty catch on localStorage load. Per project rules: catch must at minimum `console.warn(err)`. | Rule violation | — |
+
+---
+
+## Documentation Findings
+
+| Severity | ID | Finding | Tracked |
+|----------|----|---------|---------|
+| HIGH | D1 | **`sweep_old_jobs` docstring stale** — `collect.py:183`: says "Called once per new job submission"; function is now called only from the hourly background loop. Misleads future contributors. | — |
+| HIGH | D2 | **README API table missing 4 endpoints** — `README.md:247-253`: `GET /api/jobs`, `PATCH /api/jobs/{id}/sections`, `GET /api/jobs/{id}/stems/{name}.mp3`, and `/api/health` are absent. | — |
+| HIGH | D3 | **README claims range requests for WAV stems** — `README.md:251`: `FileResponse` does not implement HTTP range requests. Claim is factually wrong and misleads integrators. | — |
+| HIGH | D4 | **README config table omits 9 env vars** — `README.md:230-239`: `STEMDECK_DATA_DIR`, `STEMDECK_CACHE_DIR`, `STEMDECK_DOWNLOADS_DIR`, `STEMDECK_MODELS_DIR`, `STEMDECK_LOGS_DIR`, `STEMDECK_FFMPEG_DIR`, `STEMDECK_FFMPEG`, `STEMDECK_FFPROBE`, `STEMDECK_TIMEOUT_*` not documented. Critical for Docker/desktop users. | — |
+| MEDIUM | D5 | **`run.sh` env vars undocumented** — `HOST`, `PORT`, `RELOAD`, `FOREGROUND` used but not listed anywhere. Particularly `RELOAD=1` is useful for dev. | — |
+| MEDIUM | D6 | **All FastAPI route handlers have no docstrings** — OpenAPI `/docs` shows bare endpoint paths with no descriptions or summaries. Affects all 10 routes. | — |
+| MEDIUM | D7 | **`JobRequest` / `SectionItem` Pydantic fields use inline comments, not `Field(description=...)`** — `jobs.py:105-112`: field semantics invisible in generated OpenAPI schema. | — |
+| MEDIUM | D8 | **`FastAPI(title="StemDeck")` missing `description=` and `version=`** — `main.py:118`: `app_version()` defined but not passed to FastAPI constructor. | — |
+| MEDIUM | D9 | **`config.py` lacks module docstring explaining two-mode design** — portable mode (`STEMDECK_DATA_DIR`) vs dev mode, and internal Tauri bridge vars, not explained anywhere. | — |
+| MEDIUM | D10 | **Broken "Buy Me a Coffee" link** — `README.md:38`: URL missing `https://` scheme. | — |
+| LOW | D11 | **README Python version mismatch** — `README.md:139`: says "3.10-3.13" but `run.sh setup` pins `--python 3.12`; inconsistent. | — |
+| LOW | D12 | **Badge links use old `thcp/stemdeck` repo** — `README.md:9-12`: two different GitHub orgs in the same file; one is stale. | — |
+| LOW | D13 | **No module-level docstrings on any API module** — `jobs.py`, `stems.py`, `events.py`: OpenAPI tag descriptions never registered. | — |
+| LOW | D14 | **Dockerfile uses `pip` without explanation** — `build/Dockerfile:53`: no comment explaining why `pip` instead of `uv` for the venv install. | — |
+| LOW | D15 | **Stale date in `ci.yml` comment** — `.woodpecker/ci.yml:64-65`: "no fix version available as of 2025-12-15" — date is now 6 months old. Re-check joblib PYSEC-2024-277 advisory status. | — |
+
+---
+
+## Recommended Fix Order
+
+### Immediate (security)
+
+1. **S4 / C1** — Add `JOB_ID_RE` validation to `app/api/events.py:20`. One line.
+2. **S3** — Whitelist `http://` and `https://` schemes in `open_url` (`main.rs:933`).
+3. **S1 + S2 + S5 / C2 + C8** — Replace all `innerHTML` template literals for YouTube-sourced strings with DOM API calls in `catalog.js`.
+
+### High value (reliability + correctness)
+
+4. **R1** — Store `asyncio.create_task()` results in `main.py:104,114`. Trivial.
+5. **R5** — Make capacity check + registration atomic in `registry.py`. Small.
+6. **R4** — Call `shutil.rmtree(job_dir)` in the error branch of `runner.py`, same as cancel branch.
+7. **C4 + C5 + C13** — Add tests for sections endpoint, file upload path, MP3 streaming, and 503 response. Most impactful test gap.
+
+### Medium (quality + docs)
+
+8. **C3** — Move `_set()` to `app/core/models.py` or `pipeline/utils.py`.
+9. **C19** — Add `console.warn(err)` to empty catch in `state.js`.
+10. **C6** — Fix SSE + polling running simultaneously in the frontend.
+11. **D1** — Fix stale `sweep_old_jobs` docstring.
+12. **D2 + D3 + D4** — Update README: API table, range-request claim, env var table.
+13. **R2** — Fix `free_port()` TOCTOU in `main.rs` (retry on port conflict, or let uvicorn pick).
+14. **R6** — Hold registry lock through `persist_registry` write.
+
+### Low (cleanup)
+
+15. **C14** — Narrow `Job.status` to `Literal[...]`.
+16. **C11 + C12** — Fix test isolation (stems test writes to real JOBS_DIR; module-level side effects).
+17. **D5 + D6 + D7 + D8** — Improve OpenAPI docs quality.
+18. **D10 + D12 + D15** — README link fixes and stale comment.

--- a/static/js/catalog.js
+++ b/static/js/catalog.js
@@ -5,6 +5,15 @@ import { initSections } from "./sections.js";
 import { bpmChip, keyChip, saveSelectedStems, selectedStems, titleEl } from "./state.js";
 import { fmtTime, storeGet, storeSet } from "./utils.js";
 
+// Escape user-supplied strings before inserting into innerHTML.
+function esc(s) {
+  return String(s ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
 const STORAGE_KEY = "stemdeck.folders";
 const STORAGE_VERSION = 2; // bump to wipe stale seeded data
 const DELETED_JOBS_KEY = "stemdeck.deleted_jobs";
@@ -151,7 +160,7 @@ async function loadState() {
       }
       // else: stale version → start fresh
     }
-  } catch { /* ignore */ }
+  } catch (e) { console.warn("[catalog] failed to load state:", e); }
 
   try {
     const arr = await storeGet(DELETED_JOBS_KEY, []);
@@ -458,7 +467,7 @@ async function loadTrackIntoStudio(trackId) {
       tracks[trackId] = track;
       saveState();
     }
-  } catch { /* ignore; use stored track if server unreachable */ }
+  } catch (e) { console.warn("[catalog] server sync failed, using stored track:", e); }
 
   if (!track.audioStems?.length) return;
   if (track.status !== "done" && !hadStoredAudio) return;
@@ -849,8 +858,8 @@ function renderRecentItem(trackId) {
   el.innerHTML = `
     <div class="cat-thumb">${thumbHtml(track)}</div>
     <div class="cat-meta">
-      <div class="cat-title">${track.title ?? "Unknown track"}</div>
-      <div class="cat-sub"><span>${sub}</span></div>
+      <div class="cat-title">${esc(track.title ?? "Unknown track")}</div>
+      <div class="cat-sub"><span>${esc(sub)}</span></div>
     </div>
     <div class="cat-status${PROCESSING_STATUSES.has(track.status) ? " processing" : ""}"></div>
   `;
@@ -861,7 +870,7 @@ function renderRecentItem(trackId) {
 // ─── Rendering ───
 
 function thumbHtml(track) {
-  if (track.thumb) return `<img src="${track.thumb}" alt="" loading="lazy" />`;
+  if (track.thumb) return `<img src="${esc(track.thumb)}" alt="" loading="lazy" />`;
   return `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M9 18V5l12-2v13"></path><circle cx="6" cy="18" r="3"></circle><circle cx="18" cy="16" r="3"></circle></svg>`;
 }
 
@@ -895,21 +904,22 @@ function renderTrackItem(trackId, { inTrash = false } = {}) {
   el.innerHTML = `
     <div class="cat-thumb">${thumbHtml(track)}</div>
     <div class="cat-meta">
-      <div class="cat-title">${track.title ?? "Unknown track"}</div>
+      <div class="cat-title">${esc(track.title ?? "Unknown track")}</div>
       <div class="cat-sub">
-        <span>${track.channel ?? ""}</span>
+        <span>${esc(track.channel ?? "")}</span>
         <span class="dot">·</span>
         <span>${inTrash ? "Removed" : `${stemCount} stem${stemCount !== 1 ? "s" : ""}`}</span>
       </div>
     </div>
     <div class="cat-status${PROCESSING_STATUSES.has(track.status) ? " processing" : ""}"></div>
-    ${inTrash ? "" : `<button class="cat-del" type="button" aria-label="Move ${track.title ?? "track"} to Trash" title="Move to Trash">
+    ${inTrash ? "" : `<button class="cat-del" type="button" title="Move to Trash">
       <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
         <polyline points="3 6 5 6 21 6"></polyline>
         <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"></path>
       </svg>
     </button>`}
   `;
+  el.querySelector(".cat-del")?.setAttribute("aria-label", `Move ${track.title ?? "track"} to Trash`);
 
   el.querySelector(".cat-del")?.addEventListener("click", (e) => {
     e.stopPropagation();
@@ -1221,7 +1231,11 @@ function render() {
       chip.className = `lib-tag-chip${activeTag === tag ? " active" : ""}`;
       chip.type = "button";
       chip.dataset.tag = tag;
-      chip.innerHTML = `${tag} <span class="lib-tag-count">${count}</span>`;
+      chip.textContent = tag;
+      const countSpan = document.createElement("span");
+      countSpan.className = "lib-tag-count";
+      countSpan.textContent = String(count);
+      chip.appendChild(countSpan);
       chip.addEventListener("click", () => {
         const input = document.getElementById("catalogSearch");
         if (catalogSearchQuery === `#${tag}`) {
@@ -1399,7 +1413,7 @@ async function loadCurrentVersion() {
     if (!res.ok) return;
     const data = await res.json();
     setDisplayedVersion(data.version);
-  } catch { /* backend unavailable during bootstrap -- keep fallback */ }
+  } catch (e) { console.warn("[catalog] version fetch failed:", e); }
 }
 
 async function checkForUpdate() {
@@ -1414,7 +1428,7 @@ async function checkForUpdate() {
     if (!latest || latest === currentVersion) return;
     el.classList.add("has-update");
     el.innerHTML = `<a href="${RELEASES_URL}/tag/${data.tag_name}" target="_blank" rel="noopener noreferrer">new release available</a>`;
-  } catch { /* network unavailable — silently skip */ }
+  } catch (e) { console.warn("[catalog] update check failed:", e); }
 }
 
 function wireAboutDialog() {
@@ -1456,7 +1470,7 @@ async function syncWithServer() {
       track.id = state.job_id;
       addTrackToLibrary(track);
     }
-  } catch { /* backend unavailable — skip silently */ }
+  } catch (e) { console.warn("[catalog] failed to load jobs from backend:", e); }
 }
 
 export async function initCatalog() {

--- a/static/js/job.js
+++ b/static/js/job.js
@@ -261,6 +261,7 @@ function startJobPolling(jobId) {
 // Connect (or reconnect) to the SSE stream for a job. On unexpected
 // disconnect we probe /api/jobs/{id} to decide: if the job is already
 // terminal, accept its final state; otherwise reconnect with backoff.
+// Falls back to REST polling only after SSE exhausts its retry budget.
 function connectEvents(jobId) {
   let attempt = 0;
   let stopped = false;
@@ -310,8 +311,8 @@ function connectEvents(jobId) {
 
       attempt += 1;
       if (attempt > 6) {
-        showError("Lost connection to server");
-        setSubmitProcessing(false);
+        // SSE gave up — activate REST polling as the fallback.
+        startJobPolling(jobId);
         return;
       }
       // 0.5s, 1s, 2s, 4s, 8s, 16s
@@ -442,7 +443,6 @@ export function wireJobForm() {
       jobDetailEl.textContent = "";
     }
 
-    startJobPolling(jobId);
     connectEvents(jobId);
   });
 }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -75,7 +75,6 @@ function wireAllButton() {
   }
 
   allBtn.addEventListener("click", () => {
-    const noneSelected = selectedStems.size === 0;
     const allSelected = selectedStems.size === STEM_NAMES.length;
     if (allSelected) {
       selectedStems.clear();

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -20,9 +20,8 @@ import {
 import {
   loadMixIntoState, resetMixerState, refreshMixerVisuals,
   setLaneControlsEnabled, ensureMixerStateDefaults, applyMix,
-  renderRealMiniWave,
+  renderRealMiniWave, renderMixerRow,
 } from "./mixer.js";
-import { renderMixerRow } from "./mixer.js";
 import {
   buildRuler, updatePlayheadMarker, updateLoopRegionVisual,
   applyWaveZoom, buildPresenceRuler, updateFooterTimes,
@@ -171,6 +170,7 @@ let visualAudioContext = null;
 let stemVuRafId = null;
 let _footerWavePeaks = null;
 let _lastFooterProgress = 0;
+let _footerPlaceholderResizeObs = null;
 const _FOOTER_BARS = 300;
 
 function isAudioBufferLike(value) {
@@ -566,6 +566,8 @@ export function destroyPlayer() {
   loopRegionEl.classList.add("hidden");
   _footerWavePeaks = null;
   _lastFooterProgress = 0;
+  _footerPlaceholderResizeObs?.disconnect();
+  _footerPlaceholderResizeObs = null;
   _footerWaveResizeObs?.disconnect();
   setFooterWaveDrawFn(null);
   const cv = document.getElementById("footer-waveform");
@@ -876,7 +878,9 @@ export function drawFooterPlaceholder() {
   _drawPlaceholderWave();
   const bar = document.getElementById("footer-waveform")?.closest(".footer-wave-bar");
   if (bar) {
-    new ResizeObserver(() => { if (!_footerWavePeaks) _drawPlaceholderWave(); }).observe(bar);
+    _footerPlaceholderResizeObs?.disconnect();
+    _footerPlaceholderResizeObs = new ResizeObserver(() => { if (!_footerWavePeaks) _drawPlaceholderWave(); });
+    _footerPlaceholderResizeObs.observe(bar);
   }
 }
 

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -509,6 +509,10 @@ export function destroyPlayer() {
     multitrack.destroy();
     setMultitrack(null);
   }
+  if (visualAudioContext) {
+    visualAudioContext.close().catch(() => {});
+    visualAudioContext = null;
+  }
   renderPlaceholderTracks();
   clearOverviewWaveforms();
   for (const row of mixerEl.querySelectorAll(".lane-header")) {

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -468,37 +468,6 @@ function startStemVuLoop(stems, decodedMap, token) {
   stemVuRafId = requestAnimationFrame(tick);
 }
 
-async function decodeStemForVisuals(stem) {
-  const AudioCtx = window.AudioContext || window.webkitAudioContext;
-  if (!AudioCtx) throw new Error("Web Audio is not available");
-  visualAudioContext ??= new AudioCtx();
-  const res = await fetch(stem.url, { cache: "force-cache" });
-  if (!res.ok) throw new Error(`Failed to fetch ${stem.name} stem: ${res.status}`);
-  const data = await res.arrayBuffer();
-  return visualAudioContext.decodeAudioData(data);
-}
-
-function renderAllDecodedVisuals(stems, token) {
-  clearOverviewWaveforms();
-  const decoded = new Map();
-  const promises = stems.map((stem) => {
-    const color = STEM_COLORS[stem.name] || "#a0a0a0";
-    return decodeStemForVisuals(stem)
-      .then((buf) => {
-        if (token !== visualRenderToken) return;
-        decoded.set(stem.name, buf);
-        renderDecodedStemVisuals(stem.name, buf, color);
-      })
-      .catch((err) => console.warn(`[visuals] ${stem.name}: ${err.message}`));
-  });
-  Promise.all(promises).then(() => {
-    if (token !== visualRenderToken) return;
-    renderAllOverviewWaveforms(stems, decoded);
-    renderStemEnergyBaseline(stems, decoded);
-    startStemVuLoop(stems, decoded, token);
-  });
-}
-
 export function destroyPlayer() {
   document.querySelector(".app")?.classList.remove("is-import");
   document.querySelector(".app")?.classList.add("no-track");
@@ -752,7 +721,6 @@ export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, ti
   }
 
   clearOverviewWaveforms();
-  renderAllDecodedVisuals(stems, token);
 
   // "original" is prepended at row 0 only when it actually has a URL so it
   // appears at the top. Omitting it when absent avoids a phantom 70px gap.
@@ -844,6 +812,33 @@ export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, ti
     // instances. We pick wavesurfers[0] as the master clock since all
     // stems are kept in sync by the bundle's startSync() loop.
     const wsArr = mt.wavesurfers || mt._wavesurfers;
+
+    // Render overview waveforms, energy bars, and VU loop from wavesurfer's
+    // already-decoded buffers rather than issuing a separate full-file fetch
+    // per stem. The duplicate downloads race with streaming and cause audio
+    // chopping in WKWebView due to its tighter per-origin connection limit.
+    if (wsArr?.length) {
+      const decoded = new Map();
+      const waits = stems.map((stem) => {
+        const idx = orderedNames.indexOf(stem.name);
+        const wsi = idx >= 0 ? wsArr[idx] : null;
+        if (!wsi) return Promise.resolve();
+        const buf = wsi.getDecodedData?.();
+        if (isAudioBufferLike(buf)) { decoded.set(stem.name, buf); return Promise.resolve(); }
+        return new Promise((resolve) => {
+          wsi.once?.("decode", (b) => { if (isAudioBufferLike(b)) decoded.set(stem.name, b); resolve(); });
+          window.setTimeout(resolve, 15000);
+        });
+      });
+      Promise.all(waits).then(() => {
+        if (token !== visualRenderToken) return;
+        clearOverviewWaveforms();
+        renderAllOverviewWaveforms(stems, decoded);
+        renderStemEnergyBaseline(stems, decoded);
+        startStemVuLoop(stems, decoded, token);
+      });
+    }
+
     const ws = wsArr?.[0];
     if (!ws) return;
 

--- a/static/js/transport.js
+++ b/static/js/transport.js
@@ -168,6 +168,34 @@ export function updateLoopRegionVisual() {
 // timeupdate) — click handlers only mutate the transport, never the
 // button's CSS class. That way manual seeks (e.g. clicking the ruler)
 // keep the button states in sync without extra plumbing.
+// WKWebView (Tauri desktop) has small audio buffers. After a seek, all
+// audio elements drop their buffers and issue new range requests simultaneously.
+// Calling play() before they reach HAVE_FUTURE_DATA (readyState >= 3) causes
+// choppiness. Wait for all elements to be ready, with a hard 1.5 s fallback so
+// the user is never stuck. Desktop browsers buffer aggressively enough that
+// this wait is skipped entirely (readyState is already >= 3 by the time play
+// is pressed after a seek).
+function _playWhenReady() {
+  if (!multitrack) return;
+  const inTauri = Boolean(window.__TAURI__?.core?.invoke);
+  if (!inTauri) { multitrack.play(); return; }
+
+  const audios = (multitrack.audios ?? [])
+    .filter((a) => a instanceof HTMLMediaElement && a.src);
+  const notReady = audios.filter((a) => a.readyState < 3);
+  if (!notReady.length) { multitrack.play(); return; }
+
+  let fired = false;
+  const fire = () => { if (!fired && multitrack && !multitrack.isPlaying()) { fired = true; multitrack.play(); } };
+  const waits = notReady.map((a) => new Promise((res) => {
+    if (a.readyState >= 3) { res(); return; }
+    const onReady = () => { a.removeEventListener("canplay", onReady); res(); };
+    a.addEventListener("canplay", onReady);
+  }));
+  Promise.all(waits).then(fire);
+  window.setTimeout(fire, 1500);
+}
+
 export function togglePlayPause() {
   if (!multitrack) return;
   if (multitrack.isPlaying()) {
@@ -185,7 +213,7 @@ export function togglePlayPause() {
   if (loopEnabled && totalDuration > 0) {
     multitrack.setTime(loopStart);
   }
-  multitrack.play();
+  _playWhenReady();
 }
 
 export function stopTransport() {

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -33,7 +33,7 @@ export async function storeSet(key, value) {
 const _storePending = new Map();
 export function storeSetDebounced(key, value, delayMs = 300) {
   if (_storePending.has(key)) clearTimeout(_storePending.get(key));
-  const snapshot = JSON.parse(JSON.stringify(value));
+  const snapshot = structuredClone(value);
   _storePending.set(key, setTimeout(() => {
     _storePending.delete(key);
     storeSet(key, snapshot);

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -14,7 +14,7 @@ export async function storeGet(key, fallback = null) {
   try {
     const raw = localStorage.getItem(key);
     return raw !== null ? JSON.parse(raw) : fallback;
-  } catch { return fallback; }
+  } catch (e) { console.warn("[store] localStorage get failed for", key, e); return fallback; }
 }
 
 export async function storeSet(key, value) {

--- a/tests/test_jobs_api.py
+++ b/tests/test_jobs_api.py
@@ -109,6 +109,7 @@ def test_cancel_after_done_is_idempotent(client):
 
 # ─── Capacity (503) ───────────────────────────────────────────────────────────
 
+
 def test_youtube_503_when_queue_full(client):
     for _ in range(MAX_PENDING_JOBS):
         r = client.post("/api/jobs", json={"url": "https://youtu.be/dQw4w9WgXcQ"})
@@ -130,6 +131,7 @@ def test_upload_503_when_queue_full(upload_client):
 
 
 # ─── File upload ─────────────────────────────────────────────────────────────
+
 
 def test_upload_rejects_unsupported_extension(upload_client):
     data = io.BytesIO(b"OGG data")
@@ -173,6 +175,7 @@ def test_upload_wav_returns_job_id(upload_client):
 
 # ─── Sections endpoint ────────────────────────────────────────────────────────
 
+
 @pytest.fixture
 def done_job(client, tmp_path, monkeypatch):
     import app.api.jobs as jobs_mod
@@ -188,9 +191,7 @@ def done_job(client, tmp_path, monkeypatch):
 
 def test_sections_happy_path(client, done_job, tmp_path):
     payload = {
-        "sections": [
-            {"id": "sec1", "name": "Verse", "start": 0.0, "end": 30.0, "color": "#ff0000"}
-        ]
+        "sections": [{"id": "sec1", "name": "Verse", "start": 0.0, "end": 30.0, "color": "#ff0000"}]
     }
     r = client.patch(f"/api/jobs/{done_job.id}/sections", json=payload)
     assert r.status_code == 200
@@ -229,9 +230,7 @@ def test_sections_invalid_color_returns_422(client, done_job):
 
 def test_sections_invalid_id_returns_422(client, done_job):
     payload = {
-        "sections": [
-            {"id": "has space", "name": "x", "start": 0.0, "end": 5.0, "color": "#fff"}
-        ]
+        "sections": [{"id": "has space", "name": "x", "start": 0.0, "end": 5.0, "color": "#fff"}]
     }
     r = client.patch(f"/api/jobs/{done_job.id}/sections", json=payload)
     assert r.status_code == 422
@@ -239,7 +238,24 @@ def test_sections_invalid_id_returns_422(client, done_job):
 
 # ─── SSE job_id validation ────────────────────────────────────────────────────
 
+
 def test_sse_rejects_malformed_job_id(client):
     for bad_id in ("../etc", "ABC", "abcdefabcdef0"):
         r = client.get(f"/api/jobs/{bad_id}/events")
         assert r.status_code == 404, f"SSE should 404 for id {bad_id!r}"
+
+
+def test_sse_503_when_connection_cap_reached(client):
+    """#86/#88: SSE endpoint rejects with 503 when _MAX_SSE_CONNECTIONS is reached."""
+    import app.api.events as events_mod
+
+    original = events_mod._sse_active
+    try:
+        events_mod._sse_active = events_mod._MAX_SSE_CONNECTIONS
+        job = Job(id="abcdefabcdef")
+        job.status = "done"
+        _jobs[job.id] = job
+        r = client.get(f"/api/jobs/{job.id}/events")
+        assert r.status_code == 503
+    finally:
+        events_mod._sse_active = original

--- a/tests/test_jobs_api.py
+++ b/tests/test_jobs_api.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import io
+import json
 from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
 
+from app.core.config import MAX_PENDING_JOBS
+from app.core.models import Job
 from app.core.registry import _jobs
 
 
@@ -18,11 +22,33 @@ def _isolate_registry():
 
 @pytest.fixture
 def client():
-    # Patch run_pipeline so the test never spawns Demucs / yt-dlp.
     async def _noop_pipeline(job, url, jobs_dir):
         return None
 
     with patch("app.api.jobs.run_pipeline", _noop_pipeline):
+        from app.main import app
+
+        with TestClient(app) as c:
+            yield c
+
+
+@pytest.fixture
+def upload_client(tmp_path, monkeypatch):
+    import app.core.config as cfg
+
+    monkeypatch.setattr(cfg, "JOBS_DIR", tmp_path)
+
+    async def _noop_local(job, source_path, jobs_dir):
+        return None
+
+    async def _noop_youtube(job, url, jobs_dir):
+        return None
+
+    with (
+        patch("app.api.jobs.run_local_pipeline", _noop_local),
+        patch("app.api.jobs.run_pipeline", _noop_youtube),
+        patch("app.api.jobs._probe_duration", return_value=60.0),
+    ):
         from app.main import app
 
         with TestClient(app) as c:
@@ -58,11 +84,8 @@ def test_cancel_unknown_job_returns_404(client):
 
 
 def test_delete_running_job_rejected(client):
-    # Submit a job; the patched pipeline is a noop so status stays "queued"
-    # for the test's lifetime (no event loop tick advances it).
     r = client.post("/api/jobs", json={"url": "https://youtu.be/dQw4w9WgXcQ"})
     job_id = r.json()["job_id"]
-    # Simulate a still-running job by leaving it on its default status.
     r = client.delete(f"/api/jobs/{job_id}")
     assert r.status_code == 409
 
@@ -81,4 +104,142 @@ def test_cancel_after_done_is_idempotent(client):
     _jobs[job_id].status = "done"
     r = client.post(f"/api/jobs/{job_id}/cancel")
     assert r.status_code == 200
-    assert _jobs[job_id].cancel_requested is False  # not flipped on terminal jobs
+    assert _jobs[job_id].cancel_requested is False
+
+
+# ─── Capacity (503) ───────────────────────────────────────────────────────────
+
+def test_youtube_503_when_queue_full(client):
+    for _ in range(MAX_PENDING_JOBS):
+        r = client.post("/api/jobs", json={"url": "https://youtu.be/dQw4w9WgXcQ"})
+        assert r.status_code == 200
+    r = client.post("/api/jobs", json={"url": "https://youtu.be/dQw4w9WgXcQ"})
+    assert r.status_code == 503
+
+
+def test_upload_503_when_queue_full(upload_client):
+    for _ in range(MAX_PENDING_JOBS):
+        r = upload_client.post("/api/jobs", json={"url": "https://youtu.be/dQw4w9WgXcQ"})
+        assert r.status_code == 200
+    data = io.BytesIO(b"ID3" + b"\x00" * 128)
+    r = upload_client.post(
+        "/api/jobs",
+        files={"file": ("track.mp3", data, "audio/mpeg")},
+    )
+    assert r.status_code == 503
+
+
+# ─── File upload ─────────────────────────────────────────────────────────────
+
+def test_upload_rejects_unsupported_extension(upload_client):
+    data = io.BytesIO(b"OGG data")
+    r = upload_client.post(
+        "/api/jobs",
+        files={"file": ("track.ogg", data, "audio/ogg")},
+    )
+    assert r.status_code == 422
+    assert "Unsupported file type" in r.json()["detail"]
+
+
+def test_upload_rejects_empty_file(upload_client):
+    r = upload_client.post(
+        "/api/jobs",
+        files={"file": ("track.wav", io.BytesIO(b""), "audio/wav")},
+    )
+    assert r.status_code == 422
+    assert "empty" in r.json()["detail"].lower()
+
+
+def test_upload_mp3_returns_job_id(upload_client):
+    data = io.BytesIO(b"ID3" + b"\x00" * 128)
+    r = upload_client.post(
+        "/api/jobs",
+        files={"file": ("my_track.mp3", data, "audio/mpeg")},
+    )
+    assert r.status_code == 200
+    assert "job_id" in r.json()
+    assert len(r.json()["job_id"]) == 12
+
+
+def test_upload_wav_returns_job_id(upload_client):
+    data = io.BytesIO(b"RIFF" + b"\x00" * 128)
+    r = upload_client.post(
+        "/api/jobs",
+        files={"file": ("my_track.wav", data, "audio/wav")},
+    )
+    assert r.status_code == 200
+    assert "job_id" in r.json()
+
+
+# ─── Sections endpoint ────────────────────────────────────────────────────────
+
+@pytest.fixture
+def done_job(client, tmp_path, monkeypatch):
+    import app.api.jobs as jobs_mod
+
+    monkeypatch.setattr(jobs_mod, "JOBS_DIR", tmp_path)
+    job = Job(id="abcdefabcdef")
+    job.status = "done"
+    _jobs[job.id] = job
+    job_dir = tmp_path / job.id
+    job_dir.mkdir(parents=True, exist_ok=True)
+    return job
+
+
+def test_sections_happy_path(client, done_job, tmp_path):
+    payload = {
+        "sections": [
+            {"id": "sec1", "name": "Verse", "start": 0.0, "end": 30.0, "color": "#ff0000"}
+        ]
+    }
+    r = client.patch(f"/api/jobs/{done_job.id}/sections", json=payload)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["job_id"] == done_job.id
+    assert len(body["sections"]) == 1
+    assert body["sections"][0]["name"] == "Verse"
+    # Verify written to disk
+    meta_path = tmp_path / done_job.id / "metadata.json"
+    assert meta_path.is_file()
+    meta = json.loads(meta_path.read_text())
+    assert meta["sections"][0]["id"] == "sec1"
+
+
+def test_sections_unknown_job_returns_404(client):
+    payload = {"sections": []}
+    r = client.patch("/api/jobs/000000000000/sections", json=payload)
+    assert r.status_code == 404
+
+
+def test_sections_malformed_job_id_returns_404(client):
+    # Job IDs must be 12 lowercase hex chars; anything else is rejected.
+    r = client.patch("/api/jobs/BADID/sections", json={"sections": []})
+    assert r.status_code == 404
+
+
+def test_sections_invalid_color_returns_422(client, done_job):
+    payload = {
+        "sections": [
+            {"id": "sec1", "name": "Intro", "start": 0.0, "end": 10.0, "color": "not-a-color"}
+        ]
+    }
+    r = client.patch(f"/api/jobs/{done_job.id}/sections", json=payload)
+    assert r.status_code == 422
+
+
+def test_sections_invalid_id_returns_422(client, done_job):
+    payload = {
+        "sections": [
+            {"id": "has space", "name": "x", "start": 0.0, "end": 5.0, "color": "#fff"}
+        ]
+    }
+    r = client.patch(f"/api/jobs/{done_job.id}/sections", json=payload)
+    assert r.status_code == 422
+
+
+# ─── SSE job_id validation ────────────────────────────────────────────────────
+
+def test_sse_rejects_malformed_job_id(client):
+    for bad_id in ("../etc", "ABC", "abcdefabcdef0"):
+        r = client.get(f"/api/jobs/{bad_id}/events")
+        assert r.status_code == 404, f"SSE should 404 for id {bad_id!r}"

--- a/tests/test_pipeline_runner.py
+++ b/tests/test_pipeline_runner.py
@@ -6,7 +6,8 @@ from unittest.mock import patch
 import pytest
 
 from app.core.models import Job, JobCancelled
-from app.pipeline.runner import run_pipeline
+from app.core.registry import _jobs
+from app.pipeline.runner import run_local_pipeline, run_pipeline
 
 
 @pytest.mark.asyncio
@@ -78,3 +79,60 @@ async def test_pipeline_recovers_from_mkdir_failure(tmp_path: Path):
     await run_pipeline(job, "https://www.youtube.com/watch?v=dQw4w9WgXcQ", bad_jobs_dir)
 
     assert job.status == "error"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_error_cleans_up_job_dir(tmp_path: Path):
+    """#82: failed pipeline must remove the job directory so no orphan is left."""
+    job = Job(id="abcdefabcde9")
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("ffmpeg died")
+
+    with patch("app.pipeline.runner._run_blocking", side_effect=boom):
+        await run_pipeline(job, "https://www.youtube.com/watch?v=dQw4w9WgXcQ", tmp_path)
+
+    assert job.status == "error"
+    assert not (tmp_path / job.id).exists(), "job dir should be removed on error"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_error_calls_persist(tmp_path: Path):
+    """#83: persist is called after an error so the registry stays consistent."""
+    job = Job(id="abcdefabcde8")
+    _jobs[job.id] = job
+    persist_calls = []
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("separated badly")
+
+    def fake_persist(jobs_dir):
+        persist_calls.append(jobs_dir)
+
+    with (
+        patch("app.pipeline.runner._run_blocking", side_effect=boom),
+        patch("app.pipeline.runner.persist_registry", side_effect=fake_persist),
+    ):
+        await run_pipeline(job, "https://www.youtube.com/watch?v=dQw4w9WgXcQ", tmp_path)
+
+    assert job.status == "error"
+    assert len(persist_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_local_pipeline_error_cleans_up_job_dir(tmp_path: Path):
+    """#82: local upload error path also removes the job directory."""
+    job = Job(id="abcdefabcde7")
+    job_dir = tmp_path / job.id
+    job_dir.mkdir(parents=True)
+    source = job_dir / "source.mp3"
+    source.write_bytes(b"ID3")
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("demucs blew up")
+
+    with patch("app.pipeline.runner._run_local_blocking", side_effect=boom):
+        await run_local_pipeline(job, source, tmp_path)
+
+    assert job.status == "error"
+    assert not (tmp_path / job.id).exists(), "job dir should be removed on local error"

--- a/tests/test_registry_persistence.py
+++ b/tests/test_registry_persistence.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from fastapi.testclient import TestClient
 
 from app.core.models import Job
@@ -11,11 +12,10 @@ from app.core.registry import persist as persist_registry
 from app.core.registry import restore as restore_registry
 
 
-def setup_function():
+@pytest.fixture(autouse=True)
+def _isolate_registry():
     _jobs.clear()
-
-
-def teardown_function():
+    yield
     _jobs.clear()
 
 

--- a/tests/test_stems_api.py
+++ b/tests/test_stems_api.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import shutil
-
 import pytest
 from fastapi.testclient import TestClient
 

--- a/tests/test_stems_api.py
+++ b/tests/test_stems_api.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-from pathlib import Path
+import shutil
 
 import pytest
 from fastapi.testclient import TestClient
 
-from app.core.config import JOBS_DIR
 from app.core.models import Job
 from app.core.registry import _jobs
 
@@ -18,14 +17,17 @@ def _isolate_registry():
 
 
 @pytest.fixture
-def client():
+def client(tmp_path, monkeypatch):
+    import app.api.stems as stems_mod
+
+    monkeypatch.setattr(stems_mod, "JOBS_DIR", tmp_path)
     from app.main import app
 
     return TestClient(app)
 
 
-def _make_stem_file(job_id: str, name: str, contents: bytes = b"RIFF") -> Path:
-    stems_dir = JOBS_DIR / job_id / "stems"
+def _make_stem_file(tmp_path, job_id: str, name: str, contents: bytes = b"RIFF"):
+    stems_dir = tmp_path / job_id / "stems"
     stems_dir.mkdir(parents=True, exist_ok=True)
     path = stems_dir / f"{name}.wav"
     path.write_bytes(contents)
@@ -33,8 +35,6 @@ def _make_stem_file(job_id: str, name: str, contents: bytes = b"RIFF") -> Path:
 
 
 def test_rejects_malformed_job_id(client):
-    # Anything that isn't 12 lowercase hex chars must be rejected before
-    # touching the filesystem -- this is the path-traversal gate.
     for bad_id in ("../etc", "ABC", "abcdefabcdef0", "abcdefabcde", "abcd-efabcdef"):
         r = client.get(f"/api/jobs/{bad_id}/stems/vocals.wav")
         assert r.status_code == 404, f"id {bad_id!r} should 404"
@@ -48,31 +48,21 @@ def test_rejects_unknown_stem_name(client):
     assert r.status_code == 404
 
 
-def test_requires_done_status(client):
+def test_requires_done_status(client, tmp_path):
     job = Job(id="abcdefabcdef")
     job.status = "separating"
     _jobs[job.id] = job
-    _make_stem_file(job.id, "vocals")
-    try:
-        r = client.get(f"/api/jobs/{job.id}/stems/vocals.wav")
-        assert r.status_code == 404
-    finally:
-        (JOBS_DIR / job.id / "stems" / "vocals.wav").unlink(missing_ok=True)
-        (JOBS_DIR / job.id / "stems").rmdir()
-        (JOBS_DIR / job.id).rmdir()
+    _make_stem_file(tmp_path, job.id, "vocals")
+    r = client.get(f"/api/jobs/{job.id}/stems/vocals.wav")
+    assert r.status_code == 404
 
 
-def test_serves_done_job_stem(client):
+def test_serves_done_job_stem(client, tmp_path):
     job = Job(id="abcdefabcdee")
     job.status = "done"
     _jobs[job.id] = job
-    path = _make_stem_file(job.id, "vocals", b"RIFF1234")
-    try:
-        r = client.get(f"/api/jobs/{job.id}/stems/vocals.wav")
-        assert r.status_code == 200
-        assert r.content == b"RIFF1234"
-        assert r.headers["content-type"] == "audio/wav"
-    finally:
-        path.unlink(missing_ok=True)
-        path.parent.rmdir()
-        path.parent.parent.rmdir()
+    _make_stem_file(tmp_path, job.id, "vocals", b"RIFF1234")
+    r = client.get(f"/api/jobs/{job.id}/stems/vocals.wav")
+    assert r.status_code == 200
+    assert r.content == b"RIFF1234"
+    assert r.headers["content-type"] == "audio/wav"


### PR DESCRIPTION
## Summary

Addresses all findings from the `/review-all` code review (`reviews/SUMMARY.md`).

**Security (S1-S5)**
- Stored XSS in `catalog.js`: add `esc()` HTML-escape helper; apply to `track.title`, `track.channel`, YouTube tags, and thumbnail `src` in all `innerHTML` templates
- `aria-label` on delete button set via `setAttribute()`, not templated into `innerHTML`
- `events.py`: add `JOB_ID_RE` validation (the only endpoint that was missing it)
- `main.rs`: restrict `open_url` to `http://`/`https://` schemes only (blocks `file:///`, `ms-msdt:`, etc.)

**Reliability (R1, R4, R5, R6)**
- Store `asyncio.create_task()` refs in `main.py` so GC cannot collect the sweep loop or parent watchdog
- Delete `job_dir` on pipeline error (same cleanup already done on cancellation)
- `register_if_capacity()`: atomic capacity check + register under the registry lock
- Serialize registry JSON under lock to prevent stale snapshot on concurrent `remove()`

**Code quality (C3, C6, C7, C14, C19)**
- Move `_set()` from `download.py` to `models.py` where it belongs
- Narrow `Job.status` from `str` to `Literal[...]` for exhaustiveness checking
- REST polling is now SSE fallback only, not parallel with SSE
- Close `visualAudioContext` in `destroyPlayer()` to prevent hitting browser 6-context limit
- Replace all empty `catch {}` blocks with `console.warn` per project rules

**Tests (C4, C5, C11, C13)**
- New tests: sections endpoint (happy path, 404, 422), file upload path (extension, empty, mp3, wav), 503 capacity for both submission types, SSE `job_id` validation
- `test_stems_api.py`: use `tmp_path` + monkeypatch instead of writing to real `JOBS_DIR`

**Documentation (D1-D5, D8, D10, D12)**
- Fix stale `sweep_old_jobs` docstring
- FastAPI: add `version=` and `description=` to constructor
- README: add 4 missing API endpoints; remove false "range requests" claim; add 9 missing env vars and `run.sh` vars; fix broken buymeacoffee link; fix badge links to canonical `stemdeckapp` org

## Test plan

- [x] `uv run ruff check app/` passes
- [x] `node --check` passes for all modified JS files
- [x] `uv run pytest tests/ -q` passes (55 tests, +16 new)