### PR TITLE
fix: VU meter not animating when canplay fires before audio decode

### DIFF
--- a/static/js/player.js
+++ b/static/js/player.js
@@ -826,7 +826,7 @@ export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, ti
         const buf = wsi.getDecodedData?.();
         if (isAudioBufferLike(buf)) { decoded.set(stem.name, buf); return Promise.resolve(); }
         return new Promise((resolve) => {
-          wsi.once?.("decode", (b) => { if (isAudioBufferLike(b)) decoded.set(stem.name, b); resolve(); });
+          wsi.once?.("decode", () => { const buf = wsi.getDecodedData?.(); if (isAudioBufferLike(buf)) decoded.set(stem.name, buf); resolve(); });
           window.setTimeout(resolve, 15000);
         });
       });


### PR DESCRIPTION
## Root cause

The vendored `multitrack.js` emits the \`decode\` event with the track **duration** as its argument, not the AudioBuffer:

\`\`\`js
this.emit("decode", this.getDuration())
\`\`\`

The fallback path in \`startStemVuLoop\` was relying on the event argument being the buffer:

\`\`\`js
// BEFORE (broken)
wsi.once?.("decode", (b) => { if (isAudioBufferLike(b)) decoded.set(stem.name, b); resolve(); });
// b = duration (number) → isAudioBufferLike fails → decoded stays empty → no VU animation
\`\`\`

This path is only hit when \`canplay\` fires before Web Audio decode completes (slower/uncached audio). With fast/cached audio, \`getDecodedData()\` at line 826 returns the buffer immediately and the fallback is never reached -- which is why the bug was intermittent.

## Fix

Call \`wsi.getDecodedData()\` directly in the callback, same pattern already used in \`renderAllMiniWaves\`:

\`\`\`js
// AFTER (fixed)
wsi.once?.("decode", () => { const buf = wsi.getDecodedData?.(); if (isAudioBufferLike(buf)) decoded.set(stem.name, buf); resolve(); });
\`\`\`

## Test plan

- [ ] Load a track (fresh, uncached): VU meter bars animate while playing
- [ ] Load a cached track: VU meter bars animate while playing  
- [ ] Muted stem: its VU meter stays at zero
- [ ] Overview waveforms and energy baseline render correctly (unaffected code path)