### PR TITLE
fix: scrollable stem lanes + responsive waveform with thin scrollbars (#159)

### DIFF
--- a/static/css/daw.css
+++ b/static/css/daw.css
@@ -531,6 +531,60 @@ input, textarea { font-family: inherit; }
   gap: 2px;
 }
 
+/* Thin auto-hide scrollbar shared by the library list, the mixer column and the
+   waveform panel (both axes) — hidden until the area is hovered/focused, reserves
+   no visible gutter. `.daw .wave-scroll` overrides the gold bar from waves.css. */
+.daw-lib-list,
+.mixer-column,
+.daw .wave-scroll {
+  /* Firefox: thin overlay-style bar, fades to transparent track */
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+}
+.daw-lib-list:hover,
+.daw-lib-list:focus-within,
+.mixer-column:hover,
+.mixer-column:focus-within,
+.daw .wave-scroll:hover,
+.daw .wave-scroll:focus-within {
+  scrollbar-color: rgba(148, 163, 184, 0.4) transparent;
+}
+/* WebKit (Chrome/Safari/WKWebView): thin thumb, hidden until hover/scroll */
+.daw-lib-list::-webkit-scrollbar,
+.mixer-column::-webkit-scrollbar,
+.daw .wave-scroll::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+.daw-lib-list::-webkit-scrollbar-track,
+.mixer-column::-webkit-scrollbar-track,
+.daw .wave-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+.daw-lib-list::-webkit-scrollbar-thumb,
+.mixer-column::-webkit-scrollbar-thumb,
+.daw .wave-scroll::-webkit-scrollbar-thumb {
+  background: transparent;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+  border-radius: 999px;
+}
+.daw-lib-list:hover::-webkit-scrollbar-thumb,
+.daw-lib-list:focus-within::-webkit-scrollbar-thumb,
+.mixer-column:hover::-webkit-scrollbar-thumb,
+.mixer-column:focus-within::-webkit-scrollbar-thumb,
+.daw .wave-scroll:hover::-webkit-scrollbar-thumb,
+.daw .wave-scroll:focus-within::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.4);
+  background-clip: padding-box;
+}
+.daw-lib-list::-webkit-scrollbar-thumb:hover,
+.mixer-column::-webkit-scrollbar-thumb:hover,
+.daw .wave-scroll::-webkit-scrollbar-thumb:hover {
+  background: rgba(148, 163, 184, 0.6);
+  background-clip: padding-box;
+}
+
 /* Library item */
 .lib-item {
   display: flex;
@@ -1234,6 +1288,10 @@ input, textarea { font-family: inherit; }
   flex: 1;
   background: var(--bg-2);
   min-height: 32px;
+  /* Clip the horizontally-scrolled ruler spill. overflow-x: clip (not hidden)
+     keeps overflow-y visible so the vertical playhead line still extends down
+     over the waveform lanes. */
+  overflow-x: clip;
 }
 
 /* Ruler */
@@ -1243,6 +1301,12 @@ input, textarea { font-family: inherit; }
   font-family: var(--font-mono);
   font-size: 9px;
   color: var(--muted);
+}
+/* Match the zoomed waveform width so ticks/playhead stay aligned; JS translates
+   it by scrollLeft. Left-anchored (right: auto) so width drives the size. */
+.daw .lanes-ruler-time {
+  right: auto;
+  width: calc(100% * var(--zoom, 1));
 }
 .playhead-marker {
   position: absolute;
@@ -1291,7 +1355,8 @@ input, textarea { font-family: inherit; }
   flex-direction: column;
   flex: 1;
   min-height: 0;
-  overflow: hidden;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 /* Each mixer row height is driven by --lane-h (set dynamically in JS to fill available space) */
@@ -1497,10 +1562,12 @@ input, textarea { font-family: inherit; }
   height: auto !important;
   border-radius: 0 !important;
   border: none !important;
+  overflow-y: auto;
 }
 
-/* Establish height chain so waves-column's calc(100%-34px) resolves correctly */
-.daw .wave-canvas { height: 100%; }
+/* Canvas fills the panel when lanes fit, but grows with the track stack when
+   they overflow (#159) so .wave-scroll can scroll the extra lanes vertically. */
+.daw .wave-canvas { min-height: 100%; height: auto; }
 
 /* In the original layout a 48px stem-icon strip lived INSIDE the wave panel,
    offsetting waves-column/multitrack/waveform-layer by 48px. In our layout the
@@ -1516,6 +1583,14 @@ input, textarea { font-family: inherit; }
   pointer-events: all !important;
   position: relative !important;  /* in flow → waves-column height driven by WaveSurfer */
   inset: 0 !important;             /* waves.css sets inset: 0 0 0 48px; zero left offset */
+}
+/* The wavesurfer-multitrack bundle wraps its tracks in its own
+   `<div style="overflow-x: scroll">`, which renders a permanently visible
+   horizontal scrollbar — an empty light bar when the content fits (the "white
+   bar" bug). We fit the bundle to its container and let the outer .wave-scroll
+   own horizontal scrolling, so suppress the bundle's wrapper scrollbar. */
+.daw #multitrack-container > div {
+  overflow-x: hidden !important;
 }
 /* Zero waves.css 48px left offsets that assumed an icon strip inside the wave panel */
 .daw .waves-grid { left: 0 !important; }

--- a/static/js/transport.js
+++ b/static/js/transport.js
@@ -3,7 +3,7 @@ import {
   playBtn, playMiniBtn, stopBtn, loopBtn, timeEl, masterFader,
   rulerTime, wavesGrid, loopRegionEl, playheadMarker,
   multitrack, totalDuration, loopEnabled, loopStart, loopEnd, masterVolume,
-  waveScroll, waveCanvas,
+  waveScroll, waveCanvas, multitrackContainer,
   presenceRulerEl, presencePlayheadEl,
   footerTimeElapsed, footerTimeTotal, npScrubFill, footerWaveDrawFn,
   setLoopEnabled, setLoopStart, setLoopEnd, setMasterVolume,
@@ -11,6 +11,9 @@ import {
 import { applyMix } from "./mixer.js";
 
 const MIN_LOOP_SEC = 0.2;
+// Below this visible width the waveform stops compressing to fit and instead
+// keeps a minimum size, overflowing horizontally so .wave-scroll can scroll.
+const WAVE_MIN_WIDTH = 720;
 // rulerTime is the canonical timeline reference for both click->time
 // and time->pixel mapping. The wave-editor lays the ruler and the
 // waveform body out so they should be horizontally aligned (both gutter
@@ -310,17 +313,41 @@ function wireLoopDrag() {
 // loop region) automatically stretch with the canvas, so the loop drag
 // math stays correct without any per-element width logic.
 
+// Keep the header ruler horizontally aligned with the (possibly wider, scrolled)
+// waveform body. The ruler lives outside .wave-scroll, so translate it by the
+// same scrollLeft; .daw-ruler-area uses overflow-x: clip to hide the spill while
+// leaving the vertical playhead line (overflow-y: visible) intact.
+export function syncRulerScroll() {
+  if (rulerTime && waveScroll) {
+    rulerTime.style.transform = `translateX(${-waveScroll.scrollLeft}px)`;
+  }
+}
+
 export function applyWaveZoom() {
+  const lanes = document.getElementById("lanes") || waveCanvas;
   const wavesColumn = document.querySelector(".waves-column");
   if (wavesColumn) {
-    const lanes = document.getElementById("lanes") || waveCanvas;
     lanes?.style.setProperty("--wave-playhead-h", `${wavesColumn.clientHeight}px`);
   }
   if (multitrack && totalDuration > 0 && waveScroll) {
     const baseWidth = waveScroll.clientWidth;
     if (baseWidth > 0) {
-      const pxPerSec = baseWidth / totalDuration;
-      try { multitrack.zoom(pxPerSec); } catch { /* ignore -- pre-canplay */ }
+      // Fit to the visible width, but never compress below WAVE_MIN_WIDTH.
+      const contentWidth = Math.max(baseWidth, WAVE_MIN_WIDTH);
+      const zoom = contentWidth / baseWidth;
+      // Widen the container via --zoom FIRST. Then, after the browser has
+      // reflowed it, zoom WaveSurfer to fit the container's *actual* width.
+      // Measuring post-reflow avoids the resize race where WaveSurfer renders
+      // wider than its container and exposes its own (unstyled, light) internal
+      // horizontal scrollbar — the only horizontal scroll must come from the
+      // outer .wave-scroll, which also keeps the ruler/playhead aligned.
+      lanes?.style.setProperty("--zoom", String(zoom));
+      requestAnimationFrame(() => {
+        if (!multitrack || totalDuration <= 0) return;
+        const w = multitrackContainer?.clientWidth || contentWidth;
+        try { multitrack.zoom(w / totalDuration); } catch { /* ignore -- pre-canplay */ }
+        syncRulerScroll();
+      });
     }
   }
 }
@@ -343,8 +370,26 @@ function wireZoomButtons() {
         waveScroll.scrollLeft += e.deltaY;
       }
     }, { passive: false });
+    waveScroll.addEventListener("scroll", syncRulerScroll, { passive: true });
   }
   applyWaveZoom();
+}
+
+// Keep the mixer column and the waveform area scrolled in lockstep so stem
+// controls stay aligned with their lanes when the stack overflows (#159).
+function wireLaneScrollSync() {
+  const mixer = document.getElementById("mixer");
+  if (!mixer || !waveScroll) return;
+  let syncing = false;
+  const link = (src, dst) =>
+    src.addEventListener("scroll", () => {
+      if (syncing) return;
+      syncing = true;
+      dst.scrollTop = src.scrollTop;
+      requestAnimationFrame(() => { syncing = false; });
+    });
+  link(mixer, waveScroll);
+  link(waveScroll, mixer);
 }
 
 // ─── Wire transport buttons ───
@@ -356,6 +401,7 @@ export function wireTransportButtons() {
   loopBtn.addEventListener("click", toggleLoop);
   wireLoopDrag();
   wireZoomButtons();
+  wireLaneScrollSync();
   masterFader?.addEventListener("input", () => {
     setMasterVolume(parseFloat(masterFader.value));
     applyMix();


### PR DESCRIPTION
## Summary

Fixes #159 — on short viewports the stem lanes overflowed and were clipped with no way to scroll to them. This makes the mixer + waveform scroll together vertically, and overhauls the wave-area scrolling and scrollbar styling.

## Changes

- **Vertical lane scroll (#159):** `.mixer-column` and `.wave-scroll` scroll vertically and stay in sync (bidirectional `scrollTop`), so stem controls stay aligned with their lanes; the timeline ruler stays pinned on top.
- **Thin auto-hide scrollbars:** library, mixer, and waveform now use a thin scrollbar that's transparent until hover/focus and reserves no gutter — replaces the chunky default OS bars.
- **Responsive waveform:** fits to the visible width when the panel is ≥ 720px and stretches as the window grows; below 720px the waveform keeps its size and you scroll horizontally instead of it compressing.
- **Ruler/playhead alignment under scroll/zoom:** a single `--zoom` var widens the canvas and ruler together; the ruler translates by `scrollLeft` while `overflow-x: clip` hides the spill but keeps the vertical playhead line intact.
- **White-bar fix:** the wavesurfer-multitrack bundle wraps its tracks in its own permanently-visible `overflow-x: scroll` div (the empty scrollbar showed as a white bar). We now fit WaveSurfer to its container after the `--zoom` reflow and suppress that wrapper's scrollbar, so the only horizontal scroll comes from the outer `.wave-scroll`.

## Testing

- `node --check` on the changed JS.
- Playwright: verified horizontal/vertical scroll appears only when content overflows, ruler tracks `scrollLeft`, no white bar across resize stress, and the red playhead marker stays aligned with the waveform (click-to-seek round-trip) in both fit and zoomed/scrolled states.
- Manual: macOS / WebKit.

## Notes

- Files: `static/css/daw.css`, `static/js/transport.js` (no Python touched).
- `overflow-x: clip` requires Safari 16+ / Chromium 90+ (fine for current WKWebView/WebView2).
- No playhead auto-follow during playback when zoomed — deliberate (manual scroll); easy to add later if wanted.