### PR TITLE
feat: collapsible library, stacked export buttons, VU meter fix

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2044,6 +2044,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2707,6 +2708,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3166,7 +3191,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stemdeck"
-version = "0.5.0-alpha.3"
+version = "0.6.0-alpha.1"
 dependencies = [
  "flate2",
  "libc",
@@ -3177,6 +3202,7 @@ dependencies = [
  "tar",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tauri-plugin-store",
  "tempfile",
  "zip",
@@ -3479,6 +3505,48 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "url",
 ]
 
 [[package]]
@@ -4627,6 +4695,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -4658,11 +4735,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4696,6 +4790,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4706,6 +4806,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4720,10 +4826,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4738,6 +4856,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4748,6 +4872,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4762,6 +4892,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4772,6 +4908,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/static/css/daw.css
+++ b/static/css/daw.css
@@ -374,6 +374,8 @@ input, textarea { font-family: inherit; }
   background: var(--bg-2);
   border-right: 1px solid var(--border);
   display: flex;
+  overflow: hidden;
+  transition: width 0.28s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 /* Rail */
@@ -420,6 +422,8 @@ input, textarea { font-family: inherit; }
   gap: 10px;
   min-width: 0;
   overflow: hidden;
+  opacity: 1;
+  transition: opacity 0.15s ease;
 }
 
 /* Search */
@@ -663,7 +667,7 @@ input, textarea { font-family: inherit; }
 /* Collapsed sidebar strip */
 .cat-collapsed-strip { display: none; }
 .daw.cat-collapsed .sidebar { width: 56px; }
-.daw.cat-collapsed .sidebar-body { display: none; }
+.daw.cat-collapsed .sidebar-body { opacity: 0; pointer-events: none; visibility: hidden; }
 .daw.cat-collapsed .cat-collapsed-strip { display: flex; flex-direction: column; gap: 8px; align-items: center; padding: 8px 0; overflow-y: auto; }
 
 /* ═══════════════════════════════════
@@ -1628,6 +1632,11 @@ input, textarea { font-family: inherit; }
   display: flex; align-items: center; justify-content: flex-end; gap: 8px;
   min-width: 0;
 }
+.footer-export-stack {
+  display: flex; flex-direction: column; gap: 4px; align-items: stretch;
+}
+.footer-export-stack .footer-chip-wrap,
+.footer-export-stack .footer-chip { width: 100%; }
 
 /* Wave bar at the bottom of the footer */
 .footer-wave-bar {

--- a/static/index.html
+++ b/static/index.html
@@ -139,6 +139,11 @@
         <aside class="sidebar" id="catalogPanel">
           <!-- Rail -->
           <nav class="sidebar-rail" aria-label="Library navigation">
+            <button class="rail-btn rail-collapse" id="sidebarCollapseBtn" type="button" title="Toggle library" aria-label="Toggle library" aria-expanded="true">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
+                <line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/>
+              </svg>
+            </button>
             <button class="rail-btn rail-library active" id="appMenuBtn" type="button" title="Library" aria-label="Library" aria-pressed="true">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
                 <path d="M4 4h16v16H4z M4 9h16"/>
@@ -579,25 +584,7 @@
           </div>
 
           <div class="footer-chips">
-            <div class="footer-chip-wrap" id="footer-speed-wrap">
-              <button class="footer-chip" id="t-speed-btn" type="button" aria-haspopup="true" aria-expanded="false">
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-                  <circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>
-                </svg>
-                <span id="t-speed-label">Speed 1.0×</span>
-                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
-                  <polyline points="6 9 12 15 18 9"/>
-                </svg>
-              </button>
-              <div class="footer-chip-panel hidden" id="t-speed-panel" role="menu">
-                <button class="chip-panel-item" data-rate="0.5"  role="menuitem">0.5×</button>
-                <button class="chip-panel-item" data-rate="0.75" role="menuitem">0.75×</button>
-                <button class="chip-panel-item active" data-rate="1"    role="menuitem">1.0×</button>
-                <button class="chip-panel-item" data-rate="1.25" role="menuitem">1.25×</button>
-                <button class="chip-panel-item" data-rate="1.5"  role="menuitem">1.5×</button>
-                <button class="chip-panel-item" data-rate="2"    role="menuitem">2×</button>
-              </div>
-            </div>
+            <div class="footer-export-stack">
             <div class="footer-chip-wrap" id="footer-export-wrap">
               <button class="footer-chip footer-chip-primary" id="t-export-btn" type="button" aria-haspopup="true" aria-expanded="false">
                 <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
@@ -648,6 +635,7 @@
                 </button>
               </div>
             </div>
+            </div><!-- /.footer-export-stack -->
           </div>
 
         </div><!-- /.footer-content -->

--- a/static/index.html
+++ b/static/index.html
@@ -598,31 +598,6 @@
                 <button class="chip-panel-item" data-rate="2"    role="menuitem">2×</button>
               </div>
             </div>
-            <div class="footer-chip-wrap" id="footer-region-wrap">
-              <button class="footer-chip footer-chip-primary" id="t-region-btn" type="button" aria-haspopup="true" aria-expanded="false" disabled>
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-                  <circle cx="6" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><line x1="20" y1="4" x2="8.12" y2="15.88"/><line x1="14.47" y1="14.48" x2="20" y2="20"/><line x1="8.12" y1="8.12" x2="12" y2="12"/>
-                </svg>
-                Export Region
-                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
-                  <polyline points="6 9 12 15 18 9"/>
-                </svg>
-              </button>
-              <div class="footer-chip-panel hidden" id="t-region-panel" role="menu">
-                <button class="chip-panel-item" id="t-region-mp3" role="menuitem">
-                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-                    <path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/>
-                  </svg>
-                  MP3
-                </button>
-                <button class="chip-panel-item" id="t-region-wav" role="menuitem">
-                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/>
-                  </svg>
-                  WAV
-                </button>
-              </div>
-            </div>
             <div class="footer-chip-wrap" id="footer-export-wrap">
               <button class="footer-chip footer-chip-primary" id="t-export-btn" type="button" aria-haspopup="true" aria-expanded="false">
                 <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
@@ -641,6 +616,31 @@
                   MP3
                 </button>
                 <button class="chip-panel-item" id="t-export-wav" role="menuitem">
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/>
+                  </svg>
+                  WAV
+                </button>
+              </div>
+            </div>
+            <div class="footer-chip-wrap" id="footer-region-wrap">
+              <button class="footer-chip footer-chip-primary" id="t-region-btn" type="button" aria-haspopup="true" aria-expanded="false" disabled>
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                  <circle cx="6" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><line x1="20" y1="4" x2="8.12" y2="15.88"/><line x1="14.47" y1="14.48" x2="20" y2="20"/><line x1="8.12" y1="8.12" x2="12" y2="12"/>
+                </svg>
+                Export Region
+                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
+                  <polyline points="6 9 12 15 18 9"/>
+                </svg>
+              </button>
+              <div class="footer-chip-panel hidden" id="t-region-panel" role="menu">
+                <button class="chip-panel-item" id="t-region-mp3" role="menuitem">
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                    <path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/>
+                  </svg>
+                  MP3
+                </button>
+                <button class="chip-panel-item" id="t-region-wav" role="menuitem">
                   <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
                     <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/>
                   </svg>

--- a/static/js/catalog.js
+++ b/static/js/catalog.js
@@ -1260,23 +1260,37 @@ function render() {
 
 function wireCatalogToggle() {
   const toggle = document.getElementById("catalogToggle");
-  if (!toggle) return;
+  const collapseBtn = document.getElementById("sidebarCollapseBtn");
   const app = document.querySelector(".app");
   if (!app) return;
 
   const collapsed = localStorage.getItem("stemdeck.catalog.collapsed") === "1";
-  if (collapsed) app.classList.add("cat-collapsed");
+  if (collapsed) {
+    app.classList.add("cat-collapsed");
+    collapseBtn?.setAttribute("aria-expanded", "false");
+  }
 
-  toggle.addEventListener("click", (e) => {
-    // Only expand — never collapse from within the sidebar.
-    if (!app.classList.contains("cat-collapsed")) return;
-    app.classList.remove("cat-collapsed");
-    localStorage.setItem("stemdeck.catalog.collapsed", "0");
-    toggle.querySelector("input")?.focus();
+  function setSidebarCollapsed(isCollapsed) {
+    app.classList.toggle("cat-collapsed", isCollapsed);
+    collapseBtn?.setAttribute("aria-expanded", String(!isCollapsed));
+    localStorage.setItem("stemdeck.catalog.collapsed", isCollapsed ? "1" : "0");
+  }
+
+  collapseBtn?.addEventListener("click", () => {
+    setSidebarCollapsed(!app.classList.contains("cat-collapsed"));
   });
-  toggle.addEventListener("keydown", (e) => {
-    if (e.code === "Enter" || e.code === "Space") { e.preventDefault(); toggle.click(); }
-  });
+
+  if (toggle) {
+    toggle.addEventListener("click", (e) => {
+      // Only expand from within the sidebar body.
+      if (!app.classList.contains("cat-collapsed")) return;
+      setSidebarCollapsed(false);
+      toggle.querySelector("input")?.focus();
+    });
+    toggle.addEventListener("keydown", (e) => {
+      if (e.code === "Enter" || e.code === "Space") { e.preventDefault(); toggle.click(); }
+    });
+  }
 }
 
 function wireCatalogRailViews() {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -119,46 +119,6 @@ wireAppShellControls();
 // ─── Footer: speed dropdown, export dropdown, scrub seek ───
 
 function wireFooterControls() {
-  // ── Speed dropdown ──
-  const speedBtn   = document.getElementById("t-speed-btn");
-  const speedPanel = document.getElementById("t-speed-panel");
-  const speedLabel = document.getElementById("t-speed-label");
-
-  function applyRate(rate) {
-    const audios = multitrack?.audios;
-    if (audios?.length) {
-      for (const a of audios) {
-        const el = (a instanceof HTMLMediaElement) ? a : (a?.media ?? a?.getMediaElement?.());
-        if (!(el instanceof HTMLMediaElement)) continue;
-        el.playbackRate = rate;
-        if ("preservesPitch" in el)        el.preservesPitch    = true;
-        else if ("mozPreservesPitch" in el) el.mozPreservesPitch = true;
-      }
-    }
-    if (speedLabel) speedLabel.textContent = `Speed ${rate === 1 ? "1.0" : rate}×`;
-    speedPanel?.querySelectorAll(".chip-panel-item").forEach((btn) => {
-      btn.classList.toggle("active", parseFloat(btn.dataset.rate) === rate);
-    });
-  }
-
-  speedBtn?.addEventListener("click", (e) => {
-    e.stopPropagation();
-    const open = !speedPanel?.classList.contains("hidden");
-    closeAllChipPanels();
-    if (!open) {
-      speedPanel?.classList.remove("hidden");
-      speedBtn.setAttribute("aria-expanded", "true");
-    }
-  });
-
-  speedPanel?.addEventListener("click", (e) => {
-    const item = e.target.closest(".chip-panel-item[data-rate]");
-    if (!item) return;
-    applyRate(parseFloat(item.dataset.rate));
-    speedPanel.classList.add("hidden");
-    speedBtn?.setAttribute("aria-expanded", "false");
-  });
-
   // ── Export Region dropdown ──
   const regionBtn   = document.getElementById("t-region-btn");
   const regionPanel = document.getElementById("t-region-panel");

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -826,7 +826,7 @@ export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, ti
         const buf = wsi.getDecodedData?.();
         if (isAudioBufferLike(buf)) { decoded.set(stem.name, buf); return Promise.resolve(); }
         return new Promise((resolve) => {
-          wsi.once?.("decode", (b) => { if (isAudioBufferLike(b)) decoded.set(stem.name, b); resolve(); });
+          wsi.once?.("decode", () => { const buf = wsi.getDecodedData?.(); if (isAudioBufferLike(buf)) decoded.set(stem.name, buf); resolve(); });
           window.setTimeout(resolve, 15000);
         });
       });

--- a/uv.lock
+++ b/uv.lock
@@ -1765,7 +1765,7 @@ wheels = [
 
 [[package]]
 name = "stemdeck"
-version = "0.5.0a3"
+version = "0.6.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "demucs" },


### PR DESCRIPTION
## Changes

- **Collapsible library sidebar**: hamburger button at the top of the rail toggles the sidebar open/closed with a smooth 0.28s width transition; state persists in localStorage
- **Stacked export buttons**: Export Region is now stacked below Export Mix as equal-width buttons; Speed button removed
- **VU meter fix**: wavesurfer `decode` event emits duration (number), not AudioBuffer; switched to `getDecodedData()` to reliably get the buffer