### PR TITLE
fix: auto-update runtime on version mismatch

### DIFF
--- a/desktop/ui/setup.js
+++ b/desktop/ui/setup.js
@@ -178,7 +178,15 @@ async function runSetup() {
       return;
     }
 
-    if (!runtime.pythonReady) {
+    const runtimeStatus = await invoke("runtime_pack_status");
+    const expectedVersion = runtimeStatus.manifest?.version;
+    const installedVersion = runtimeStatus.installedVersion;
+    const versionMismatch = expectedVersion && installedVersion && expectedVersion !== installedVersion;
+
+    if (!runtime.pythonReady || versionMismatch) {
+      if (versionMismatch) {
+        setStatus(`Updating runtime from ${installedVersion} to ${expectedVersion}...`);
+      }
       await invoke("ensure_workspace");
       await installRuntimePack(runtime.appRoot);
       runtime = await invoke("probe_runtime");


### PR DESCRIPTION
Fixes #121

The runtime was only re-downloaded when Python was missing entirely. On upgrades (e.g. alpha.1 to alpha.2), the old runtime stayed in place and the About dialog showed the previous version.

Fix: read `installedVersion` and `manifest.version` from `runtime_pack_status` and force a re-download when they differ. Shows "Updating runtime from X to Y..." in the setup UI during the upgrade.