### PR TITLE
fix(#111): use explorer.exe to open URLs on Windows

### DIFF
--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -1,6 +1,4 @@
 use flate2::read::GzDecoder;
-#[cfg(unix)]
-use libc;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::{
@@ -940,9 +938,9 @@ fn open_url(url: String) -> Result<(), String> {
     }
     #[cfg(windows)]
     {
-        let mut cmd = Command::new("cmd");
-        cmd.args(["/c", "start", "", &url]);
-        hide_console_window(&mut cmd);
+        // Use explorer.exe directly to avoid cmd.exe interpreting '&' in query strings.
+        let mut cmd = Command::new("explorer.exe");
+        cmd.arg(&url);
         cmd.spawn()
             .map_err(|e| format!("failed to open URL: {e}"))?;
     }


### PR DESCRIPTION
Closes #111

## Summary

- `cmd /c start "" <url>` runs through `cmd.exe`, which interprets `&` as a command separator -- query strings with multiple params (e.g. `?start=12.035&end=25.0`) were silently truncated after the first param
- Replaced with `explorer.exe <url>` which passes the URL as a single argument with no shell interpretation
- Also removed a redundant `use libc;` import flagged by clippy

## Test plan

- [x] Export Region WAV on Windows: both `start` and `end` params arrive at the backend
- [x] Export Region MP3 on Windows: same
- [x] Export Mix (no params) on Windows: still opens correctly
- [x] macOS/Linux: unaffected (no change to those paths)