### PR TITLE
fix: stale track load race, all-stems-muted recovery, live update notification

### DIFF
--- a/.woodpecker/macos-release.yml
+++ b/.woodpecker/macos-release.yml
@@ -19,8 +19,10 @@ steps:
         printf '{ "version": "%s" }\n' "$VERSION" > static/version.json
         sed -i '' "s/^version = \".*\"/version = \"$VERSION\"/" desktop/src-tauri/Cargo.toml
         sed -i '' "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" desktop/src-tauri/tauri.conf.json
+        sed -i '' "s/^version = \".*\"/version = \"$VERSION\"/" pyproject.toml
+        sed -i '' "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" desktop/package.json
         echo "VERSION=$VERSION" > .macos-release.env
-        echo "Wrote version $VERSION to static/version.json, Cargo.toml, tauri.conf.json"
+        echo "Wrote version $VERSION to all version files"
 
   build-macos-arm64:
     image: bash

--- a/.woodpecker/version-bump.yml
+++ b/.woodpecker/version-bump.yml
@@ -1,0 +1,47 @@
+# Triggered on every tag push. Updates all 5 version files to match the tag
+# and commits the result back to main so self-hosted users get the correct
+# version after a plain `git pull`.
+
+when:
+  - event: tag
+
+labels:
+  platform: linux/amd64
+  backend: kubernetes
+
+steps:
+  bump-and-commit:
+    image: alpine/git
+    environment:
+      GITHUB_TOKEN:
+        from_secret: github_token
+    commands:
+      - |
+        if [ -z "${CI_COMMIT_TAG:-}" ]; then
+          echo "CI_COMMIT_TAG is not set" >&2
+          exit 1
+        fi
+        VERSION="${CI_COMMIT_TAG#v}"
+
+        printf '{ "version": "%s" }\n' "$VERSION" > static/version.json
+        sed -i "s/^version = \".*\"/version = \"$VERSION\"/" pyproject.toml
+        sed -i "s/^version = \".*\"/version = \"$VERSION\"/" desktop/src-tauri/Cargo.toml
+        sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" desktop/src-tauri/tauri.conf.json
+        sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" desktop/package.json
+
+        git config user.email "ci@stemdeck.app"
+        git config user.name "StemDeck CI"
+        git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/stemdeckapp/stemdeck.git"
+
+        git add static/version.json pyproject.toml \
+          desktop/src-tauri/Cargo.toml desktop/src-tauri/tauri.conf.json \
+          desktop/package.json
+
+        if git diff --cached --quiet; then
+          echo "Version files already at $VERSION — nothing to commit."
+          exit 0
+        fi
+
+        git commit -m "chore: bump version to $VERSION [skip ci]"
+        git push origin HEAD:main
+        echo "Pushed version $VERSION to main."

--- a/.woodpecker/windows-release.yml
+++ b/.woodpecker/windows-release.yml
@@ -20,7 +20,11 @@ steps:
           Set-Content "desktop/src-tauri/Cargo.toml"
         (Get-Content "desktop/src-tauri/tauri.conf.json") -replace '"version": "[^"]*"', "`"version`": `"$version`"" |
           Set-Content "desktop/src-tauri/tauri.conf.json"
-        Write-Host "Wrote version $version to static/version.json, Cargo.toml, tauri.conf.json"
+        (Get-Content "pyproject.toml") -replace '^version = ".*"', "version = `"$version`"" |
+          Set-Content "pyproject.toml"
+        (Get-Content "desktop/package.json") -replace '"version": "[^"]*"', "`"version`": `"$version`"" |
+          Set-Content "desktop/package.json"
+        Write-Host "Wrote version $version to all version files"
 
   build-windows-nvidia:
     depends_on:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
   <a href="https://discord.gg/JGk7FdZb9N"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord"></a>
   <a href="https://www.reddit.com/r/StemDeckApp/"><img src="https://img.shields.io/badge/Reddit-r%2FStemDeckApp-FF4500?style=flat-square&logo=reddit&logoColor=white" alt="Reddit"></a>
   <a href="https://www.instagram.com/stemdeck"><img src="https://img.shields.io/badge/Instagram-stemdeck-E4405F?style=flat-square&logo=instagram&logoColor=white" alt="Instagram"></a>
+  <a href="https://x.com/StemDeckApp"><img src="https://img.shields.io/badge/X-StemDeckApp-000000?style=flat-square&logo=x&logoColor=white" alt="X"></a>
   <a href="https://stemdeck.app"><img src="https://img.shields.io/badge/Website-stemdeck.app_(soon)-000000?style=flat-square&logo=safari&logoColor=white" alt="Website"></a>
 </div>
 
@@ -325,6 +326,7 @@ The author(s) of StemDeck provide this software "as is", without warranty of any
 | Discord | [discord.gg/JGk7FdZb9N](https://discord.gg/JGk7FdZb9N) |
 | Reddit | [r/StemDeckApp](https://www.reddit.com/r/StemDeckApp/) |
 | Instagram | [@stemdeck](https://www.instagram.com/stemdeck) |
+| X | [@StemDeckApp](https://x.com/StemDeckApp) |
 | Website | [stemdeck.app](https://stemdeck.app) *(coming soon)* |
 
 ---

--- a/static/css/daw.css
+++ b/static/css/daw.css
@@ -431,7 +431,7 @@ input, textarea { font-family: inherit; }
 .rail-btn svg { flex-shrink: 0; }
 .rail-btn span { white-space: nowrap; }
 .settings-coming-soon {
-  position: absolute; left: calc(100% + 8px); bottom: 48px;
+  position: fixed;
   background: var(--panel-2); border: 1px solid var(--border-strong);
   border-radius: var(--radius); padding: 8px 12px;
   font-size: 12px; color: var(--muted); white-space: nowrap;
@@ -1805,32 +1805,68 @@ input, textarea { font-family: inherit; }
 .about-backdrop {
   position: fixed; inset: 0; z-index: 100;
   display: grid; place-items: center;
-  background: rgba(3,8,13,0.55); backdrop-filter: blur(4px);
+  background: rgba(3,8,13,0.6); backdrop-filter: blur(6px);
 }
 .about-backdrop.hidden { display: none !important; }
 .about-card {
-  width: min(320px, calc(100vw - 32px));
+  width: min(300px, calc(100vw - 32px));
   background: var(--panel-2); border: 1px solid var(--border-strong);
-  border-radius: 14px; box-shadow: var(--shadow-panel);
-  padding: 24px; text-align: center;
-  position: relative;
+  border-radius: 18px; box-shadow: 0 24px 64px rgba(0,0,0,0.6);
+  padding: 28px 24px 24px; text-align: center;
+  position: relative; display: flex; flex-direction: column; align-items: center; gap: 0;
 }
 .about-close {
   position: absolute; top: 12px; right: 12px;
-  width: 28px; height: 28px;
+  width: 26px; height: 26px;
   background: transparent; border: 1px solid var(--border);
   border-radius: 6px; color: var(--muted);
-  font-size: 16px; cursor: pointer;
-  display: flex; align-items: center; justify-content: center;
+  cursor: pointer; display: flex; align-items: center; justify-content: center;
 }
 .about-close:hover { background: var(--panel-3); color: var(--fg); }
-.about-card h2 { margin: 0 0 8px; font-size: 20px; font-family: var(--font-mono); }
-.about-version { font-size: 13px; color: var(--muted); margin: 0 0 16px; }
-.about-link {
-  display: block; color: var(--accent); font-size: 13px;
-  text-decoration: none; font-family: var(--font-mono);
+.about-logo {
+  width: 56px; height: 56px; border-radius: 14px;
+  background: linear-gradient(135deg, rgba(139,92,246,0.2), rgba(244,183,64,0.15));
+  border: 1px solid rgba(139,92,246,0.25);
+  display: flex; align-items: center; justify-content: center;
+  color: var(--accent); margin-bottom: 14px;
 }
-.about-link:hover { text-decoration: underline; }
+.about-card h2 { margin: 0 0 4px; font-size: 18px; font-family: var(--font-mono); font-weight: 700; }
+.about-tagline { margin: 0 0 12px; font-size: 12px; color: var(--muted); }
+.about-version-badge {
+  display: inline-block; font-size: 11px; font-family: var(--font-mono);
+  color: var(--muted); background: var(--panel); border: 1px solid var(--border);
+  border-radius: 20px; padding: 2px 10px; margin-bottom: 20px;
+}
+.about-primary-links {
+  display: flex; gap: 8px; width: 100%; margin-bottom: 16px;
+}
+.about-link {
+  flex: 1; display: flex; align-items: center; justify-content: center; gap: 6px;
+  padding: 8px 10px; border-radius: 8px; font-size: 12px;
+  text-decoration: none; transition: background 0.15s;
+}
+.about-link-primary {
+  background: var(--accent); color: #000; font-weight: 600;
+}
+.about-link-primary:hover { filter: brightness(1.1); }
+.about-link-secondary {
+  background: var(--panel); border: 1px solid var(--border);
+  color: var(--fg-2);
+}
+.about-link-secondary:hover { background: var(--panel-3); color: var(--fg); }
+.about-divider {
+  width: 100%; height: 1px; background: var(--border); margin-bottom: 16px;
+}
+.about-socials {
+  display: flex; gap: 10px; align-items: center; justify-content: center;
+}
+.about-social-btn {
+  width: 36px; height: 36px; border-radius: 8px;
+  background: var(--panel); border: 1px solid var(--border);
+  display: flex; align-items: center; justify-content: center;
+  color: var(--muted); text-decoration: none; transition: all 0.15s;
+}
+.about-social-btn:hover { background: var(--panel-3); color: var(--fg); border-color: var(--border-strong); }
 
 /* ── Library sections (Recent · Stem Collections · Tags) ── */
 .lib-section {

--- a/static/css/daw.css
+++ b/static/css/daw.css
@@ -352,6 +352,24 @@ input, textarea { font-family: inherit; }
 .daw-notif-card-body { flex: 1; min-width: 0; }
 .daw-notif-card-title { font-size: 12px; font-weight: 600; color: var(--fg); }
 .daw-notif-card-desc { font-size: 11px; color: var(--muted); margin-top: 2px; }
+.daw-notif-badge {
+  position: absolute; top: 4px; right: 4px;
+  width: 7px; height: 7px;
+  background: #f4b740; border-radius: 50%;
+  pointer-events: none;
+}
+.daw-notif-dismiss {
+  flex-shrink: 0; align-self: flex-start;
+  width: 18px; height: 18px;
+  background: none; border: none; cursor: pointer;
+  color: var(--muted); display: flex; align-items: center; justify-content: center;
+  border-radius: 4px; padding: 0;
+}
+.daw-notif-dismiss:hover { background: var(--panel-3); color: var(--fg); }
+.daw-notif-empty {
+  font-size: 12px; color: var(--muted);
+  text-align: center; padding: 16px 0; margin: 0;
+}
 
 /* Hidden collapsed strip (JS compat, not shown in new design) */
 .appbar-icon-strip.hidden { display: none !important; }
@@ -412,6 +430,14 @@ input, textarea { font-family: inherit; }
 .rail-btn.active { color: var(--accent); background: var(--panel); }
 .rail-btn svg { flex-shrink: 0; }
 .rail-btn span { white-space: nowrap; }
+.settings-coming-soon {
+  position: absolute; left: calc(100% + 8px); bottom: 48px;
+  background: var(--panel-2); border: 1px solid var(--border-strong);
+  border-radius: var(--radius); padding: 8px 12px;
+  font-size: 12px; color: var(--muted); white-space: nowrap;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.4); z-index: 300;
+  pointer-events: none;
+}
 
 /* Sidebar body */
 .sidebar-body {

--- a/static/index.html
+++ b/static/index.html
@@ -175,7 +175,6 @@
               </svg>
               <span>Settings</span>
             </button>
-            <div class="settings-coming-soon hidden" id="settingsComingSoon" role="tooltip">More features coming soon</div>
             <button class="rail-btn" id="aboutBtn" type="button" title="Help" aria-label="Help">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
                 <circle cx="12" cy="12" r="9"/>
@@ -661,18 +660,57 @@
 
     </div><!-- /.daw -->
 
+    <!-- Settings coming-soon tooltip (outside sidebar to avoid overflow:hidden clip) -->
+    <div class="settings-coming-soon hidden" id="settingsComingSoon" role="tooltip">More features coming soon</div>
+
     <!-- About dialog -->
     <div class="about-backdrop hidden" id="aboutDialog" role="dialog" aria-modal="true" aria-labelledby="aboutTitle">
       <div class="about-card">
-        <button class="about-close" id="aboutClose" type="button" aria-label="Close about dialog">×</button>
+        <button class="about-close" id="aboutClose" type="button" aria-label="Close about dialog">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M18 6 6 18M6 6l12 12"/></svg>
+        </button>
+
+        <div class="about-logo" aria-hidden="true">
+          <svg width="28" height="28" viewBox="0 0 28 28" fill="none">
+            <rect x="2" y="10" width="3" height="8" rx="1.5" fill="currentColor" opacity=".5"/>
+            <rect x="7" y="6" width="3" height="16" rx="1.5" fill="currentColor" opacity=".7"/>
+            <rect x="12" y="2" width="4" height="24" rx="2" fill="currentColor"/>
+            <rect x="18" y="6" width="3" height="16" rx="1.5" fill="currentColor" opacity=".7"/>
+            <rect x="23" y="10" width="3" height="8" rx="1.5" fill="currentColor" opacity=".5"/>
+          </svg>
+        </div>
+
         <h2 id="aboutTitle">StemDeck</h2>
-        <p class="about-version" id="aboutVersion">…</p>
-        <a class="about-link" href="https://github.com/stemdeckapp/stemdeck" target="_blank" rel="noopener noreferrer">
-          github.com/stemdeckapp/stemdeck
-        </a>
-        <a class="about-link" href="https://stemdeck.app" target="_blank" rel="noopener noreferrer">
-          stemdeck.app
-        </a>
+        <p class="about-tagline">Open source. No subscriptions. Built by musicians, for musicians.</p>
+        <span class="about-version-badge" id="aboutVersion">…</span>
+
+        <div class="about-primary-links">
+          <a class="about-link about-link-primary" href="https://stemdeck.app" target="_blank" rel="noopener noreferrer">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+            Website
+          </a>
+          <a class="about-link about-link-secondary" href="https://github.com/stemdeckapp/stemdeck" target="_blank" rel="noopener noreferrer">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/></svg>
+            GitHub
+          </a>
+        </div>
+
+        <div class="about-divider"></div>
+
+        <div class="about-socials">
+          <a class="about-social-btn" href="https://discord.gg/JGk7FdZb9N" target="_blank" rel="noopener noreferrer" title="Discord" aria-label="Discord">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"/></svg>
+          </a>
+          <a class="about-social-btn" href="https://www.reddit.com/r/StemDeckApp/" target="_blank" rel="noopener noreferrer" title="Reddit" aria-label="Reddit">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg>
+          </a>
+          <a class="about-social-btn" href="https://www.instagram.com/stemdeck" target="_blank" rel="noopener noreferrer" title="Instagram" aria-label="Instagram">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zM12 0C8.741 0 8.333.014 7.053.072 2.695.272.273 2.69.073 7.052.014 8.333 0 8.741 0 12c0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98C8.333 23.986 8.741 24 12 24c3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98C15.668.014 15.259 0 12 0zm0 5.838a6.162 6.162 0 1 0 0 12.324 6.162 6.162 0 0 0 0-12.324zM12 16a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm6.406-11.845a1.44 1.44 0 1 0 0 2.881 1.44 1.44 0 0 0 0-2.881z"/></svg>
+          </a>
+          <a class="about-social-btn" href="https://x.com/StemDeckApp" target="_blank" rel="noopener noreferrer" title="X" aria-label="X">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.747l7.73-8.835L1.254 2.25H8.08l4.253 5.622 5.911-5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+          </a>
+        </div>
       </div>
     </div>
 
@@ -694,7 +732,13 @@
       /* Settings button: show coming soon tooltip */
       document.getElementById('settingsBtn')?.addEventListener('click', () => {
         const tip = document.getElementById('settingsComingSoon');
-        tip?.classList.toggle('hidden');
+        if (!tip) return;
+        if (!tip.classList.contains('hidden')) { tip.classList.add('hidden'); return; }
+        const rect = document.getElementById('settingsBtn').getBoundingClientRect();
+        tip.style.top = (rect.top + rect.height / 2) + 'px';
+        tip.style.left = (rect.right + 8) + 'px';
+        tip.style.transform = 'translateY(-50%)';
+        tip.classList.remove('hidden');
       });
     </script>
   </body>

--- a/static/index.html
+++ b/static/index.html
@@ -104,6 +104,7 @@
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
               <path d="M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9 M13.7 21a2 2 0 0 1-3.4 0"/>
             </svg>
+            <span class="daw-notif-badge hidden" id="notifBadge" aria-hidden="true"></span>
           </button>
           <div class="daw-notif-panel" role="menu" aria-label="Notifications">
             <div class="daw-notif-header">
@@ -113,15 +114,19 @@
               </button>
             </div>
             <div class="daw-notif-list" id="notifList">
-              <div class="daw-notif-card daw-notif-release">
+              <div class="daw-notif-card daw-notif-release hidden" id="notifReleaseCard">
                 <div class="daw-notif-card-icon">
                   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M12 2l2.4 7.4H22l-6.2 4.5 2.4 7.4L12 17l-6.2 4.3 2.4-7.4L2 9.4h7.6z"/></svg>
                 </div>
                 <div class="daw-notif-card-body">
                   <div class="daw-notif-card-title">New release available</div>
-                  <div class="daw-notif-card-desc" id="brandVersionNotif"></div>
+                  <div class="daw-notif-card-desc" id="notifReleaseDesc"></div>
                 </div>
+                <button class="daw-notif-dismiss" id="notifReleaseDismiss" type="button" aria-label="Dismiss notification">
+                  <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M18 6 6 18M6 6l12 12"/></svg>
+                </button>
               </div>
+              <p class="daw-notif-empty" id="notifEmpty">No new notifications</p>
             </div>
           </div>
         </div>
@@ -163,13 +168,14 @@
               <span>Trash</span>
             </button>
             <div style="flex:1"></div>
-            <button class="rail-btn" type="button" title="Settings" aria-label="Settings">
+            <button class="rail-btn" id="settingsBtn" type="button" title="Settings" aria-label="Settings">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
                 <circle cx="12" cy="12" r="3"/>
                 <path d="M12 2v2 M12 20v2 M4 12H2 M22 12h-2 M5 5l1.5 1.5 M17.5 17.5 19 19 M5 19l1.5-1.5 M17.5 6.5 19 5"/>
               </svg>
               <span>Settings</span>
             </button>
+            <div class="settings-coming-soon hidden" id="settingsComingSoon" role="tooltip">More features coming soon</div>
             <button class="rail-btn" id="aboutBtn" type="button" title="Help" aria-label="Help">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
                 <circle cx="12" cy="12" r="9"/>
@@ -672,15 +678,6 @@
 
     <script type="module" src="/js/main.js"></script>
     <script>
-      /* Relay brandVersion text into the notification card description */
-      const _bv = document.getElementById('brandVersion');
-      const _bn = document.getElementById('brandVersionNotif');
-      if (_bv && _bn) {
-        const _obs = new MutationObserver(() => {
-          _bn.textContent = _bv.textContent || _bv.innerText || '';
-        });
-        _obs.observe(_bv, { childList: true, subtree: true, characterData: true });
-      }
       /* Close notification panel on outside click */
       document.addEventListener('click', (e) => {
         const wrap = document.querySelector('.daw-notif-wrap.open');
@@ -688,6 +685,16 @@
           wrap.classList.remove('open');
           document.getElementById('notifBtn')?.setAttribute('aria-expanded', 'false');
         }
+        /* Hide settings tooltip on outside click */
+        const tip = document.getElementById('settingsComingSoon');
+        if (tip && !tip.classList.contains('hidden') && !document.getElementById('settingsBtn')?.contains(e.target)) {
+          tip.classList.add('hidden');
+        }
+      });
+      /* Settings button: show coming soon tooltip */
+      document.getElementById('settingsBtn')?.addEventListener('click', () => {
+        const tip = document.getElementById('settingsComingSoon');
+        tip?.classList.toggle('hidden');
       });
     </script>
   </body>

--- a/static/js/catalog.js
+++ b/static/js/catalog.js
@@ -1472,11 +1472,9 @@ function wireAboutDialog() {
   const dialog = document.getElementById("aboutDialog");
   const close = document.getElementById("aboutClose");
   const version = document.getElementById("aboutVersion");
-  const link = dialog?.querySelector(".about-link");
   if (!btn || !dialog) return;
 
   if (version) version.textContent = `v${currentVersion}`;
-  if (link) link.setAttribute("href", REPO_URL);
 
   const open = () => dialog.classList.remove("hidden");
   const hide = () => dialog.classList.add("hidden");

--- a/static/js/catalog.js
+++ b/static/js/catalog.js
@@ -22,6 +22,7 @@ let folders = [];
 let tracks = {};
 let _deletedJobIds = new Set();
 let _currentTrackId = null;
+let _loadTrackToken = 0;
 let catalogView = "library";
 let catalogSearchQuery = "";
 
@@ -456,11 +457,13 @@ async function loadTrackIntoStudio(trackId) {
   let track = tracks[trackId];
   if (!track) return;
   const hadStoredAudio = Boolean(track.audioStems?.length);
+  const token = ++_loadTrackToken;
 
   // Always fetch fresh state so server-side changes (sections, analysis, stems)
   // are reflected — cached localStorage data can be stale.
   try {
     const res = await fetch(`/api/jobs/${trackId}`);
+    if (token !== _loadTrackToken) return;
     if (res.ok) {
       const state = await res.json();
       track = stateMetadataToTrack(state, track);
@@ -469,6 +472,7 @@ async function loadTrackIntoStudio(trackId) {
     }
   } catch (e) { console.warn("[catalog] server sync failed, using stored track:", e); }
 
+  if (token !== _loadTrackToken) return;
   if (!track.audioStems?.length) return;
   if (track.status !== "done" && !hadStoredAudio) return;
   applyStoredStemSelection(track);
@@ -1405,9 +1409,10 @@ function wireWidgets() {
 
 const FALLBACK_VERSION = "0.1.0";
 let currentVersion = FALLBACK_VERSION;
-const REPO_URL = "https://github.com/thcp/stemdeck";
-const RELEASES_URL = "https://github.com/thcp/stemdeck/releases";
-const RELEASES_API = "https://api.github.com/repos/thcp/stemdeck/releases/latest";
+const REPO_URL = "https://github.com/stemdeckapp/stemdeck";
+const RELEASES_URL = "https://github.com/stemdeckapp/stemdeck/releases";
+const RELEASES_API = "https://api.github.com/repos/stemdeckapp/stemdeck/releases/latest";
+const DISMISSED_UPDATE_KEY = "stemdeck.dismissed_update";
 
 function normalizeVersion(value) {
   return String(value || "").trim().replace(/^v/i, "") || FALLBACK_VERSION;
@@ -1431,17 +1436,34 @@ async function loadCurrentVersion() {
 }
 
 async function checkForUpdate() {
-  const el = document.getElementById("brandVersion");
-  if (!el) return;
-  el.classList.remove("has-update");
   try {
     const res = await fetch(RELEASES_API, { headers: { Accept: "application/vnd.github+json" } });
     if (!res.ok) return;
     const data = await res.json();
     const latest = normalizeVersion(data.tag_name);
     if (!latest || latest === currentVersion) return;
-    el.classList.add("has-update");
-    el.innerHTML = `<a href="${RELEASES_URL}/tag/${data.tag_name}" target="_blank" rel="noopener noreferrer">new release available</a>`;
+
+    let dismissed = null;
+    try { dismissed = localStorage.getItem(DISMISSED_UPDATE_KEY); } catch (e) { console.warn(e); }
+    if (dismissed === latest) return;
+
+    const card = document.getElementById("notifReleaseCard");
+    const desc = document.getElementById("notifReleaseDesc");
+    const badge = document.getElementById("notifBadge");
+    const empty = document.getElementById("notifEmpty");
+    const dismissBtn = document.getElementById("notifReleaseDismiss");
+
+    if (desc) desc.textContent = `v${latest}`;
+    card?.classList.remove("hidden");
+    badge?.classList.remove("hidden");
+    empty?.classList.add("hidden");
+
+    dismissBtn?.addEventListener("click", () => {
+      try { localStorage.setItem(DISMISSED_UPDATE_KEY, latest); } catch (e) { console.warn(e); }
+      card?.classList.add("hidden");
+      badge?.classList.add("hidden");
+      empty?.classList.remove("hidden");
+    }, { once: true });
   } catch (e) { console.warn("[catalog] update check failed:", e); }
 }
 

--- a/static/js/mixer.js
+++ b/static/js/mixer.js
@@ -17,7 +17,7 @@ export function ensureMixerStateDefaults() {
   }
 }
 
-export async function loadMixIntoState(jobId) {
+export async function loadMixIntoState(jobId, loadedStemNames = STEM_NAMES) {
   let stored = {};
   try {
     const data = await storeGet(`stemdeck:mix:${jobId}`, {});
@@ -25,6 +25,11 @@ export async function loadMixIntoState(jobId) {
   } catch (e) { console.warn("[mixer] failed to load mix state:", e); }
   for (const name of TRACK_NAMES) {
     Object.assign(mixerState[name], defaultMixerEntry(), stored[name] || {});
+  }
+  // If all loaded stems are muted the session is unplayable -- unmute as recovery.
+  const loadedStems = loadedStemNames.filter((n) => mixerState[n]);
+  if (loadedStems.length > 0 && loadedStems.every((n) => mixerState[n].muted)) {
+    for (const name of loadedStems) mixerState[name].muted = false;
   }
 }
 

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -668,8 +668,10 @@ export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, ti
   }, 60000);
   setCurrentJobId(jobId);
   setTotalDuration(duration || 0);
-  loadMixIntoState(jobId);
   refreshMixerVisuals();
+  const mixReady = loadMixIntoState(jobId, stems.map((s) => s.name))
+    .then(() => { if (currentJobId === jobId) refreshMixerVisuals(); })
+    .catch((e) => { console.warn("[player] mix state load failed:", e); });
   setLaneControlsEnabled(true);
   setLoopEnabled(false);
   setLoopStart(0);
@@ -801,7 +803,7 @@ export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, ti
     updateFooterTimes(0);
     updatePresencePlayhead(0);
     setMasterVolume(masterFader ? parseFloat(masterFader.value) : masterVolume);
-    applyMix();
+    mixReady.then(() => { if (currentJobId === jobId && multitrack === mt) applyMix(); });
     setLoopStart(totalDuration * LOOP_DEFAULT_START_FRAC);
     setLoopEnd(totalDuration * LOOP_DEFAULT_END_FRAC);
     renderAllMiniWaves(mt, stems);

--- a/uv.lock
+++ b/uv.lock
@@ -1765,7 +1765,7 @@ wheels = [
 
 [[package]]
 name = "stemdeck"
-version = "0.6.0a1"
+version = "0.6.0a2"
 source = { editable = "." }
 dependencies = [
     { name = "demucs" },


### PR DESCRIPTION
## Summary

- **Bug: stale track load race** -- if you switch tracks before the fetch completes, the in-flight load now aborts via a token guard in `catalog.js`
- **Bug: all stems muted on load** -- if a saved mix state has every loaded stem muted (unplayable), they are all unmuted on restore; partial mutes are preserved
- **Bug: mix state applied before storage resolves** -- `applyMix()` in the `canplay` handler now waits for the async storage read, guarded by jobId and multitrack instance
- **Notifications: live update check** -- panel is hidden by default; shows release card only when GitHub reports a newer version; bell badge appears; dismiss persists to localStorage per version
- **Fix: repo URLs** -- `checkForUpdate` was pointing at `thcp/stemdeck`; corrected to `stemdeckapp/stemdeck`
- **Settings button** -- shows "More features coming soon" tooltip on click

## Test plan

- [x] Process a track, mute all stems, reload -- stems should come back unmuted
- [x] Double-click two different tracks quickly -- only the second track loads
- [x] Bell shows no badge when on latest version; shows badge + card when a newer release exists on GitHub
- [x] Dismiss release card -- does not reappear on reload for same version
- [x] Settings button click shows coming-soon tooltip; click outside dismisses it
- [x] `node --check` passes on all changed JS files
- [x] `uv run pytest tests/ -q` -- 59 passed

Closes #122