### PR TITLE
fix: smoother stem-lane scroll sync (#163)

### DIFF
--- a/static/js/transport.js
+++ b/static/js/transport.js
@@ -380,14 +380,14 @@ function wireZoomButtons() {
 function wireLaneScrollSync() {
   const mixer = document.getElementById("mixer");
   if (!mixer || !waveScroll) return;
-  let syncing = false;
+  // Mirror scrollTop between the two panes by assigning only when the values
+  // differ. The echo stops on its own (once equal, the partner's handler is a
+  // no-op), so no reentrancy guard / rAF is needed — that frame-delayed guard
+  // was what made inertial scrolling stutter (#163).
   const link = (src, dst) =>
     src.addEventListener("scroll", () => {
-      if (syncing) return;
-      syncing = true;
-      dst.scrollTop = src.scrollTop;
-      requestAnimationFrame(() => { syncing = false; });
-    });
+      if (dst.scrollTop !== src.scrollTop) dst.scrollTop = src.scrollTop;
+    }, { passive: true });
   link(mixer, waveScroll);
   link(waveScroll, mixer);
 }


### PR DESCRIPTION
Closes #163.

Vertical scrolling of the stem lanes (mixer ↔ waveform) stuttered/"buffered" during trackpad inertia.

## Cause
`wireLaneScrollSync` (`static/js/transport.js`) mirrored `scrollTop` between the two panes using a `requestAnimationFrame`-released reentrancy guard. The guard cleared one frame late, so during momentum scrolling the echo could write a stale `scrollTop` back to the pane being actively scrolled, and the partner trailed by up to a frame.

## Fix
Drop the guard; assign `scrollTop` only when the values differ. The echo terminates naturally (once equal, the partner's handler is a no-op), with no frame delay — so inertial scrolling stays smooth.

## Testing
- `node --check`.
- Playwright: with lanes overflowing, scrolling either pane keeps both in lockstep (mixer→wave and wave→mixer), no echo loop, no errors.

Introduced in #159.