### PR TITLE
fix: constrain job progress box to waveform panel area

### DIFF
--- a/static/css/daw.css
+++ b/static/css/daw.css
@@ -1982,6 +1982,9 @@ input, textarea { font-family: inherit; }
 .daw.no-track .daw-section-ribbon,
 .daw.no-track .daw-wave-header,
 .daw.no-track .daw-content { opacity: 0.3; pointer-events: none; }
+/* Overlay and job progress live inside .daw-content but must stay fully visible while processing */
+.daw.no-track .daw-content .wave-loading-overlay,
+.daw.no-track .daw-content .job { opacity: 1; pointer-events: auto; }
 
 .app.no-track #t-export-btn,
 .app.is-import #t-export-btn {

--- a/static/css/daw.css
+++ b/static/css/daw.css
@@ -722,7 +722,7 @@ input, textarea { font-family: inherit; }
 /* ── Job progress overlay ── */
 .job {
   position: absolute;
-  top: 64px; left: 260px; right: 0; bottom: 56px;
+  inset: 0;
   z-index: 20;
   background: rgb(7, 13, 19);
   display: flex;
@@ -1474,6 +1474,7 @@ input, textarea { font-family: inherit; }
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  position: relative;
 }
 
 /* waves.css gives .wave-editor padding + border-radius for the old rounded panel

--- a/static/index.html
+++ b/static/index.html
@@ -498,7 +498,7 @@
                     <div class="wave-loading-lines" aria-hidden="true">
                       <i></i><i></i><i></i><i></i><i></i><i></i>
                     </div>
-                    <p class="wave-loading-msg">Still loading waveform…</p>
+                    <p id="waveLoadingPhrase" class="wave-loading-msg"></p>
                   </div>
                 </div>
               </div>

--- a/static/index.html
+++ b/static/index.html
@@ -232,15 +232,6 @@
         <div id="lanes" class="daw-main">
 
           <!-- Job progress -->
-          <div id="job" class="job hidden" role="status" aria-live="polite">
-            <div class="job-header">
-              <div id="job-title" class="title"></div>
-              <div id="job-stage" class="stage"></div>
-              <button id="job-cancel" class="cancel-btn hidden" type="button" aria-label="Cancel job">Cancel</button>
-            </div>
-            <progress id="progress" max="100" value="0"></progress>
-            <div id="job-detail" class="job-detail" aria-live="polite"></div>
-          </div>
           <div id="error" class="error hidden" role="alert"></div>
 
           <!-- Track header / info panel -->
@@ -487,6 +478,15 @@
 
             <!-- Waveform panel -->
             <div class="daw-wave-panel wave-editor surface-panel">
+              <div id="job" class="job hidden" role="status" aria-live="polite">
+                <div class="job-header">
+                  <div id="job-title" class="title"></div>
+                  <div id="job-stage" class="stage"></div>
+                  <button id="job-cancel" class="cancel-btn hidden" type="button" aria-label="Cancel job">Cancel</button>
+                </div>
+                <progress id="progress" max="100" value="0"></progress>
+                <div id="job-detail" class="job-detail" aria-live="polite"></div>
+              </div>
               <div class="wave-scroll" id="wave-scroll">
                 <div class="wave-canvas" id="wave-canvas">
                   <div class="waves-column">

--- a/static/js/job.js
+++ b/static/js/job.js
@@ -34,13 +34,21 @@ function pickPhrase(status) {
   return pool[Math.floor(Math.random() * pool.length)];
 }
 
+function setOverlayPhrase(text) {
+  const el = document.getElementById("waveLoadingPhrase");
+  if (el) el.textContent = text;
+}
+
 function startPhraseRotation(status) {
   stopPhraseRotation();
-  jobStageEl.textContent = pickPhrase(status);
-  phraseTimerId = setInterval(
-    () => { jobStageEl.textContent = pickPhrase(status); },
-    ROTATION_MS,
-  );
+  const phrase = pickPhrase(status);
+  jobStageEl.textContent = phrase;
+  setOverlayPhrase(phrase);
+  phraseTimerId = setInterval(() => {
+    const p = pickPhrase(status);
+    jobStageEl.textContent = p;
+    setOverlayPhrase(p);
+  }, ROTATION_MS);
 }
 
 function stopPhraseRotation() {
@@ -48,6 +56,7 @@ function stopPhraseRotation() {
     clearInterval(phraseTimerId);
     phraseTimerId = null;
   }
+  jobStageEl.textContent = "";
 }
 
 function stopJobPolling() {
@@ -370,14 +379,10 @@ export function wireJobForm() {
     const postUrlText = document.getElementById("post-url-text");
     if (postUrlText) postUrlText.textContent = displayTitle;
 
-    setWaveformLoading(true);
-    // Show progress box immediately for file uploads — the HTTP upload of a
-    // large file takes time and the UI would otherwise appear frozen.
+    // Show overlay immediately for both paths. File uploads show "Uploading…"
+    // in the overlay phrase until the fetch completes and SSE takes over.
+    setWaveformLoading(true, file ? "Uploading…" : "");
     if (file) {
-      jobBox.classList.remove("hidden");
-      jobCancelBtn.classList.add("hidden");
-      jobDetailEl.textContent = "Uploading…";
-      startPhraseRotation("queued");
       lastStatus = "queued";
     }
 
@@ -434,16 +439,12 @@ export function wireJobForm() {
     });
     setCurrentTrack(jobId);
 
-    if (!file) {
-      // YouTube path: keep progress box hidden until SSE events arrive.
-      jobBox.classList.add("hidden");
-      jobCancelBtn.classList.add("hidden");
-      startPhraseRotation("queued");
-      lastStatus = "queued";
-    } else {
-      // File path: clear the upload message — SSE will take over from here.
-      jobDetailEl.textContent = "";
-    }
+    // Both paths: keep job box hidden, overlay drives the UI.
+    // Start phrase rotation now that the job exists on the server.
+    jobBox.classList.add("hidden");
+    jobCancelBtn.classList.add("hidden");
+    startPhraseRotation("queued");
+    lastStatus = "queued";
 
     connectEvents(jobId);
   });

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -594,11 +594,14 @@ let _currentStems = [];
 let _mixUrl = null;
 let _currentTitle = "";
 
-export function setWaveformLoading(loading) {
+export function setWaveformLoading(loading, phrase) {
   const el = document.getElementById("waveLoadingOverlay");
   if (!el) return;
   if (loading) {
     _loadingShownAt = performance.now();
+    const phraseEl = document.getElementById("waveLoadingPhrase");
+    if (phraseEl && phrase !== undefined) phraseEl.textContent = phrase;
+    else if (phraseEl && !phraseEl.textContent) phraseEl.textContent = "Still loading waveform…";
     el.classList.remove("hidden");
   } else {
     const elapsed = performance.now() - _loadingShownAt;
@@ -606,6 +609,8 @@ export function setWaveformLoading(loading) {
     window.setTimeout(() => {
       el.classList.add("hidden");
       el.classList.remove("stalled");
+      const phraseEl = document.getElementById("waveLoadingPhrase");
+      if (phraseEl) phraseEl.textContent = "";
     }, delay);
   }
 }


### PR DESCRIPTION
## Summary

- `#job` progress overlay was positioned with hardcoded screen coordinates (`top: 64px; left: 260px; right: 0; bottom: 56px;`), making it span the full app area during file uploads
- Moved `#job` inside `.daw-wave-panel` and switched to `inset: 0`, scoping it to the waveform area — same pattern as `.wave-loading-overlay`
- Added `position: relative` to `.daw-wave-panel` as the positioning context

## Test plan

- [ ] Upload an MP3/WAV — progress box overlays only the waveform panel, not the full screen
- [ ] Submit a YouTube URL — same constrained appearance, no regression
- [ ] Cancel mid-job — box hides correctly
- [ ] Resize window — box stays within waveform bounds