### PR TITLE
chore: bump version to 0.6.0-alpha.2

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stemdeck-desktop",
-  "version": "0.6.0-alpha.1",
+  "version": "0.6.0-alpha.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stemdeck"
-version = "0.6.0-alpha.1"
+version = "0.6.0-alpha.2"
 description = "StemDeck desktop launcher"
 authors = ["StemDeck contributors"]
 edition = "2021"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "StemDeck",
-  "version": "0.6.0-alpha.1",
+  "version": "0.6.0-alpha.2",
   "identifier": "app.stemdeck.desktop",
   "build": {
     "frontendDist": "../ui",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stemdeck"
-version = "0.6.0-alpha.1"
+version = "0.6.0-alpha.2"
 description = "Paste a YouTube URL, get audio stems split into a DAW-style player."
 requires-python = ">=3.10,<3.14"
 dependencies = [

--- a/static/version.json
+++ b/static/version.json
@@ -1,1 +1,1 @@
-{ "version": "0.6.0-alpha.1" }
+{ "version": "0.6.0-alpha.2" }


### PR DESCRIPTION
Bumps all version files from 0.6.0-alpha.1 to 0.6.0-alpha.2.