### PR TITLE
feat: consolidate footer export into one dropdown with stems .zip

### DIFF
--- a/app/api/stems.py
+++ b/app/api/stems.py
@@ -1,12 +1,22 @@
 from __future__ import annotations
 
 import asyncio
+import logging
+import os
+import re
+import subprocess
+import tempfile
+import zipfile
+from pathlib import Path
 
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import FileResponse, Response, StreamingResponse
+from starlette.background import BackgroundTask
 
-from app.core.config import JOB_ID_RE, JOBS_DIR, STEM_NAMES, ffmpeg_executable
+from app.core.config import JOB_ID_RE, JOBS_DIR, STEM_NAMES, TIMEOUT_FFMPEG, ffmpeg_executable
 from app.core.registry import get as registry_get
+
+logger = logging.getLogger("stemdeck.api")
 
 router = APIRouter(tags=["stems"])
 
@@ -151,4 +161,108 @@ async def get_stem_mp3(
         _stream_ffmpeg(cmd),
         media_type="audio/mpeg",
         headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+def _safe_title(title: str | None) -> str:
+    """Sanitize a song title into a filename-safe slug (matches the frontend)."""
+    safe = re.sub(r"[^a-zA-Z0-9]+", "_", title or "")
+    safe = re.sub(r"_{2,}", "_", safe).strip("_")[:80].strip("_")
+    return safe or "stems"
+
+
+def _build_stems_zip(sources: list[tuple[str, Path]], fmt: str, dest: Path) -> None:
+    """Blocking: write the stems into a ZIP. WAV files are stored as-is; MP3 is
+    transcoded per stem via ffmpeg. ZIP_STORED throughout — audio doesn't
+    meaningfully compress, and STORED keeps the build fast. Runs in a thread."""
+    if fmt == "wav":
+        with zipfile.ZipFile(dest, "w", zipfile.ZIP_STORED) as zf:
+            for name, p in sources:
+                zf.write(p, arcname=f"{name}.wav")
+        return
+    with tempfile.TemporaryDirectory() as td, zipfile.ZipFile(dest, "w", zipfile.ZIP_STORED) as zf:
+        for name, p in sources:
+            out = os.path.join(td, f"{name}.mp3")
+            cmd = [
+                ffmpeg_executable(),
+                "-nostdin",
+                "-loglevel",
+                "error",
+                "-i",
+                str(p),
+                "-q:a",
+                "2",  # VBR ~190 kbps, matches the per-stem mp3 endpoint
+                "-f",
+                "mp3",
+                out,
+            ]
+            proc = subprocess.run(  # noqa: S603 — list args, no shell, trusted ffmpeg
+                cmd,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+                timeout=TIMEOUT_FFMPEG,
+            )
+            if proc.returncode != 0:
+                tail = proc.stderr[-2000:].decode("utf-8", "replace")
+                raise RuntimeError(f"ffmpeg failed for {name}: {tail}")
+            zf.write(out, arcname=f"{name}.mp3")
+
+
+@router.get("/jobs/{job_id}/stems/all.zip")
+async def get_all_stems_zip(
+    job_id: str,
+    fmt: str = Query(default="wav", alias="format"),
+    stems: str | None = Query(default=None, description="Comma-separated stems; default all"),
+) -> FileResponse:
+    """Bundle the requested stems into a single ZIP, named after the song.
+
+    `stems` is the active subset selected in the DAW (whitelisted). When omitted,
+    every available stem is included."""
+    if not JOB_ID_RE.match(job_id):
+        raise HTTPException(status_code=404, detail="job not found")
+    if fmt not in ("wav", "mp3"):
+        raise HTTPException(status_code=422, detail="format must be 'wav' or 'mp3'")
+    job = registry_get(job_id)
+    if job is None or job.status != "done":
+        raise HTTPException(status_code=404, detail="job not ready")
+
+    # Resolve the requested subset (whitelisted) or fall back to all stems.
+    if stems:
+        requested = {s for s in stems.split(",") if s}
+        if not requested <= set(STEM_NAMES):
+            raise HTTPException(status_code=422, detail="unknown stem requested")
+        wanted = [name for name in STEM_NAMES if name in requested]
+    else:
+        wanted = list(STEM_NAMES)
+
+    jobs_root = JOBS_DIR.resolve()
+    stems_dir = (JOBS_DIR / job_id / "stems").resolve()
+    if not stems_dir.is_dir() or not stems_dir.is_relative_to(jobs_root):
+        raise HTTPException(status_code=404, detail="stems not found")
+
+    sources: list[tuple[str, Path]] = []
+    for name in wanted:
+        p = (stems_dir / f"{name}.wav").resolve()
+        if p.is_file() and p.is_relative_to(jobs_root):
+            sources.append((name, p))
+    if not sources:
+        raise HTTPException(status_code=404, detail="no stems found")
+
+    fd, tmp = tempfile.mkstemp(prefix="stemdeck_zip_", suffix=".zip")
+    os.close(fd)
+    tmp_path = Path(tmp)
+    try:
+        await asyncio.to_thread(_build_stems_zip, sources, fmt, tmp_path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        logger.exception("failed to build stems zip for job %s", job_id)
+        raise HTTPException(status_code=500, detail="failed to build archive") from None
+
+    filename = f"{_safe_title(job.title)}_stems.zip"
+    return FileResponse(
+        tmp_path,
+        media_type="application/zip",
+        filename=filename,
+        background=BackgroundTask(lambda: tmp_path.unlink(missing_ok=True)),
     )

--- a/static/css/daw.css
+++ b/static/css/daw.css
@@ -1666,12 +1666,6 @@ input, textarea { font-family: inherit; }
   display: flex; align-items: center; justify-content: flex-end; gap: 8px;
   min-width: 0;
 }
-.footer-export-stack {
-  display: flex; flex-direction: column; gap: 4px; align-items: stretch;
-}
-.footer-export-stack .footer-chip-wrap,
-.footer-export-stack .footer-chip { width: 100%; }
-
 /* Wave bar at the bottom of the footer */
 .footer-wave-bar {
   height: 40px; flex-shrink: 0;
@@ -1808,6 +1802,53 @@ input, textarea { font-family: inherit; }
 }
 .chip-panel-item:hover { background: var(--panel-3); }
 .chip-panel-item.active { color: var(--accent); font-weight: 600; }
+
+/* ── Export split-button dropdown ── */
+/* The whole button toggles the menu, so the caret is purely a decorative
+   open/close indicator (no separate hit area). */
+.export-caret { opacity: 0.8; }
+/* Primary button busy state: swap the download icon for a spinner. */
+.export-spinner { display: none; }
+.footer-chip.is-busy .export-dl-icon { display: none; }
+.footer-chip.is-busy .export-spinner { display: inline-block; animation: sections-spin 700ms linear infinite; }
+
+.chip-panel-export { min-width: 260px; padding: 6px; }
+
+/* WAV / MP3 segmented toggle in the panel header */
+.export-format-toggle {
+  display: flex; gap: 3px; padding: 3px;
+  margin-bottom: 4px;
+  background: var(--bg); border: 1px solid var(--border);
+  border-radius: 8px;
+}
+.export-fmt {
+  flex: 1; padding: 5px 0; border: none; border-radius: 6px;
+  background: transparent; color: var(--muted);
+  font-family: var(--font-mono); font-size: 11px; font-weight: 600;
+  letter-spacing: 0.04em; cursor: pointer;
+  transition: background var(--t-fast), color var(--t-fast);
+}
+.export-fmt:hover { color: var(--fg-2); }
+.export-fmt.active { background: var(--panel-3); color: var(--accent); }
+
+/* Action rows — two-line: icon + (title/desc) + trailing check/count */
+.export-item {
+  align-items: center; gap: 11px;
+  padding: 9px 10px; white-space: normal;
+}
+.export-item .chip-item-icon {
+  flex-shrink: 0; width: 22px;
+  display: flex; align-items: center; justify-content: center;
+  color: var(--muted);
+}
+.export-item .chip-item-text {
+  flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px;
+}
+.chip-item-title { font-size: 13px; font-weight: 500; color: var(--fg); }
+.chip-item-desc { font-size: 11px; color: var(--muted); }
+.chip-item-check { color: var(--accent); flex-shrink: 0; }
+.export-item:hover:not([aria-disabled="true"]) { background: var(--panel-3); }
+.export-item[aria-disabled="true"] { opacity: 0.4; pointer-events: none; }
 
 /* ── About dialog ── */
 .about-backdrop {

--- a/static/index.html
+++ b/static/index.html
@@ -579,58 +579,54 @@
           </div>
 
           <div class="footer-chips">
-            <div class="footer-export-stack">
             <div class="footer-chip-wrap" id="footer-export-wrap">
-              <button class="footer-chip footer-chip-primary" id="t-export-btn" type="button" aria-haspopup="true" aria-expanded="false">
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <button class="footer-chip footer-chip-primary" id="t-export-btn" type="button" aria-haspopup="menu" aria-expanded="false" aria-controls="t-export-panel">
+                <svg class="export-dl-icon" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
                   <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/>
                 </svg>
-                Export Mix
-                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
+                <svg class="export-spinner" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true">
+                  <circle cx="12" cy="12" r="9" stroke-opacity="0.25"/><path d="M21 12a9 9 0 0 0-9-9"/>
+                </svg>
+                <span class="export-btn-label" id="t-export-label">Export Mix</span>
+                <svg class="export-caret" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
                   <polyline points="6 9 12 15 18 9"/>
                 </svg>
               </button>
-              <div class="footer-chip-panel hidden" id="t-export-panel" role="menu">
-                <button class="chip-panel-item" id="t-export-mp3" role="menuitem">
-                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-                    <path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/>
-                  </svg>
-                  MP3
+              <div class="footer-chip-panel chip-panel-export hidden" id="t-export-panel" role="menu" aria-label="Export options">
+                <div class="export-format-toggle" role="radiogroup" aria-label="Export format">
+                  <button class="export-fmt active" id="t-fmt-wav" type="button" role="radio" aria-checked="true">WAV</button>
+                  <button class="export-fmt" id="t-fmt-mp3" type="button" role="radio" aria-checked="false">MP3</button>
+                </div>
+                <button class="chip-panel-item export-item" id="t-export-mix" type="button" role="menuitem">
+                  <span class="chip-item-icon" aria-hidden="true">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9"><line x1="4" y1="9" x2="4" y2="15"/><line x1="9" y1="5" x2="9" y2="19"/><line x1="14" y1="8" x2="14" y2="16"/><line x1="19" y1="4" x2="19" y2="20"/></svg>
+                  </span>
+                  <span class="chip-item-text">
+                    <span class="chip-item-title">Export Mix</span>
+                    <span class="chip-item-desc">Export the mixed audio</span>
+                  </span>
+                  <svg class="chip-item-check" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
                 </button>
-                <button class="chip-panel-item" id="t-export-wav" role="menuitem">
-                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/>
-                  </svg>
-                  WAV
+                <button class="chip-panel-item export-item" id="t-export-stems" type="button" role="menuitem">
+                  <span class="chip-item-icon" aria-hidden="true">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9"><polygon points="12 2 22 8.5 12 15 2 8.5 12 2"/><polyline points="2 15.5 12 22 22 15.5"/></svg>
+                  </span>
+                  <span class="chip-item-text">
+                    <span class="chip-item-title">Export All Stems</span>
+                    <span class="chip-item-desc">All stems as a .zip</span>
+                  </span>
                 </button>
-              </div>
-            </div>
-            <div class="footer-chip-wrap" id="footer-region-wrap">
-              <button class="footer-chip footer-chip-primary" id="t-region-btn" type="button" aria-haspopup="true" aria-expanded="false" disabled>
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-                  <circle cx="6" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><line x1="20" y1="4" x2="8.12" y2="15.88"/><line x1="14.47" y1="14.48" x2="20" y2="20"/><line x1="8.12" y1="8.12" x2="12" y2="12"/>
-                </svg>
-                Export Region
-                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
-                  <polyline points="6 9 12 15 18 9"/>
-                </svg>
-              </button>
-              <div class="footer-chip-panel hidden" id="t-region-panel" role="menu">
-                <button class="chip-panel-item" id="t-region-mp3" role="menuitem">
-                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-                    <path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/>
-                  </svg>
-                  MP3
-                </button>
-                <button class="chip-panel-item" id="t-region-wav" role="menuitem">
-                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/>
-                  </svg>
-                  WAV
+                <button class="chip-panel-item export-item" id="t-export-region" type="button" role="menuitem" aria-disabled="true">
+                  <span class="chip-item-icon" aria-hidden="true">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9"><circle cx="6" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><line x1="20" y1="4" x2="8.12" y2="15.88"/><line x1="14.47" y1="14.48" x2="20" y2="20"/><line x1="8.12" y1="8.12" x2="12" y2="12"/></svg>
+                  </span>
+                  <span class="chip-item-text">
+                    <span class="chip-item-title">Export Current Region</span>
+                    <span class="chip-item-desc">Export selected region</span>
+                  </span>
                 </button>
               </div>
             </div>
-            </div><!-- /.footer-export-stack -->
           </div>
 
         </div><!-- /.footer-content -->

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -3,7 +3,7 @@ import {
   setLoopStart, setLoopEnd, selectedStems, saveSelectedStems, stemSelectionReady,
 } from "./state.js";
 import { STEM_NAMES, syncStemNamesFromAPI } from "./constants.js";
-import { renderEmptyShell, buildStripStems, downloadCurrentMix, downloadCurrentMixMp3, downloadRegionMix, downloadRegionMixMp3, drawFooterPlaceholder } from "./player.js";
+import { renderEmptyShell, buildStripStems, downloadCurrentMix, downloadCurrentMixMp3, downloadAllStemsZip, downloadRegionMix, downloadRegionMixMp3, drawFooterPlaceholder } from "./player.js";
 import { wireJobForm, showError } from "./job.js";
 import { wireTransportButtons } from "./transport.js";
 import { togglePlayPause, updateLoopRegionVisual } from "./transport.js";
@@ -119,56 +119,107 @@ wireAppShellControls();
 // ─── Footer: speed dropdown, export dropdown, scrub seek ───
 
 function wireFooterControls() {
-  // ── Export Region dropdown ──
-  const regionBtn   = document.getElementById("t-region-btn");
-  const regionPanel = document.getElementById("t-region-panel");
-
-  regionBtn?.addEventListener("click", (e) => {
-    e.stopPropagation();
-    const open = !regionPanel?.classList.contains("hidden");
-    closeAllChipPanels();
-    if (!open) {
-      regionPanel?.classList.remove("hidden");
-      regionBtn.setAttribute("aria-expanded", "true");
-    }
-  });
-
-  document.getElementById("t-region-wav")?.addEventListener("click", () => {
-    downloadRegionMix();
-    regionPanel?.classList.add("hidden");
-    regionBtn?.setAttribute("aria-expanded", "false");
-  });
-
-  document.getElementById("t-region-mp3")?.addEventListener("click", () => {
-    downloadRegionMixMp3();
-    regionPanel?.classList.add("hidden");
-    regionBtn?.setAttribute("aria-expanded", "false");
-  });
-
-  // ── Export Mix dropdown ──
+  // ── Export split-button dropdown ──
+  // The full button toggles the export menu. Export actions live inside
+  // the dropdown so the hit target is predictable.
+  // The menu offers Mix / All Stems / Current Region, with a WAV/MP3 toggle in
+  // the header. All exports reuse the backend-served download helpers.
   const exportBtn   = document.getElementById("t-export-btn");
   const exportPanel = document.getElementById("t-export-panel");
+  const exportLabel = document.getElementById("t-export-label");
+  const fmtWav   = document.getElementById("t-fmt-wav");
+  const fmtMp3   = document.getElementById("t-fmt-mp3");
+  const itemMix    = document.getElementById("t-export-mix");
+  const itemStems  = document.getElementById("t-export-stems");
+  const itemRegion = document.getElementById("t-export-region");
+  const actionItems = () => [itemMix, itemStems, itemRegion];
+
+  let format = "wav";
+  let busy = false;
+
+  const panelOpen = () => exportPanel && !exportPanel.classList.contains("hidden");
+  function openPanel() {
+    closeAllChipPanels();
+    exportPanel?.classList.remove("hidden");
+    exportBtn?.setAttribute("aria-expanded", "true");
+  }
+  function closePanel() {
+    exportPanel?.classList.add("hidden");
+    exportBtn?.setAttribute("aria-expanded", "false");
+  }
+
+  function setFormat(f) {
+    format = f;
+    fmtWav?.classList.toggle("active", f === "wav");
+    fmtWav?.setAttribute("aria-checked", String(f === "wav"));
+    fmtMp3?.classList.toggle("active", f === "mp3");
+    fmtMp3?.setAttribute("aria-checked", String(f === "mp3"));
+  }
+  fmtWav?.addEventListener("click", (e) => { e.stopPropagation(); setFormat("wav"); });
+  fmtMp3?.addEventListener("click", (e) => { e.stopPropagation(); setFormat("mp3"); });
+
+  function resetBusy() {
+    busy = false;
+    exportBtn?.classList.remove("is-busy");
+    if (exportLabel) exportLabel.textContent = "Export Mix";
+    itemMix?.removeAttribute("aria-disabled");
+    itemStems?.removeAttribute("aria-disabled");
+    updateLoopRegionVisual(); // restores the region item's disabled state
+  }
+
+  // Single-file (mix/region) downloads give no JS-observable byte progress, so
+  // show a brief indeterminate "Exporting…" state, then reset.
+  function flashBusy() {
+    busy = true;
+    exportBtn?.classList.add("is-busy");
+    if (exportLabel) exportLabel.textContent = "Exporting…";
+    actionItems().forEach((it) => it?.setAttribute("aria-disabled", "true"));
+    closePanel();
+    window.setTimeout(resetBusy, 1200);
+  }
 
   exportBtn?.addEventListener("click", (e) => {
     e.stopPropagation();
-    const open = !exportPanel?.classList.contains("hidden");
-    closeAllChipPanels();
-    if (!open) {
-      exportPanel?.classList.remove("hidden");
-      exportBtn.setAttribute("aria-expanded", "true");
+    if (busy) return;
+    panelOpen() ? closePanel() : openPanel();
+  });
+
+  itemMix?.addEventListener("click", (e) => {
+    e.stopPropagation();
+    if (busy) return;
+    if (format === "mp3") downloadCurrentMixMp3(); else downloadCurrentMix();
+    flashBusy();
+  });
+
+  itemRegion?.addEventListener("click", (e) => {
+    e.stopPropagation();
+    if (busy || itemRegion.getAttribute("aria-disabled") === "true") return;
+    if (format === "mp3") downloadRegionMixMp3(); else downloadRegionMix();
+    flashBusy();
+  });
+
+  // All Stems = a single backend-built ZIP, named after the song.
+  itemStems?.addEventListener("click", (e) => {
+    e.stopPropagation();
+    if (busy) return;
+    downloadAllStemsZip(format);
+    flashBusy();
+  });
+
+  // Keyboard: ↓ opens/moves into the menu, ↑/↓ cycle rows, Esc closes + restores focus.
+  exportBtn?.addEventListener("keydown", (e) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      if (!panelOpen()) openPanel();
+      actionItems().find((it) => it?.getAttribute("aria-disabled") !== "true")?.focus();
     }
   });
-
-  document.getElementById("t-export-wav")?.addEventListener("click", () => {
-    downloadCurrentMix();
-    exportPanel?.classList.add("hidden");
-    exportBtn?.setAttribute("aria-expanded", "false");
-  });
-
-  document.getElementById("t-export-mp3")?.addEventListener("click", () => {
-    downloadCurrentMixMp3();
-    exportPanel?.classList.add("hidden");
-    exportBtn?.setAttribute("aria-expanded", "false");
+  exportPanel?.addEventListener("keydown", (e) => {
+    const focusable = actionItems().filter((it) => it && it.getAttribute("aria-disabled") !== "true");
+    const idx = focusable.indexOf(document.activeElement);
+    if (e.key === "Escape") { closePanel(); exportBtn?.focus(); }
+    else if (e.key === "ArrowDown") { e.preventDefault(); focusable[(idx + 1) % focusable.length]?.focus(); }
+    else if (e.key === "ArrowUp") { e.preventDefault(); focusable[(idx - 1 + focusable.length) % focusable.length]?.focus(); }
   });
 
   // ── Scrub bar seek ──

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -1120,11 +1120,40 @@ export function downloadCurrentMixMp3() {
   _triggerDownload(url.replace(/\.wav$/, ".mp3"), _exportFilename("mp3"));
 }
 
-export function downloadCurrentStems() {
+export function downloadCurrentStems(format = "wav", onProgress) {
   const stems = _currentStems.filter((s) => s.name !== "original");
+  const total = stems.length;
+  if (!total) { onProgress?.(0, 0); return; }
+  // Name each file "<song title>_<instrument>.<ext>" using the same title
+  // sanitization as the mix/region exports.
+  const safe = _currentTitle
+    .replace(/[^a-zA-Z0-9]+/g, "_")
+    .replace(/_{2,}/g, "_")
+    .slice(0, 80)
+    .replace(/^_+|_+$/g, "");
   stems.forEach((s, i) => {
-    window.setTimeout(() => _triggerDownload(s.url, `${s.name}.wav`), i * 150);
+    window.setTimeout(() => {
+      const url = format === "mp3" ? s.url.replace(/\.wav(\?|$)/, ".mp3$1") : s.url;
+      const fname = safe ? `${safe}_${s.name}.${format}` : `${s.name}.${format}`;
+      _triggerDownload(url, fname);
+      onProgress?.(i + 1, total);
+    }, i * 150);
   });
+}
+
+export function downloadAllStemsZip(format = "wav") {
+  if (!currentJobId) return;
+  // Only the active (selected) stems loaded in the DAW — not all 6.
+  const names = _currentStems.filter((s) => s.name !== "original").map((s) => s.name);
+  if (!names.length) return;
+  const safe = _currentTitle
+    .replace(/[^a-zA-Z0-9]+/g, "_")
+    .replace(/_{2,}/g, "_")
+    .slice(0, 80)
+    .replace(/^_+|_+$/g, "");
+  const name = safe ? `${safe}_stems.zip` : "stems.zip";
+  const q = new URLSearchParams({ format, stems: names.join(",") });
+  _triggerDownload(`/api/jobs/${currentJobId}/stems/all.zip?${q}`, name);
 }
 
 function _regionFilename(ext) {

--- a/static/js/transport.js
+++ b/static/js/transport.js
@@ -139,9 +139,9 @@ export function updatePresencePlayhead(currentSec) {
 }
 
 export function updateLoopRegionVisual() {
-  const regionBtn = document.getElementById("t-region-btn");
+  const regionItem = document.getElementById("t-export-region");
   const hasRegion = loopEnabled && totalDuration > 0 && loopEnd > loopStart;
-  if (regionBtn) regionBtn.disabled = !hasRegion;
+  if (regionItem) regionItem.setAttribute("aria-disabled", String(!hasRegion));
   if (!loopEnabled || !totalDuration) {
     loopRegionEl.classList.add("hidden");
     return;

--- a/tests/test_stems_api.py
+++ b/tests/test_stems_api.py
@@ -115,3 +115,118 @@ def test_peaks_rejects_malformed_job_id(client):
     for bad_id in ("../etc", "ABC", "abcdefabcdef0", "abcdefabcde"):
         r = client.get(f"/api/jobs/{bad_id}/stems/peaks.json")
         assert r.status_code == 404, f"id {bad_id!r} should 404"
+
+
+# ── Export All Stems (.zip) ──
+
+
+def test_all_stems_zip_all_when_no_subset(client, tmp_path):
+    import io
+    import zipfile
+
+    job = Job(id="abcdefabcdab")
+    job.status = "done"
+    job.title = "My Song! (Live)"
+    _jobs[job.id] = job
+    _make_stem_file(tmp_path, job.id, "vocals", b"RIFFvocals")
+    _make_stem_file(tmp_path, job.id, "drums", b"RIFFdrums")
+    _make_stem_file(tmp_path, job.id, "bass", b"RIFFbass")
+
+    r = client.get(f"/api/jobs/{job.id}/stems/all.zip")
+    assert r.status_code == 200
+    assert r.headers["content-type"] == "application/zip"
+    assert "My_Song_Live_stems.zip" in r.headers["content-disposition"]
+
+    zf = zipfile.ZipFile(io.BytesIO(r.content))
+    assert sorted(zf.namelist()) == ["bass.wav", "drums.wav", "vocals.wav"]
+    assert zf.read("vocals.wav") == b"RIFFvocals"
+
+
+def test_all_stems_zip_only_active_subset(client, tmp_path):
+    """Only the requested (active) stems are bundled — not every stem on disk."""
+    import io
+    import zipfile
+
+    job = Job(id="abcdefabcdba")
+    job.status = "done"
+    _jobs[job.id] = job
+    for name in ("vocals", "drums", "bass", "guitar", "piano", "other"):
+        _make_stem_file(tmp_path, job.id, name, f"RIFF{name}".encode())
+
+    r = client.get(f"/api/jobs/{job.id}/stems/all.zip?stems=vocals,bass")
+    assert r.status_code == 200
+    zf = zipfile.ZipFile(io.BytesIO(r.content))
+    assert sorted(zf.namelist()) == ["bass.wav", "vocals.wav"]
+
+
+def test_all_stems_zip_rejects_unknown_stem(client, tmp_path):
+    job = Job(id="abcdefabcdbb")
+    job.status = "done"
+    _jobs[job.id] = job
+    _make_stem_file(tmp_path, job.id, "vocals")
+    r = client.get(f"/api/jobs/{job.id}/stems/all.zip?stems=vocals,banjo")
+    assert r.status_code == 422
+
+
+def test_all_stems_zip_rejects_bad_format(client, tmp_path):
+    job = Job(id="abcdefabcdac")
+    job.status = "done"
+    _jobs[job.id] = job
+    _make_stem_file(tmp_path, job.id, "vocals")
+    r = client.get(f"/api/jobs/{job.id}/stems/all.zip?format=flac")
+    assert r.status_code == 422
+
+
+def test_all_stems_zip_404_for_unknown_job(client):
+    r = client.get("/api/jobs/abcdefabcdad/stems/all.zip")
+    assert r.status_code == 404
+
+
+def test_all_stems_zip_rejects_malformed_job_id(client):
+    for bad_id in ("../etc", "ABC", "abcdefabcdef0", "abcdefabcde"):
+        r = client.get(f"/api/jobs/{bad_id}/stems/all.zip")
+        assert r.status_code == 404, f"id {bad_id!r} should 404"
+
+
+def test_all_stems_zip_404_when_no_stem_files(client, tmp_path):
+    job = Job(id="abcdefabcdae")
+    job.status = "done"
+    _jobs[job.id] = job
+    (tmp_path / job.id / "stems").mkdir(parents=True, exist_ok=True)
+    r = client.get(f"/api/jobs/{job.id}/stems/all.zip")
+    assert r.status_code == 404
+
+
+def test_all_stems_zip_mp3(client, tmp_path):
+    """MP3 zip transcodes via ffmpeg; skip if ffmpeg isn't available."""
+    import io
+    import shutil
+    import zipfile
+
+    if shutil.which("ffmpeg") is None:
+        import pytest
+
+        pytest.skip("ffmpeg not available")
+
+    # A real (tiny) WAV so ffmpeg can transcode it.
+    import struct
+
+    sr = 8000
+    nframes = sr // 10
+    data = b"\x00\x00" * nframes
+    hdr = b"RIFF" + struct.pack("<I", 36 + len(data)) + b"WAVE"
+    hdr += b"fmt " + struct.pack("<IHHIIHH", 16, 1, 1, sr, sr * 2, 2, 16)
+    hdr += b"data" + struct.pack("<I", len(data))
+    wav = hdr + data
+
+    job = Job(id="abcdefabcdaf")
+    job.status = "done"
+    job.title = "Track"
+    _jobs[job.id] = job
+    _make_stem_file(tmp_path, job.id, "vocals", wav)
+
+    r = client.get(f"/api/jobs/{job.id}/stems/all.zip?format=mp3")
+    assert r.status_code == 200
+    zf = zipfile.ZipFile(io.BytesIO(r.content))
+    assert zf.namelist() == ["vocals.mp3"]
+    assert len(zf.read("vocals.mp3")) > 0


### PR DESCRIPTION
Closes #160.

Adds a one-click "Export All Stems" (the original ask in #160 — no more clicking 6 download buttons) and consolidates the footer's two export split-buttons into a single dropdown.

## Frontend
- One **Export Mix** split-button → dropdown with **Export Mix**, **Export All Stems**, **Export Current Region** (icon + title + description). The whole button opens the menu; the caret is a decorative indicator.
- **WAV/MP3 toggle** in the panel header, applied to whichever action is picked.
- **Export Current Region** is disabled (greyed, `aria-disabled`) until a loop region exists.
- **Export Mix and Export Stems operate on the active (selected) stems only**, not all six.
- Stem-mix exports keep song-titled filenames; brief "Exporting…" busy state.
- Keyboard: arrow nav + Esc-to-close with focus return; `role="menu"/menuitem"`.

## Backend
- New `GET /api/jobs/{id}/stems/all.zip?format=wav|mp3&stems=…` — streams a single ZIP **named after the song**, scoped to the requested (whitelisted) stems.
- WAV stems are stored as-is; MP3 is transcoded per stem via ffmpeg in a worker thread.
- **Stdlib `zipfile` only — no new dependencies.** Temp file + background cleanup; full job-id/format/path validation.

Bonus: in the Tauri desktop app this is now one save dialog instead of six.

## Testing
- `uv run pytest tests/` — 6 new zip cases (subset scoping, default-all, bad format, unknown stem, malformed/unknown job, no-stems, mp3 transcode); full suite green.
- `ruff check` + `ruff format` clean; `bandit -ll` 0 medium/high.
- `node --check` on changed JS; Playwright verified open/close, format toggle, active-stems param, filenames, region enable/disable, keyboard nav.

## Notes
- Branch is based on `main`, independent of #161.
- Requires Safari 16+ / Chromium 90+ baseline already used elsewhere; no new runtime deps.