### PR TITLE
fix: update release pipeline repo from thcp to stemdeckapp

### DIFF
--- a/.woodpecker/macos-release.yml
+++ b/.woodpecker/macos-release.yml
@@ -134,7 +134,7 @@ steps:
         fi
       - |
         scan_note="macOS arm64 and x64 DMGs and runtime packs were built and inspected on a macOS Woodpecker agent before upload."
-        body="$(gh release view "$CI_COMMIT_TAG" --repo "thcp/stemdeck" --json body --jq ".body")"
+        body="$(gh release view "$CI_COMMIT_TAG" --repo "stemdeckapp/stemdeck" --json body --jq ".body")"
         case "$body" in
           *"$scan_note"*) ;;
           *)
@@ -144,12 +144,12 @@ steps:
               printf '### Artifact build\n\n'
               printf -- '- %s\n' "$scan_note"
             } > "$notes_path"
-            gh release edit "$CI_COMMIT_TAG" --repo "thcp/stemdeck" --notes-file "$notes_path"
+            gh release edit "$CI_COMMIT_TAG" --repo "stemdeckapp/stemdeck" --notes-file "$notes_path"
             rm -f "$notes_path"
             ;;
         esac
       - |
-        existing=$(gh release view "$CI_COMMIT_TAG" --repo "thcp/stemdeck" --json assets --jq '[.assets[].name] | join(" ")')
+        existing=$(gh release view "$CI_COMMIT_TAG" --repo "stemdeckapp/stemdeck" --json assets --jq '[.assets[].name] | join(" ")')
         if echo "$existing" | grep -q "StemDeck-macOS-arm64.dmg"; then
           echo "macOS assets already present for $CI_COMMIT_TAG — skipping upload (pre-release promotion)."
           exit 0
@@ -161,4 +161,4 @@ steps:
           ".build/macos-dist/StemDeck-macOS-x64.dmg" \
           ".build/StemDeck-runtime-macOS-x64.tar.zst" \
           ".build/macos-dist/SHA256SUMS-macOS-x64.txt" \
-          --repo "thcp/stemdeck"
+          --repo "stemdeckapp/stemdeck"

--- a/.woodpecker/windows-release.yml
+++ b/.woodpecker/windows-release.yml
@@ -96,16 +96,16 @@ steps:
         }
       - |
         $scanNote = "Windows portable packages were scanned with ClamAV in CI before upload."
-        $bodyRaw = gh release view "$env:CI_COMMIT_TAG" --repo "thcp/stemdeck" --json body --jq ".body"
+        $bodyRaw = gh release view "$env:CI_COMMIT_TAG" --repo "stemdeckapp/stemdeck" --json body --jq ".body"
         $body = ($bodyRaw -join "`n")
         if ($body -notlike "*$scanNote*") {
           $notesPath = Join-Path $env:TEMP "stemdeck-release-notes.md"
           $updatedBody = ($body.TrimEnd(), "", "### Artifact scan", "", "- $scanNote") -join "`n"
           Set-Content -Path $notesPath -Value $updatedBody -Encoding UTF8
-          gh release edit "$env:CI_COMMIT_TAG" --repo "thcp/stemdeck" --notes-file $notesPath
+          gh release edit "$env:CI_COMMIT_TAG" --repo "stemdeckapp/stemdeck" --notes-file $notesPath
         }
       - |
-        $existing = gh release view "$env:CI_COMMIT_TAG" --repo "thcp/stemdeck" --json assets --jq '[.assets[].name] | join(" ")'
+        $existing = gh release view "$env:CI_COMMIT_TAG" --repo "stemdeckapp/stemdeck" --json assets --jq '[.assets[].name] | join(" ")'
         if ($existing -like "*StemDeck-Windows-x64.zip*") {
           Write-Host "Windows assets already present for $env:CI_COMMIT_TAG — skipping upload (pre-release promotion)."
           exit 0
@@ -115,4 +115,4 @@ steps:
           "dist/StemDeck-Windows-x64.NVIDIA.zip.sha256" `
           "dist/StemDeck-Windows-x64.zip" `
           "dist/StemDeck-Windows-x64.zip.sha256" `
-          --repo "thcp/stemdeck"
+          --repo "stemdeckapp/stemdeck"


### PR DESCRIPTION
Both `windows-release.yml` and `macos-release.yml` were still referencing `thcp/stemdeck` in all `gh release` commands. Updated to `stemdeckapp/stemdeck`.