### PR TITLE
feat: native save dialog for audio exports (Windows + macOS)

### DIFF
--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = "1"
 sha2 = "0.10"
 tar = "0.4"
 tauri = { version = "2", features = [] }
+tauri-plugin-dialog = "2"
 tauri-plugin-store = "2"
 zip = { version = "2", default-features = false, features = ["deflate"] }
 zstd = "0.13"

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -3,5 +3,5 @@
   "identifier": "default",
   "description": "Default StemDeck desktop window permissions",
   "windows": ["main"],
-  "permissions": ["core:default"]
+  "permissions": ["core:default", "dialog:allow-save"]
 }

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -109,6 +109,7 @@ struct GpuSetup {
 
 fn main() {
     tauri::Builder::default()
+        .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_store::Builder::default().build())
         .setup(|app| {
             let data_dir = match local_data_dir() {
@@ -152,6 +153,7 @@ fn main() {
             ensure_torch_device,
             start_backend,
             open_url,
+            save_audio_file,
             store_get,
             store_set,
             mark_store_migration_done,
@@ -958,6 +960,35 @@ fn open_url(url: String) -> Result<(), String> {
             .spawn()
             .map_err(|e| format!("failed to open URL: {e}"))?;
     }
+    Ok(())
+}
+
+#[tauri::command]
+async fn save_audio_file(app: tauri::AppHandle, url: String, filename: String) -> Result<(), String> {
+    if !url.starts_with("http://") && !url.starts_with("https://") {
+        return Err("only http/https URLs are permitted".to_string());
+    }
+    use tauri_plugin_dialog::DialogExt;
+    let dest = app
+        .dialog()
+        .file()
+        .set_file_name(&filename)
+        .blocking_save_file();
+    let Some(file_path) = dest else {
+        return Ok(()); // user cancelled
+    };
+    let dest = file_path.into_path().map_err(|e| e.to_string())?;
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| format!("fetch failed: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("backend returned HTTP {}", resp.status()));
+    }
+    let bytes = resp.bytes().await.map_err(|e| format!("read failed: {e}"))?;
+    std::fs::write(&dest, &bytes).map_err(|e| format!("write failed: {e}"))?;
     Ok(())
 }
 

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -1011,7 +1011,7 @@ export function updateFooterTrack({ title, thumbnail, key, bpm, stemCount } = {}
 function _triggerDownload(url, filename) {
   const fullUrl = url.startsWith("http") ? url : `${location.origin}${url}`;
   if (window.__TAURI__?.core?.invoke) {
-    window.__TAURI__.core.invoke("open_url", { url: fullUrl });
+    window.__TAURI__.core.invoke("save_audio_file", { url: fullUrl, filename });
     return;
   }
   const a = document.createElement("a");


### PR DESCRIPTION
## Summary

Replaces the `open_url` browser-delegation approach with a proper native save dialog for all audio downloads in the desktop app.

- Adds `tauri-plugin-dialog` and a new `save_audio_file` Tauri command
- Command opens a native Save As dialog pre-filled with the suggested filename
- On confirm: fetches audio bytes from the local backend via reqwest and writes to the chosen path
- On cancel: no-op, no error
- Browser / self-hosted path (`<a download>`) is unchanged

## Changes

- `desktop/src-tauri/Cargo.toml` -- add `tauri-plugin-dialog = "2"`
- `desktop/src-tauri/capabilities/default.json` -- add `dialog:allow-save` permission
- `desktop/src-tauri/src/main.rs` -- register plugin, add `save_audio_file` async command
- `static/js/player.js` -- `_triggerDownload` calls `save_audio_file` instead of `open_url` in Tauri context

## Test plan

- [ ] Export Region WAV on desktop: native save dialog appears, file writes to chosen path
- [ ] Export Region MP3 on desktop: same
- [ ] Export Mix on desktop: same
- [ ] Cancel dialog: nothing happens, no error
- [ ] Self-hosted browser: `<a download>` behavior unchanged