### PR TITLE
fix: settings hover tooltip, waveform resize debounce, single-click track load

### DIFF
--- a/static/css/daw.css
+++ b/static/css/daw.css
@@ -1860,7 +1860,7 @@ input, textarea { font-family: inherit; }
   background: var(--panel); border: 1px solid var(--border);
   color: var(--fg-2);
 }
-.about-link-secondary:hover { background: var(--panel-3); color: var(--fg); }
+.about-link-secondary:hover { background: var(--accent); border-color: var(--accent); color: #000; }
 .about-divider {
   width: 100%; height: 1px; background: var(--border); margin-bottom: 16px;
 }
@@ -1873,7 +1873,7 @@ input, textarea { font-family: inherit; }
   display: flex; align-items: center; justify-content: center;
   color: var(--muted); text-decoration: none; transition: all 0.15s;
 }
-.about-social-btn:hover { background: var(--panel-3); color: var(--fg); border-color: var(--border-strong); }
+.about-social-btn:hover { background: var(--accent); border-color: var(--accent); color: #000; }
 
 /* ── Library sections (Recent · Stem Collections · Tags) ── */
 .lib-section {

--- a/static/css/daw.css
+++ b/static/css/daw.css
@@ -432,11 +432,15 @@ input, textarea { font-family: inherit; }
 .rail-btn span { white-space: nowrap; }
 .settings-coming-soon {
   position: fixed;
+  display: none;
   background: var(--panel-2); border: 1px solid var(--border-strong);
   border-radius: var(--radius); padding: 8px 12px;
   font-size: 12px; color: var(--muted); white-space: nowrap;
   box-shadow: 0 4px 16px rgba(0,0,0,0.4); z-index: 300;
   pointer-events: none;
+}
+#settingsBtn:hover .settings-coming-soon {
+  display: block;
 }
 
 /* Sidebar body */
@@ -1846,9 +1850,12 @@ input, textarea { font-family: inherit; }
   text-decoration: none; transition: background 0.15s;
 }
 .about-link-primary {
-  background: var(--accent); color: #000; font-weight: 600;
+  background: var(--panel); border: 1px solid var(--border);
+  color: var(--fg-2); font-weight: 600;
 }
-.about-link-primary:hover { filter: brightness(1.1); }
+.about-link-primary:hover {
+  background: var(--accent); border-color: var(--accent); color: #000;
+}
 .about-link-secondary {
   background: var(--panel); border: 1px solid var(--border);
   color: var(--fg-2);

--- a/static/index.html
+++ b/static/index.html
@@ -723,23 +723,21 @@
           wrap.classList.remove('open');
           document.getElementById('notifBtn')?.setAttribute('aria-expanded', 'false');
         }
-        /* Hide settings tooltip on outside click */
-        const tip = document.getElementById('settingsComingSoon');
-        if (tip && !tip.classList.contains('hidden') && !document.getElementById('settingsBtn')?.contains(e.target)) {
-          tip.classList.add('hidden');
-        }
       });
-      /* Settings button: show coming soon tooltip */
-      document.getElementById('settingsBtn')?.addEventListener('click', () => {
+      /* Settings button: show coming soon tooltip on hover */
+      (function() {
+        const btn = document.getElementById('settingsBtn');
         const tip = document.getElementById('settingsComingSoon');
-        if (!tip) return;
-        if (!tip.classList.contains('hidden')) { tip.classList.add('hidden'); return; }
-        const rect = document.getElementById('settingsBtn').getBoundingClientRect();
-        tip.style.top = (rect.top + rect.height / 2) + 'px';
-        tip.style.left = (rect.right + 8) + 'px';
-        tip.style.transform = 'translateY(-50%)';
-        tip.classList.remove('hidden');
-      });
+        if (!btn || !tip) return;
+        btn.addEventListener('mouseenter', () => {
+          const rect = btn.getBoundingClientRect();
+          tip.style.top = (rect.top + rect.height / 2) + 'px';
+          tip.style.left = (rect.right + 8) + 'px';
+          tip.style.transform = 'translateY(-50%)';
+          tip.classList.remove('hidden');
+        });
+        btn.addEventListener('mouseleave', () => tip.classList.add('hidden'));
+      })();
     </script>
   </body>
 </html>

--- a/static/index.html
+++ b/static/index.html
@@ -168,7 +168,7 @@
               <span>Trash</span>
             </button>
             <div style="flex:1"></div>
-            <button class="rail-btn" id="settingsBtn" type="button" title="Settings" aria-label="Settings">
+            <button class="rail-btn" id="settingsBtn" type="button" aria-label="Settings">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
                 <circle cx="12" cy="12" r="3"/>
                 <path d="M12 2v2 M12 20v2 M4 12H2 M22 12h-2 M5 5l1.5 1.5 M17.5 17.5 19 19 M5 19l1.5-1.5 M17.5 6.5 19 5"/>
@@ -729,14 +729,23 @@
         const btn = document.getElementById('settingsBtn');
         const tip = document.getElementById('settingsComingSoon');
         if (!btn || !tip) return;
-        btn.addEventListener('mouseenter', () => {
+        const show = () => {
           const rect = btn.getBoundingClientRect();
           tip.style.top = (rect.top + rect.height / 2) + 'px';
           tip.style.left = (rect.right + 8) + 'px';
           tip.style.transform = 'translateY(-50%)';
           tip.classList.remove('hidden');
+        };
+        const hide = () => tip.classList.add('hidden');
+        btn.addEventListener('mouseenter', show);
+        btn.addEventListener('mouseleave', hide);
+        // Fallback: hide when mouse moves outside the button bounds
+        document.addEventListener('mousemove', (e) => {
+          if (tip.classList.contains('hidden')) return;
+          const rect = btn.getBoundingClientRect();
+          if (e.clientX < rect.left || e.clientX > rect.right ||
+              e.clientY < rect.top || e.clientY > rect.bottom) hide();
         });
-        btn.addEventListener('mouseleave', () => tip.classList.add('hidden'));
       })();
     </script>
   </body>

--- a/static/js/catalog.js
+++ b/static/js/catalog.js
@@ -708,10 +708,6 @@ function wireTrackDragAndLoad(el, trackId) {
   el.addEventListener("dragend", () => endDrag(el));
   el.addEventListener("click", (e) => {
     if (e.target.closest(".cat-del")) return;
-    setCurrentTrack(trackId);
-  });
-  el.addEventListener("dblclick", (e) => {
-    if (e.target.closest(".cat-del")) return;
     loadTrackIntoStudio(trackId);
   });
 }

--- a/static/js/job.js
+++ b/static/js/job.js
@@ -360,7 +360,9 @@ export function wireJobForm() {
     setSubmitProcessing(true);
 
     const fileInput = document.getElementById("fileInput");
-    const file = fileInput?.files?.[0] ?? null;
+    // Prefer _file cache: browsers (WKWebView, Chromium) silently clear
+    // fileInput.files after a fetch() submission, breaking re-submits.
+    const file = fileInput?._file ?? fileInput?.files?.[0] ?? null;
     const sanitized = file ? sanitizeFilename(file.name) : null;
     const sourceUrl = file ? `local:${sanitized}` : urlInput.value;
     const displayTitle = sanitized ?? (urlInput.value || "Processing track");

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -233,7 +233,10 @@ function wireFileDrop() {
     if (fileSize) fileSize.textContent = formatBytes(file.size);
     filePill.classList.remove("hidden");
     urlWrap.classList.add("has-file");
-    // Store file on the hidden input for job.js to pick up
+    // Cache the File object directly on the element so job.js can always
+    // retrieve it even after the browser clears fileInput.files following
+    // a fetch() submission (known WKWebView / Chromium behaviour).
+    fileInput._file = file;
     const dt = new DataTransfer();
     dt.items.add(file);
     fileInput.files = dt.files;
@@ -244,6 +247,7 @@ function wireFileDrop() {
   function clearFile() {
     filePill.classList.add("hidden");
     urlWrap.classList.remove("has-file");
+    fileInput._file = null;
     fileInput.value = "";
     urlInput.setAttribute("required", "");
   }

--- a/static/js/transport.js
+++ b/static/js/transport.js
@@ -327,8 +327,11 @@ export function applyWaveZoom() {
 
 function wireZoomButtons() {
   if (waveScroll) {
+    let rafId = null;
     const ro = new ResizeObserver(() => {
-      if (multitrack && totalDuration > 0) applyWaveZoom();
+      if (!multitrack || totalDuration <= 0) return;
+      if (rafId) cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(() => { rafId = null; applyWaveZoom(); });
     });
     ro.observe(waveScroll);
   }


### PR DESCRIPTION
## Summary

- Settings tooltip now appears on hover (mouseenter/mouseleave) instead of click; moved outside `.sidebar` to `position: fixed` so it escapes the `overflow: hidden` clip from the sidebar collapse animation
- `ResizeObserver` in `wireZoomButtons` debounces through `requestAnimationFrame` so `applyWaveZoom` fires after layout settles, fixing waveform misalignment on window resize
- Single click on a library track now loads it into the studio (removed the `dblclick` handler); drag-and-drop continues to work unchanged

## Test plan

- [ ] Hover settings button: tooltip appears to the right, disappears on mouse-out, not clipped
- [ ] Resize the app window (or browser): waveform stretches/shrinks correctly without misalignment
- [ ] Single click a library track: loads into studio immediately
- [ ] Drag a track from library to the lanes drop zone: still loads correctly