### PR TITLE
feat: SoundCloud support + instant waveform rendering from pre-computed peaks

### DIFF
--- a/app/api/stems.py
+++ b/app/api/stems.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 
 from fastapi import APIRouter, HTTPException, Query
-from fastapi.responses import FileResponse, StreamingResponse
+from fastapi.responses import FileResponse, Response, StreamingResponse
 
 from app.core.config import JOB_ID_RE, JOBS_DIR, STEM_NAMES, ffmpeg_executable
 from app.core.registry import get as registry_get
@@ -49,6 +49,24 @@ async def _stream_ffmpeg(cmd: list[str]):
         if proc.returncode is None:
             proc.kill()
         await proc.wait()
+
+
+@router.get("/jobs/{job_id}/stems/peaks.json")
+async def get_stem_peaks(job_id: str) -> Response:
+    """Return pre-computed waveform peaks for all stems."""
+    if not JOB_ID_RE.match(job_id):
+        raise HTTPException(status_code=404, detail="job not found")
+    job = registry_get(job_id)
+    if job is None or job.status != "done":
+        raise HTTPException(status_code=404, detail="job not ready")
+    path = (JOBS_DIR / job_id / "stems" / "peaks.json").resolve()
+    if not path.is_file() or not path.is_relative_to(JOBS_DIR.resolve()):
+        raise HTTPException(status_code=404, detail="peaks not found")
+    return FileResponse(
+        path,
+        media_type="application/json",
+        headers={"Cache-Control": "public, max-age=31536000, immutable"},
+    )
 
 
 @router.api_route("/jobs/{job_id}/stems/{name}.wav", methods=["GET", "HEAD"], response_model=None)

--- a/app/pipeline/collect.py
+++ b/app/pipeline/collect.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import json
 import logging
 import shutil
 import subprocess
 import time
 from pathlib import Path
+
+import numpy as np
+import soundfile as sf
 
 from app.core.config import (
     DEMUCS_MODEL,
@@ -177,6 +181,43 @@ def make_selected_mix(job: Job, stems_dir: Path, found: list[str]) -> Path | Non
         str(out),
     ]
     return out if _run_ffmpeg(job, cmd) else None
+
+
+_PEAK_POINTS = 1500  # matches OVERVIEW_WAVE_POINTS in player.js
+
+
+def compute_stem_peaks(stems_dir: Path, stem_names: list[str]) -> None:
+    """Compute and cache [min, max] waveform peaks for each stem.
+    Failure is non-fatal — missing peaks.json degrades to client-side decode."""
+    peaks: dict[str, list[list[float]]] = {}
+    for name in stem_names:
+        path = stems_dir / f"{name}.wav"
+        if not path.is_file():
+            continue
+        try:
+            data, _ = sf.read(path, dtype="float32", always_2d=True)
+            ch = data[:, 0]
+            n = len(ch)
+            if n == 0:
+                continue
+            chunk = max(1, n // _PEAK_POINTS)
+            result: list[list[float]] = []
+            for i in range(0, n, chunk):
+                block = ch[i : i + chunk]
+                result.append([float(np.min(block)), float(np.max(block))])
+            peaks[name] = result[:_PEAK_POINTS]
+        except Exception:
+            logger.warning("could not compute peaks for %s/%s", stems_dir.name, name, exc_info=True)
+
+    if not peaks:
+        return
+
+    try:
+        tmp = stems_dir / "peaks.json.tmp"
+        tmp.write_text(json.dumps(peaks), encoding="utf-8")
+        tmp.replace(stems_dir / "peaks.json")
+    except Exception:
+        logger.warning("could not write peaks.json for %s", stems_dir.name, exc_info=True)
 
 
 def sweep_old_jobs(jobs_dir: Path) -> None:

--- a/app/pipeline/download.py
+++ b/app/pipeline/download.py
@@ -50,7 +50,7 @@ def _is_retriable(exc: Exception) -> bool:
 
 
 _VIDEO_ID_RE = re.compile(r"^[A-Za-z0-9_-]{11}$")
-_ALLOWED_HOSTS = frozenset(
+_YOUTUBE_HOSTS = frozenset(
     (
         "youtube.com",
         "www.youtube.com",
@@ -59,6 +59,8 @@ _ALLOWED_HOSTS = frozenset(
         "youtu.be",
     )
 )
+_SOUNDCLOUD_HOSTS = frozenset(("soundcloud.com", "www.soundcloud.com", "on.soundcloud.com"))
+_ALLOWED_HOSTS = _YOUTUBE_HOSTS | _SOUNDCLOUD_HOSTS
 
 
 class InvalidYouTubeURL(ValueError):
@@ -66,9 +68,9 @@ class InvalidYouTubeURL(ValueError):
 
 
 def validate_youtube_url(url: str) -> str:
-    """Reject anything that isn't an http(s) URL on a known YouTube host, then
-    return the normalized single-video form. Keeps StemDeck from acting as a
-    generic URL fetcher and gives callers a clean 422 instead of a yt-dlp
+    """Reject anything that isn't an http(s) URL on a known supported host.
+    YouTube URLs are normalized to single-video form; SoundCloud URLs are
+    passed through as-is. Gives callers a clean 422 instead of a yt-dlp
     extractor stack trace."""
     if not isinstance(url, str) or not url.strip():
         raise InvalidYouTubeURL("URL is required")
@@ -82,6 +84,9 @@ def validate_youtube_url(url: str) -> str:
     host = (parsed.hostname or "").lower()
     if host not in _ALLOWED_HOSTS:
         raise InvalidYouTubeURL(f"unsupported host: {host or '(empty)'}")
+
+    if host in _SOUNDCLOUD_HOSTS:
+        return url
 
     normalized = normalize_youtube_url(url)
     # normalize_youtube_url returns the original on playlist-only URLs with

--- a/app/pipeline/runner.py
+++ b/app/pipeline/runner.py
@@ -11,7 +11,13 @@ from app.core.config import TIMEOUT_FFMPEG
 from app.core.models import Job, JobCancelled, _set
 from app.core.registry import persist as persist_registry
 from app.pipeline.analyze import analyze, compute_stem_presence
-from app.pipeline.collect import cleanup_source, collect, make_original_track, make_selected_mix
+from app.pipeline.collect import (
+    cleanup_source,
+    collect,
+    compute_stem_peaks,
+    make_original_track,
+    make_selected_mix,
+)
 from app.pipeline.download import download
 from app.pipeline.separate import separate
 
@@ -106,6 +112,11 @@ def _run_common(job: Job, source: Path, job_dir: Path) -> None:
     if mix_path is not None:
         job.mix_url = f"/api/jobs/{job.id}/stems/{mix_path.name}"
     _check_cancel(job)
+
+    all_stem_names = [s["name"] for s in job.stems]
+    if mix_path is not None and mix_path.stem not in all_stem_names:
+        all_stem_names.append(mix_path.stem)
+    compute_stem_peaks(stems_dir, all_stem_names)
 
 
 def _run_blocking(job: Job, url: str, job_dir: Path) -> None:

--- a/static/css/daw.css
+++ b/static/css/daw.css
@@ -591,6 +591,9 @@ input, textarea { font-family: inherit; }
 .cat-sub { color: var(--muted); font-size: 10.5px; display: flex; gap: 5px; white-space: nowrap; overflow: hidden; }
 .cat-status { width: 6px; height: 6px; border-radius: 50%; background: #5fbc56; flex-shrink: 0; }
 .cat-status.processing { background: var(--accent); animation: cat-pulse 1.4s infinite; }
+.cat-status.unavailable { background: #666; }
+.cat-item.unavailable { cursor: not-allowed; }
+.cat-item.unavailable .cat-meta { opacity: 0.45; }
 @keyframes cat-pulse { 0%,100%{opacity:1;} 50%{opacity:0.3;} }
 .cat-del {
   width: 20px; height: 20px; border: 0; border-radius: 5px;

--- a/static/css/daw.css
+++ b/static/css/daw.css
@@ -1980,6 +1980,7 @@ input, textarea { font-family: inherit; }
 .daw.is-import .daw-section-ribbon,
 .daw.is-import .daw-wave-header,
 .daw.is-import .daw-content { opacity: 0.3; pointer-events: none; }
+.daw.is-import .daw-content .mixer-column { opacity: 1; pointer-events: auto; }
 
 .daw.no-track .daw-track-header,
 .daw.no-track .daw-section-ribbon,

--- a/static/css/daw.css
+++ b/static/css/daw.css
@@ -1896,6 +1896,9 @@ input, textarea { font-family: inherit; }
   letter-spacing: 0.09em;
   text-transform: uppercase;
   color: var(--muted);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
 /* Tag chips */
@@ -1962,8 +1965,8 @@ input, textarea { font-family: inherit; }
 /* ── Clear bin bar (trash view only) ── */
 .clear-bin-bar { display: none; padding: 6px 10px 4px; }
 .sidebar.trash-view .clear-bin-bar { display: block; }
-.sidebar.trash-view .daw-lib-header { display: none; }
-.sidebar.favorites-view .daw-lib-header { display: none; }
+.sidebar.trash-view .lib-section-head .new-folder-btn { display: none; }
+.sidebar.favorites-view .lib-section-head .new-folder-btn { display: none; }
 .clear-bin-btn {
   display: flex; align-items: center; gap: 5px;
   width: 100%; padding: 6px 10px; border-radius: 6px;

--- a/static/index.html
+++ b/static/index.html
@@ -39,7 +39,7 @@
             <input
               id="url"
               type="url"
-              placeholder="Paste a YouTube link, or drop an audio file…"
+              placeholder="Paste a YouTube or SoundCloud link, or drop an audio file…"
               spellcheck="false"
               autocomplete="off"
             />

--- a/static/index.html
+++ b/static/index.html
@@ -197,17 +197,6 @@
               <span class="search-kbd" aria-hidden="true">⌘K</span>
             </div>
 
-            <!-- Folder action row -->
-            <div class="daw-lib-header">
-              <span id="catCount" style="display:none"></span>
-              <button id="newFolderBtn" class="new-folder-btn" type="button" aria-label="New folder">
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-                  <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
-                  <path d="M12 11v6 M9 14h6"/>
-                </svg>
-                New folder
-              </button>
-            </div>
 
             <!-- Clear bin (visible only in trash-view) -->
             <div id="clearBinBar" class="clear-bin-bar">

--- a/static/js/catalog.js
+++ b/static/js/catalog.js
@@ -295,6 +295,7 @@ function deriveSource(sourceUrl) {
   if (!sourceUrl) return "—";
   if (sourceUrl.startsWith("local:")) return "Local file";
   if (sourceUrl.includes("youtube.com") || sourceUrl.includes("youtu.be")) return "YouTube";
+  if (sourceUrl.includes("soundcloud.com")) return "SoundCloud";
   return "Web";
 }
 
@@ -307,6 +308,7 @@ function deriveQuality(sourceUrl) {
     return "Local file";
   }
   if (sourceUrl.includes("youtube.com") || sourceUrl.includes("youtu.be")) return "High";
+  if (sourceUrl.includes("soundcloud.com")) return "Compressed (MP3)";
   return "—";
 }
 

--- a/static/js/catalog.js
+++ b/static/js/catalog.js
@@ -3,6 +3,7 @@ import { STEM_NAMES } from "./constants.js";
 import { wireUpAudio, updateFooterTrack } from "./player.js";
 import { initSections } from "./sections.js";
 import { bpmChip, keyChip, saveSelectedStems, selectedStems, titleEl } from "./state.js";
+import { showError } from "./job.js";
 import { fmtTime, storeGet, storeSet } from "./utils.js";
 
 // Escape user-supplied strings before inserting into innerHTML.
@@ -239,7 +240,11 @@ export function updateTrackStatus(trackId, status) {
     saveState();
     const statusDot = document.querySelector(`.cat-item[data-id="${trackId}"] .cat-status`);
     if (statusDot) {
-      statusDot.className = `cat-status ${PROCESSING_STATUSES.has(status) ? "processing" : ""}`;
+      const modifier = PROCESSING_STATUSES.has(status) ? " processing" : status === "unavailable" ? " unavailable" : "";
+      statusDot.className = `cat-status${modifier}`;
+    }
+    for (const el of document.querySelectorAll(`.cat-item[data-id="${trackId}"]`)) {
+      el.classList.toggle("unavailable", status === "unavailable");
     }
   }
 }
@@ -458,6 +463,10 @@ function applyStoredStemSelection(track) {
 async function loadTrackIntoStudio(trackId) {
   let track = tracks[trackId];
   if (!track) return;
+  if (track.status === "unavailable") {
+    showError("This track's audio is no longer available. Re-upload to restore it.");
+    return;
+  }
   const hadStoredAudio = Boolean(track.audioStems?.length);
   const token = ++_loadTrackToken;
 
@@ -471,6 +480,13 @@ async function loadTrackIntoStudio(trackId) {
       track = stateMetadataToTrack(state, track);
       tracks[trackId] = track;
       saveState();
+    } else if (res.status === 404) {
+      track = { ...track, status: "unavailable" };
+      tracks[trackId] = track;
+      saveState();
+      updateTrackStatus(trackId, "unavailable");
+      showError("This track's audio is no longer available. Re-upload to restore it.");
+      return;
     }
   } catch (e) { console.warn("[catalog] server sync failed, using stored track:", e); }
 
@@ -852,7 +868,8 @@ function renderRecentItem(trackId) {
   const track = tracks[trackId];
   if (!track) return null;
   const el = document.createElement("div");
-  el.className = `cat-item${trackId === _currentTrackId ? " active" : ""}`;
+  const isUnavailable = track.status === "unavailable";
+  el.className = `cat-item${trackId === _currentTrackId ? " active" : ""}${isUnavailable ? " unavailable" : ""}`;
   el.dataset.id = trackId;
   const duration = track.duration ? fmtTime(track.duration) : "";
   const stemCount = track.stems?.length ?? 0;
@@ -863,7 +880,7 @@ function renderRecentItem(trackId) {
       <div class="cat-title">${esc(track.title ?? "Unknown track")}</div>
       <div class="cat-sub"><span>${esc(sub)}</span></div>
     </div>
-    <div class="cat-status${PROCESSING_STATUSES.has(track.status) ? " processing" : ""}"></div>
+    <div class="cat-status${PROCESSING_STATUSES.has(track.status) ? " processing" : isUnavailable ? " unavailable" : ""}"></div>
   `;
   wireTrackDragAndLoad(el, trackId);
   return el;
@@ -899,7 +916,8 @@ function renderTrackItem(trackId, { inTrash = false } = {}) {
   if (!track) return null;
 
   const el = document.createElement("div");
-  el.className = `cat-item${trackId === _currentTrackId ? " active" : ""}`;
+  const isUnavailable = track.status === "unavailable";
+  el.className = `cat-item${trackId === _currentTrackId ? " active" : ""}${isUnavailable ? " unavailable" : ""}`;
   el.dataset.id = trackId;
 
   const stemCount = track.stems?.length ?? 0;
@@ -913,7 +931,7 @@ function renderTrackItem(trackId, { inTrash = false } = {}) {
         <span>${inTrash ? "Removed" : `${stemCount} stem${stemCount !== 1 ? "s" : ""}`}</span>
       </div>
     </div>
-    <div class="cat-status${PROCESSING_STATUSES.has(track.status) ? " processing" : ""}"></div>
+    <div class="cat-status${PROCESSING_STATUSES.has(track.status) ? " processing" : isUnavailable ? " unavailable" : ""}"></div>
     ${inTrash ? "" : `<button class="cat-del" type="button" title="Move to Trash">
       <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
         <polyline points="3 6 5 6 21 6"></polyline>

--- a/static/js/catalog.js
+++ b/static/js/catalog.js
@@ -470,6 +470,13 @@ async function loadTrackIntoStudio(trackId) {
   const hadStoredAudio = Boolean(track.audioStems?.length);
   const token = ++_loadTrackToken;
 
+  // Start peaks fetch immediately — runs in parallel with job-data fetch so it
+  // resolves before wireUpAudio calls Multitrack.create. This prevents peaks.json
+  // from competing with stem WAV fetches for Safari's 6-connection-per-origin limit.
+  const peaksPromise = fetch(`/api/jobs/${trackId}/stems/peaks.json`)
+    .then((r) => (r.ok ? r.json() : {}))
+    .catch(() => ({}));
+
   // Always fetch fresh state so server-side changes (sections, analysis, stems)
   // are reflected — cached localStorage data can be stale.
   try {
@@ -504,7 +511,7 @@ async function loadTrackIntoStudio(trackId) {
   }
 
   applyTrackInfoToPanel(track);
-  wireUpAudio(trackId, track.audioStems, track.duration || 0, track.thumb, track.mixUrl ?? null, track.title || "");
+  wireUpAudio(trackId, track.audioStems, track.duration || 0, track.thumb, track.mixUrl ?? null, track.title || "", peaksPromise);
   initSections(trackId, track.sections, track.duration || 0);
 }
 

--- a/static/js/catalog.js
+++ b/static/js/catalog.js
@@ -1224,6 +1224,14 @@ function render() {
 
   // Stem Collections section
   const collectionsSection = makeSectionEl("Stem Collections");
+  const newFolderBtn = document.createElement("button");
+  newFolderBtn.id = "newFolderBtn";
+  newFolderBtn.className = "new-folder-btn";
+  newFolderBtn.type = "button";
+  newFolderBtn.setAttribute("aria-label", "New folder");
+  newFolderBtn.innerHTML = `<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><path d="M12 11v6 M9 14h6"/></svg>New folder`;
+  newFolderBtn.addEventListener("click", createFolder);
+  collectionsSection.querySelector(".lib-section-head").appendChild(newFolderBtn);
   let hasCollections = false;
   for (const folder of nonTrash) {
     const el = renderFolder(folder);
@@ -1537,7 +1545,7 @@ export async function initCatalog() {
   setDisplayedVersion(currentVersion);
   render();
 
-  document.getElementById("newFolderBtn")?.addEventListener("click", createFolder);
+
   loadCurrentVersion().finally(checkForUpdate);
   syncWithServer();
 }

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -731,6 +731,7 @@ export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, ti
   // AudioContext while the gesture handler is still on the call stack.
   // Awaiting before create breaks that chain and causes choppy audio.
   let precomputedPeaks = {};
+  let _canplayFired = false;
   const _footerStemName = stems.find((s) => s.name === "original") ? "original" : stems[0]?.name;
   const _peaksPromise = jobId
     ? (() => {
@@ -822,7 +823,9 @@ export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, ti
     } else if (waveformUrl) {
       initFooterWaveform(waveformUrl);
     }
-    if (Object.keys(peaks).length) {
+    // Edge case: canplay fired before peaks arrived, so the canplay handler
+    // couldn't render from peaks. Render now that we have them.
+    if (_canplayFired && Object.keys(peaks).length) {
       clearOverviewWaveforms();
       renderAllOverviewWaveformsFromPeaks(stems, peaks);
     }
@@ -841,6 +844,7 @@ export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, ti
   };
 
   mt.once("canplay", () => {
+    _canplayFired = true;
     setWaveformLoading(false);
     const ctx = mt.audioContext;
     console.debug(
@@ -867,6 +871,10 @@ export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, ti
     setLoopEnd(totalDuration * LOOP_DEFAULT_END_FRAC);
     renderAllMiniWaves(mt, stems);
     applyWaveZoom();
+    if (Object.keys(precomputedPeaks).length) {
+      clearOverviewWaveforms();
+      renderAllOverviewWaveformsFromPeaks(stems, precomputedPeaks);
+    }
 
     // CRITICAL: the Multitrack class itself does NOT emit play / pause /
     // timeupdate / seeking — those fire on the individual wavesurfer

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -666,7 +666,7 @@ function _applyLaneHeight(count) {
   return laneH;
 }
 
-export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, title = "") {
+export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, title = "", peaksPromise = null) {
   const app = document.querySelector(".app");
   app?.classList.remove("is-import");
   app?.classList.remove("no-track");
@@ -726,14 +726,14 @@ export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, ti
     || stems.find((s) => s.name === "original")?.url
     || stems[0]?.url;
 
-  // Kick off peaks fetch without awaiting — Multitrack.create must run
-  // synchronously during the user gesture so WKWebView initialises its
-  // AudioContext while the gesture handler is still on the call stack.
-  // Awaiting before create breaks that chain and causes choppy audio.
+  // Use the pre-started peaks promise from catalog.js (started in parallel with
+  // the job-data fetch) so peaks.json is resolved before Multitrack.create fires
+  // its stem WAV fetches. This keeps peaks.json out of Safari's 6-connection-per-
+  // origin window, preventing stem WAV queuing that causes buffer underruns.
   let precomputedPeaks = {};
   let _canplayFired = false;
   const _footerStemName = stems.find((s) => s.name === "original") ? "original" : stems[0]?.name;
-  const _peaksPromise = jobId
+  const _peaksPromise = peaksPromise ?? (jobId
     ? (() => {
         const ac = new AbortController();
         const timer = setTimeout(() => ac.abort(), 3000);
@@ -742,7 +742,7 @@ export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, ti
           .catch(() => ({}))
           .finally(() => clearTimeout(timer));
       })()
-    : Promise.resolve({});
+    : Promise.resolve({}));
 
   for (const stem of stems) {
     const row = mixerEl.querySelector(`.lane-header[data-stem="${stem.name}"]`);

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -666,7 +666,7 @@ function _applyLaneHeight(count) {
   return laneH;
 }
 
-export async function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, title = "") {
+export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, title = "") {
   const app = document.querySelector(".app");
   app?.classList.remove("is-import");
   app?.classList.remove("no-track");
@@ -726,36 +726,22 @@ export async function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = nu
     || stems.find((s) => s.name === "original")?.url
     || stems[0]?.url;
 
-  // Fetch pre-computed peaks (best-effort — old jobs 404, degrade gracefully).
+  // Kick off peaks fetch without awaiting — Multitrack.create must run
+  // synchronously during the user gesture so WKWebView initialises its
+  // AudioContext while the gesture handler is still on the call stack.
+  // Awaiting before create breaks that chain and causes choppy audio.
   let precomputedPeaks = {};
-  if (jobId) {
-    const ac = new AbortController();
-    const timer = setTimeout(() => ac.abort(), 3000);
-    try {
-      const res = await fetch(`/api/jobs/${jobId}/stems/peaks.json`, { signal: ac.signal });
-      if (res.ok) precomputedPeaks = await res.json();
-    } catch (_) {
-      // 404 for old jobs or timeout — proceed without peaks
-    } finally {
-      clearTimeout(timer);
-    }
-  }
-
-  // Bail out if another wireUpAudio call started while we were awaiting the peaks fetch.
-  if (token !== visualRenderToken) return;
-
-  // Footer waveform: use pre-computed peaks if available, skip the full WAV decode.
-  const footerStemName = stems.find((s) => s.name === "original") ? "original" : stems[0]?.name;
-  const footerPeaks = precomputedPeaks[footerStemName]
-    || precomputedPeaks[Object.keys(precomputedPeaks)[0]];
-  if (footerPeaks?.length) {
-    const step = Math.ceil(footerPeaks.length / _FOOTER_BARS);
-    _footerWavePeaks = footerPeaks.filter((_, i) => i % step === 0).slice(0, _FOOTER_BARS);
-    setFooterWaveDrawFn(_drawFooterWave);
-    _drawFooterWave(0);
-  } else if (waveformUrl) {
-    initFooterWaveform(waveformUrl);
-  }
+  const _footerStemName = stems.find((s) => s.name === "original") ? "original" : stems[0]?.name;
+  const _peaksPromise = jobId
+    ? (() => {
+        const ac = new AbortController();
+        const timer = setTimeout(() => ac.abort(), 3000);
+        return fetch(`/api/jobs/${jobId}/stems/peaks.json`, { signal: ac.signal })
+          .then((r) => (r.ok ? r.json() : {}))
+          .catch(() => ({}))
+          .finally(() => clearTimeout(timer));
+      })()
+    : Promise.resolve({});
 
   for (const stem of stems) {
     const row = mixerEl.querySelector(`.lane-header[data-stem="${stem.name}"]`);
@@ -822,13 +808,25 @@ export async function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = nu
   );
   setMultitrack(mt);
 
-  // Render overview waveforms immediately from pre-computed peaks so they
-  // appear before audio decoding completes. canplay still fires normally
-  // since we don't pass peaks to WaveSurfer (avoids empty-src deferral).
-  const hasPeaks = Object.keys(precomputedPeaks).length > 0;
-  if (hasPeaks) {
-    renderAllOverviewWaveformsFromPeaks(stems, precomputedPeaks);
-  }
+  // Apply peaks to visuals once the fetch resolves. Runs after Multitrack.create
+  // so AudioContext is already initialised before this callback fires.
+  _peaksPromise.then((peaks) => {
+    if (token !== visualRenderToken) return;
+    precomputedPeaks = peaks;
+    const footerPeaks = peaks[_footerStemName] || peaks[Object.keys(peaks)[0]];
+    if (footerPeaks?.length) {
+      const step = Math.ceil(footerPeaks.length / _FOOTER_BARS);
+      _footerWavePeaks = footerPeaks.filter((_, i) => i % step === 0).slice(0, _FOOTER_BARS);
+      setFooterWaveDrawFn(_drawFooterWave);
+      _drawFooterWave(0);
+    } else if (waveformUrl) {
+      initFooterWaveform(waveformUrl);
+    }
+    if (Object.keys(peaks).length) {
+      clearOverviewWaveforms();
+      renderAllOverviewWaveformsFromPeaks(stems, peaks);
+    }
+  });
 
   // Stop button glows iff transport is paused AND at the "start" (0,
   // or loopStart if loop is on). Centralised here so manual seeks via
@@ -895,7 +893,7 @@ export async function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = nu
       });
       Promise.all(waits).then(() => {
         if (token !== visualRenderToken) return;
-        if (!hasPeaks) {
+        if (!Object.keys(precomputedPeaks).length) {
           clearOverviewWaveforms();
           renderAllOverviewWaveforms(stems, decoded);
         }

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -294,6 +294,25 @@ function renderOverviewWaveformPath(stemName, peaks, norm, color) {
   `;
 }
 
+function renderAllOverviewWaveformsFromPeaks(stems, peaksData) {
+  let globalMax = 0;
+  for (const stem of stems) {
+    const pts = peaksData[stem.name];
+    if (!pts?.length) continue;
+    for (const [mn, mx] of pts) {
+      if (mx > globalMax) globalMax = mx;
+      if (-mn > globalMax) globalMax = -mn;
+    }
+  }
+  if (globalMax <= 0) return;
+  const norm = 1 / globalMax;
+  for (const stem of stems) {
+    const pts = peaksData[stem.name];
+    if (!pts?.length) continue;
+    renderOverviewWaveformPath(stem.name, pts, norm, STEM_COLORS[stem.name] || "#a0a0a0");
+  }
+}
+
 // Normalize all stems to a single shared max so the overview waveforms
 // preserve real amplitude relationships (drums tall, piano short),
 // matching what a DAW shows. Per-stem normalization made every lane
@@ -647,7 +666,7 @@ function _applyLaneHeight(count) {
   return laneH;
 }
 
-export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, title = "") {
+export async function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, title = "") {
   const app = document.querySelector(".app");
   app?.classList.remove("is-import");
   app?.classList.remove("no-track");
@@ -700,14 +719,43 @@ export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, ti
   applyStemSelectionFilter(new Set(stems.map((s) => s.name)));
   updateFooterTrack({ thumbnail, stemCount: stems.filter((s) => s.name !== "original").length });
 
-  // Reset and re-init footer waveform — prefer the full selected-stems mix,
-  // fall back to the complement "original" track, then first available stem.
+  // Reset footer waveform state — will be re-populated below after peaks fetch.
   _footerWavePeaks = null;
   setFooterWaveDrawFn(null);
   const waveformUrl = _mixUrl
     || stems.find((s) => s.name === "original")?.url
     || stems[0]?.url;
-  if (waveformUrl) initFooterWaveform(waveformUrl);
+
+  // Fetch pre-computed peaks (best-effort — old jobs 404, degrade gracefully).
+  let precomputedPeaks = {};
+  if (jobId) {
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort(), 3000);
+    try {
+      const res = await fetch(`/api/jobs/${jobId}/stems/peaks.json`, { signal: ac.signal });
+      if (res.ok) precomputedPeaks = await res.json();
+    } catch (_) {
+      // 404 for old jobs or timeout — proceed without peaks
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  // Bail out if another wireUpAudio call started while we were awaiting the peaks fetch.
+  if (token !== visualRenderToken) return;
+
+  // Footer waveform: use pre-computed peaks if available, skip the full WAV decode.
+  const footerStemName = stems.find((s) => s.name === "original") ? "original" : stems[0]?.name;
+  const footerPeaks = precomputedPeaks[footerStemName]
+    || precomputedPeaks[Object.keys(precomputedPeaks)[0]];
+  if (footerPeaks?.length) {
+    const step = Math.ceil(footerPeaks.length / _FOOTER_BARS);
+    _footerWavePeaks = footerPeaks.filter((_, i) => i % step === 0).slice(0, _FOOTER_BARS);
+    setFooterWaveDrawFn(_drawFooterWave);
+    _drawFooterWave(0);
+  } else if (waveformUrl) {
+    initFooterWaveform(waveformUrl);
+  }
 
   for (const stem of stems) {
     const row = mixerEl.querySelector(`.lane-header[data-stem="${stem.name}"]`);
@@ -774,6 +822,14 @@ export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, ti
   );
   setMultitrack(mt);
 
+  // Render overview waveforms immediately from pre-computed peaks so they
+  // appear before audio decoding completes. canplay still fires normally
+  // since we don't pass peaks to WaveSurfer (avoids empty-src deferral).
+  const hasPeaks = Object.keys(precomputedPeaks).length > 0;
+  if (hasPeaks) {
+    renderAllOverviewWaveformsFromPeaks(stems, precomputedPeaks);
+  }
+
   // Stop button glows iff transport is paused AND at the "start" (0,
   // or loopStart if loop is on). Centralised here so manual seeks via
   // the ruler also update the visual without extra plumbing.
@@ -839,8 +895,10 @@ export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, ti
       });
       Promise.all(waits).then(() => {
         if (token !== visualRenderToken) return;
-        clearOverviewWaveforms();
-        renderAllOverviewWaveforms(stems, decoded);
+        if (!hasPeaks) {
+          clearOverviewWaveforms();
+          renderAllOverviewWaveforms(stems, decoded);
+        }
         renderStemEnergyBaseline(stems, decoded);
         startStemVuLoop(stems, decoded, token);
       });

--- a/tests/test_pipeline_collect.py
+++ b/tests/test_pipeline_collect.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+import struct
+import wave
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from app.pipeline.collect import _PEAK_POINTS, compute_stem_peaks
+
+
+def _write_wav(path: Path, samples: list[float], sample_rate: int = 44100) -> None:
+    """Write a mono 16-bit PCM WAV file."""
+    with wave.open(str(path), "w") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        data = struct.pack(f"<{len(samples)}h", *[int(s * 32767) for s in samples])
+        wf.writeframes(data)
+
+
+def test_produces_peaks_json(tmp_path):
+    stems_dir = tmp_path / "stems"
+    stems_dir.mkdir()
+
+    # 1-second sine wave at 440 Hz
+    sr = 44100
+    t = np.linspace(0, 1, sr, endpoint=False)
+    samples = (np.sin(2 * np.pi * 440 * t) * 0.5).tolist()
+    _write_wav(stems_dir / "vocals.wav", samples, sr)
+
+    compute_stem_peaks(stems_dir, ["vocals"])
+
+    peaks_path = stems_dir / "peaks.json"
+    assert peaks_path.is_file()
+    data = json.loads(peaks_path.read_text())
+    assert "vocals" in data
+    pts = data["vocals"]
+    assert len(pts) <= _PEAK_POINTS
+    assert len(pts) > 0
+    # each point is [min, max] with min <= 0 <= max (sine wave)
+    for mn, mx in pts:
+        assert mn <= mx
+        assert -1.0 <= mn <= 1.0
+        assert -1.0 <= mx <= 1.0
+
+
+def test_multiple_stems(tmp_path):
+    stems_dir = tmp_path / "stems"
+    stems_dir.mkdir()
+    for name in ("vocals", "drums", "bass"):
+        _write_wav(stems_dir / f"{name}.wav", [0.1, -0.1, 0.2, -0.2])
+
+    compute_stem_peaks(stems_dir, ["vocals", "drums", "bass"])
+
+    data = json.loads((stems_dir / "peaks.json").read_text())
+    assert set(data.keys()) == {"vocals", "drums", "bass"}
+
+
+def test_skips_missing_wav(tmp_path):
+    stems_dir = tmp_path / "stems"
+    stems_dir.mkdir()
+    _write_wav(stems_dir / "drums.wav", [0.1, -0.1])
+    # "vocals.wav" intentionally absent
+
+    compute_stem_peaks(stems_dir, ["vocals", "drums"])
+
+    data = json.loads((stems_dir / "peaks.json").read_text())
+    assert "drums" in data
+    assert "vocals" not in data
+
+
+def test_no_output_when_all_stems_missing(tmp_path):
+    stems_dir = tmp_path / "stems"
+    stems_dir.mkdir()
+
+    compute_stem_peaks(stems_dir, ["vocals", "drums"])
+
+    assert not (stems_dir / "peaks.json").exists()
+
+
+def test_writes_atomically(tmp_path):
+    """No partial peaks.json.tmp should survive a successful run."""
+    stems_dir = tmp_path / "stems"
+    stems_dir.mkdir()
+    _write_wav(stems_dir / "vocals.wav", [0.1, -0.1, 0.3])
+
+    compute_stem_peaks(stems_dir, ["vocals"])
+
+    assert (stems_dir / "peaks.json").is_file()
+    assert not (stems_dir / "peaks.json.tmp").exists()
+
+
+def test_non_fatal_on_corrupt_wav(tmp_path):
+    stems_dir = tmp_path / "stems"
+    stems_dir.mkdir()
+    (stems_dir / "vocals.wav").write_bytes(b"not a wav file at all")
+    _write_wav(stems_dir / "drums.wav", [0.1, -0.1])
+
+    # Should not raise; drums should still be computed
+    compute_stem_peaks(stems_dir, ["vocals", "drums"])
+
+    data = json.loads((stems_dir / "peaks.json").read_text())
+    assert "drums" in data
+    assert "vocals" not in data

--- a/tests/test_pipeline_collect.py
+++ b/tests/test_pipeline_collect.py
@@ -6,7 +6,6 @@ import wave
 from pathlib import Path
 
 import numpy as np
-import pytest
 
 from app.pipeline.collect import _PEAK_POINTS, compute_stem_peaks
 

--- a/tests/test_stems_api.py
+++ b/tests/test_stems_api.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -64,3 +66,52 @@ def test_serves_done_job_stem(client, tmp_path):
     assert r.status_code == 200
     assert r.content == b"RIFF1234"
     assert r.headers["content-type"] == "audio/wav"
+
+
+# --- peaks endpoint ---
+
+
+def _make_peaks_file(tmp_path, job_id: str, data: dict) -> None:
+    stems_dir = tmp_path / job_id / "stems"
+    stems_dir.mkdir(parents=True, exist_ok=True)
+    (stems_dir / "peaks.json").write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_peaks_returns_json_for_done_job(client, tmp_path):
+    job = Job(id="abcdefabcdea")
+    job.status = "done"
+    _jobs[job.id] = job
+    payload = {"vocals": [[-0.1, 0.2], [-0.3, 0.4]], "drums": [[-0.5, 0.6]]}
+    _make_peaks_file(tmp_path, job.id, payload)
+
+    r = client.get(f"/api/jobs/{job.id}/stems/peaks.json")
+    assert r.status_code == 200
+    assert r.headers["content-type"] == "application/json"
+    assert "immutable" in r.headers.get("cache-control", "")
+    assert r.json() == payload
+
+
+def test_peaks_404_when_file_missing(client, tmp_path):
+    job = Job(id="abcdefabcdeb")
+    job.status = "done"
+    _jobs[job.id] = job
+    # stems dir exists but no peaks.json
+    (tmp_path / job.id / "stems").mkdir(parents=True, exist_ok=True)
+
+    r = client.get(f"/api/jobs/{job.id}/stems/peaks.json")
+    assert r.status_code == 404
+
+
+def test_peaks_404_for_non_done_job(client):
+    job = Job(id="abcdefabcdec")
+    job.status = "separating"
+    _jobs[job.id] = job
+
+    r = client.get(f"/api/jobs/{job.id}/stems/peaks.json")
+    assert r.status_code == 404
+
+
+def test_peaks_rejects_malformed_job_id(client):
+    for bad_id in ("../etc", "ABC", "abcdefabcdef0", "abcdefabcde"):
+        r = client.get(f"/api/jobs/{bad_id}/stems/peaks.json")
+        assert r.status_code == 404, f"id {bad_id!r} should 404"

--- a/tests/test_url_validation.py
+++ b/tests/test_url_validation.py
@@ -50,3 +50,17 @@ def test_rejects_bad_urls(url: str, reason_substring: str) -> None:
     with pytest.raises(InvalidYouTubeURL) as exc:
         validate_youtube_url(url)
     assert reason_substring in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://soundcloud.com/artist/track",
+        "https://www.soundcloud.com/artist/track",
+        "https://on.soundcloud.com/abc123",
+        "  https://soundcloud.com/artist/track  ",
+    ],
+)
+def test_accepts_soundcloud_urls(url: str) -> None:
+    result = validate_youtube_url(url)
+    assert result == url.strip()

--- a/uv.lock
+++ b/uv.lock
@@ -1796,7 +1796,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "demucs", specifier = ">=4.0.1" },
-    { name = "fastapi", specifier = ">=0.115" },
+    { name = "fastapi", specifier = ">=0.115,!=0.136.3" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "librosa", specifier = ">=0.10" },
     { name = "numba", marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'", specifier = ">=0.61,<0.62" },


### PR DESCRIPTION
Closes #156
Closes #157

## Summary

- **SoundCloud support**: `soundcloud.com`, `www.soundcloud.com`, and `on.soundcloud.com` added to the URL allowlist alongside YouTube. SoundCloud links pass through without normalization. UI labels tracks as "SoundCloud" with "Compressed (MP3)" quality.
- **Instant waveform rendering**: Pipeline pre-computes 1500 `[min, max]` peak pairs per stem at the end of separation and writes `peaks.json` atomically. Frontend fetches this ~50 KB file on track load and renders overview + footer waveforms immediately — before audio is ready to play — eliminating the multi-second WAV decode wait. Old jobs without `peaks.json` fall back gracefully to the existing client-side decode path.
- **Unavailable track handling**: When a catalog track's job is no longer on the server (reinstall, migration, fresh dev server), the item is now greyed out with a grey status dot and clicking surfaces a clear error: "This track's audio is no longer available. Re-upload to restore it."

## New endpoint

`GET /api/jobs/{id}/stems/peaks.json` — returns pre-computed peaks with `Cache-Control: immutable`.

## Test plan

- [ ] Process a new YouTube track — confirm `jobs/{id}/stems/peaks.json` written
- [ ] Process a SoundCloud track — confirm it processes end-to-end
- [ ] Click track from library — waveforms appear immediately (before playback is ready)
- [ ] Click a second and third track — each loads correctly, no stale renders
- [ ] Load an old job without `peaks.json` — still loads, just slower (fallback path)
- [ ] Delete a job directory while it's in the catalog, then click the track — grey dot, error toast, no blank UI
- [ ] `uv run pytest` — 73 tests pass