### PR TITLE
feat: Web Audio decode-and-mix engine to fix Safari/WKWebView chop

### DIFF
--- a/static/js/audioEngine.js
+++ b/static/js/audioEngine.js
@@ -1,0 +1,174 @@
+// Web Audio decode-and-mix playback engine.
+//
+// Safari/WKWebView goes choppy when playing N streaming <audio> elements (one per
+// stem) over HTTP/1.1: the 6-connection-per-origin cap + small media buffers + the
+// multitrack's per-element currentTime nudging cause underruns. This engine instead
+// decodes each active stem once into an AudioBuffer and plays them all from a single
+// AudioContext clock — sample-accurate, zero streaming connections during playback,
+// no drift. Works identically on WKWebView, Safari, and Chrome.
+//
+// Graph:  per-stem AudioBufferSourceNode -> GainNode (vol/mute/solo) -> AnalyserNode (VU)
+//                                                                    -> masterGain -> destination
+//
+// Used behind a feature flag (see player.js) so it can be A/B'd against the legacy
+// streaming path before cutover.
+
+const AudioCtx = window.AudioContext || window.webkitAudioContext;
+
+/**
+ * @param {{name:string,url:string}[]} stems  Active stems only (caller filters).
+ * @param {{onTime?:(t:number)=>void, onEnded?:()=>void}} cbs
+ */
+export function createAudioEngine(stems, { onTime, onEnded } = {}) {
+  const ctx = new AudioCtx();
+  const master = ctx.createGain();
+  master.connect(ctx.destination);
+
+  /** @type {Map<string,{buffer:AudioBuffer,gain:GainNode,analyser:AnalyserNode,source:AudioBufferSourceNode|null}>} */
+  const tracks = new Map();
+  let duration = 0;
+  let playing = false;
+  let startCtxTime = 0; // ctx.currentTime at playback start
+  let startOffset = 0; // media offset at that moment
+  let rafId = null;
+  let destroyed = false;
+  let loop = { enabled: false, start: 0, end: 0 };
+
+  // Decode all stems up front. Resolves true once at least one stem is ready.
+  const ready = (async () => {
+    await Promise.all(
+      stems.map(async (s) => {
+        if (!s?.url) return;
+        try {
+          const res = await fetch(s.url);
+          if (!res.ok) throw new Error(`fetch ${res.status}`);
+          const buffer = await ctx.decodeAudioData(await res.arrayBuffer());
+          if (destroyed) return;
+          const gain = ctx.createGain();
+          const analyser = ctx.createAnalyser();
+          analyser.fftSize = 1024;
+          gain.connect(analyser);
+          analyser.connect(master);
+          tracks.set(s.name, { buffer, gain, analyser, source: null });
+          duration = Math.max(duration, buffer.duration);
+        } catch (e) {
+          console.warn(`[audioEngine] decode failed for ${s.name}:`, e);
+        }
+      }),
+    );
+    return tracks.size > 0;
+  })();
+
+  const now = () => (playing ? ctx.currentTime - startCtxTime + startOffset : startOffset);
+
+  function stopSources() {
+    for (const t of tracks.values()) {
+      if (t.source) {
+        try { t.source.stop(); } catch { /* already stopped */ }
+        try { t.source.disconnect(); } catch { /* noop */ }
+        t.source = null;
+      }
+    }
+  }
+
+  function startSources(offset) {
+    const when = ctx.currentTime;
+    for (const t of tracks.values()) {
+      const src = ctx.createBufferSource();
+      src.buffer = t.buffer;
+      src.connect(t.gain);
+      src.start(when, Math.max(0, Math.min(offset, t.buffer.duration)));
+      t.source = src;
+    }
+    startCtxTime = when;
+    startOffset = offset;
+  }
+
+  function tick() {
+    if (!playing) return;
+    let t = now();
+    if (loop.enabled && loop.end > loop.start && t >= loop.end) {
+      seek(loop.start);
+      t = loop.start;
+    } else if (t >= duration) {
+      pause();
+      startOffset = duration;
+      onTime?.(duration);
+      onEnded?.();
+      return;
+    }
+    onTime?.(t);
+    rafId = requestAnimationFrame(tick);
+  }
+
+  function play() {
+    if (playing || destroyed || !tracks.size) return;
+    // Safari: resume the context fire-and-forget within the user-gesture tick.
+    if (ctx.state === "suspended") ctx.resume().catch(() => {});
+    let off = startOffset;
+    if (off >= duration) off = 0;
+    startSources(off);
+    playing = true;
+    rafId = requestAnimationFrame(tick);
+  }
+
+  function pause() {
+    if (!playing) return;
+    const t = now();
+    stopSources();
+    playing = false;
+    startOffset = Math.max(0, Math.min(t, duration));
+    if (rafId) { cancelAnimationFrame(rafId); rafId = null; }
+  }
+
+  function seek(t) {
+    const clamped = Math.max(0, Math.min(t, duration || 0));
+    if (playing) {
+      stopSources();
+      startSources(clamped);
+    } else {
+      startOffset = clamped;
+    }
+    onTime?.(clamped);
+  }
+
+  function setGain(name, v) {
+    const t = tracks.get(name);
+    if (t) t.gain.gain.setTargetAtTime(Math.max(0, v), ctx.currentTime, 0.01);
+  }
+
+  function setMasterGain(v) {
+    master.gain.setTargetAtTime(Math.max(0, v), ctx.currentTime, 0.01);
+  }
+
+  function destroy() {
+    destroyed = true;
+    stopSources();
+    if (rafId) { cancelAnimationFrame(rafId); rafId = null; }
+    tracks.clear();
+    ctx.close().catch(() => {});
+  }
+
+  return {
+    ready,
+    play,
+    pause,
+    seek,
+    setTime: seek, // alias to match the multitrack interface used by transport.js
+    isPlaying: () => playing,
+    getCurrentTime: now,
+    getDuration: () => duration,
+    setLoop: (enabled, start, end) => { loop = { enabled, start, end }; },
+    setGain,
+    setMasterGain,
+    getAnalyser: (name) => tracks.get(name)?.analyser ?? null,
+    destroy,
+    audioContext: ctx,
+  };
+}
+
+// Rough decoded-PCM memory estimate (Float32 = 4 bytes/sample/channel) used by the
+// caller's guard to fall back to streaming for very long / many-stem tracks.
+export function estimateDecodedBytes(durationSec, stemCount, channels = 2, sampleRate = 44100) {
+  return Math.round(durationSec * stemCount * channels * sampleRate * 4);
+}

--- a/static/js/mixer.js
+++ b/static/js/mixer.js
@@ -3,7 +3,7 @@ import {
 } from "./constants.js";
 import {
   mixerState, mixerEl, stemListEl, currentJobId, multitrack, trackIndex,
-  masterVolume,
+  masterVolume, audioEngine,
 } from "./state.js";
 import { storeGet, storeSetDebounced } from "./utils.js";
 
@@ -57,6 +57,14 @@ export function applyMix() {
     if (idx === undefined) continue;
 
     const targetGain = effective * masterVolume;
+
+    if (audioEngine) {
+      // Web Audio engine owns playback: set the per-stem gain directly (no 1.0
+      // cap, so >1.0 lane boost works), and skip the streaming volume path —
+      // the multitrack is mounted for visuals only and never plays.
+      audioEngine.setGain(name, targetGain);
+      continue;
+    }
 
     const audioEl = multitrack.audios?.[idx];
     if (audioEl instanceof HTMLMediaElement) {

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -11,12 +11,14 @@ import {
   multitrack, currentJobId, trackIndex, totalDuration, loopEnabled,
   loopStart, loopEnd, trackAnalysers,
   masterVolume, masterFader, mixerState,
+  audioEngine, setAudioEngine,
   setMultitrack, setCurrentJobId, setTrackIndex, setTotalDuration,
   setLoopEnabled, setLoopStart, setLoopEnd, setMasterVolume,
   waveScroll, selectedStems,
   footerTitle, footerMeta, footerThumb,
   setFooterWaveDrawFn,
 } from "./state.js";
+import { createAudioEngine, estimateDecodedBytes } from "./audioEngine.js";
 import {
   loadMixIntoState, resetMixerState, refreshMixerVisuals,
   setLaneControlsEnabled, ensureMixerStateDefaults, applyMix,
@@ -29,6 +31,22 @@ import {
 } from "./transport.js";
 import { stopVuLoop } from "./audio.js";
 import { destroySections } from "./sections.js";
+
+// Feature flag for the Web Audio decode-and-mix engine (audioEngine.js).
+// Playback runs off decoded AudioBuffers on a single AudioContext clock instead
+// of N streaming <audio> elements — fixes Safari/WKWebView choppiness. Default
+// ON (the desktop app is WKWebView for every macOS user); set
+// localStorage "stemdeck.audioEngine" = "0" to opt back into the legacy
+// streaming path for A/B without a rebuild.
+function audioEngineEnabled() {
+  try { return localStorage.getItem("stemdeck.audioEngine") !== "0"; }
+  catch (e) { console.warn("[player] audioEngine flag read failed:", e); return true; }
+}
+
+// Above this estimated decoded-PCM size the engine is skipped and playback
+// falls back to streaming, so a long full-stem track can't exhaust WKWebView's
+// memory. ~1.2 GB ≈ 6 stems × ~10 min (or 4 stems × ~15 min) at 44.1 kHz/Float32.
+const MAX_ENGINE_DECODED_BYTES = 1.2e9;
 
 // Stem-selection filter: the import-page stem-choice toggles set
 // selectedStems (state.js). Backend always processes all 6 -- we
@@ -438,8 +456,11 @@ function startStemVuLoop(stems, decodedMap, token) {
   if (!meters.length) return;
   const tick = () => {
     if (token !== visualRenderToken || !multitrack) return;
-    const playing = multitrack.isPlaying?.() ?? false;
-    const time = multitrack.getCurrentTime?.() ?? 0;
+    // When the Web Audio engine owns playback, the multitrack is silent — read
+    // the clock/transport state from the engine so the meters track real audio.
+    const src = audioEngine ?? multitrack;
+    const playing = src.isPlaying?.() ?? false;
+    const time = src.getCurrentTime?.() ?? 0;
     for (const m of meters) {
       const idx = Math.max(0, Math.min(m.env.length - 1, Math.floor(time * STEM_VU_FPS)));
       const gain = stemVuGain(m.name);
@@ -493,6 +514,10 @@ export function destroyPlayer() {
   destroySections();
   stopVuLoop();
   stopStemVuLoop();
+  if (audioEngine) {
+    audioEngine.destroy();
+    setAudioEngine(null);
+  }
   if (multitrack) {
     multitrack.destroy();
     setMultitrack(null);
@@ -836,10 +861,11 @@ export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, ti
   // the ruler also update the visual without extra plumbing.
   const STOP_TOLERANCE_SEC = 0.15;
   const updateStopVisual = () => {
-    const t = mt.getCurrentTime?.() ?? 0;
+    const src = audioEngine ?? mt;
+    const t = src.getCurrentTime?.() ?? 0;
     const startPos = loopEnabled ? loopStart : 0;
     const atStart = Math.abs(t - startPos) < STOP_TOLERANCE_SEC;
-    const stopped = !mt.isPlaying() && atStart;
+    const stopped = !src.isPlaying() && atStart;
     stopBtn.classList.toggle("stopped", stopped);
   };
 
@@ -937,6 +963,63 @@ export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, ti
       updateStopVisual();
     });
     ws.on("seeking", updateStopVisual);
+
+    // ── Web Audio engine (flag-gated) ──────────────────────────────────────
+    // When enabled, decode the active stems and play them off a single
+    // AudioContext clock instead of the streaming <audio> elements above. The
+    // multitrack stays mounted for visuals only (it never plays), so the ws
+    // play/pause/timeupdate handlers wired above simply don't fire — the engine
+    // drives the identical UI updates via onTime/onEnded. transport.js, mixer
+    // applyMix, the VU loop, and updateStopVisual all route through
+    // `audioEngine ?? multitrack`, so flag-off is byte-identical to before.
+    const engineStemCount = stems.filter((s) => s.url).length;
+    const engineTooLarge =
+      estimateDecodedBytes(totalDuration, engineStemCount) > MAX_ENGINE_DECODED_BYTES;
+    if (engineTooLarge) {
+      console.warn(
+        `[player] track too large for Web Audio engine `
+        + `(~${Math.round(estimateDecodedBytes(totalDuration, engineStemCount) / 1e6)} MB `
+        + `for ${engineStemCount} stems × ${Math.round(totalDuration)}s); using streaming path`,
+      );
+    }
+    if (audioEngineEnabled() && !engineTooLarge) {
+      // Mirror the streaming "timeupdate" handler body so playhead/footer/
+      // presence/stop-visual update the same way regardless of which clock runs.
+      const driveTransportUi = (t) => {
+        timeEl.textContent = `${fmtTime(t)} / ${fmtTime(totalDuration)}`;
+        updatePlayheadMarker(t);
+        updateFooterTimes(t);
+        updatePresencePlayhead(t);
+        updateStopVisual();
+      };
+      if (audioEngine) { audioEngine.destroy(); setAudioEngine(null); }
+      const eng = createAudioEngine(stems, {
+        onTime: driveTransportUi,
+        onEnded: () => { playBtn.classList.remove("playing"); updateStopVisual(); },
+      });
+      setAudioEngine(eng);
+      eng.ready.then((ok) => {
+        // Bail if the user switched tracks while we were decoding.
+        if (token !== visualRenderToken || multitrack !== mt) {
+          eng.destroy();
+          if (audioEngine === eng) setAudioEngine(null);
+          return;
+        }
+        if (!ok) {
+          // No decodable stems — fall back to the streaming path transparently.
+          console.warn("[player] audio engine had no decodable stems; using streaming path");
+          eng.destroy();
+          setAudioEngine(null);
+          return;
+        }
+        eng.setLoop(loopEnabled, loopStart, loopEnd);
+        applyMix(); // push per-stem gains (incl. >1.0 boost) into the engine
+      }).catch((e) => {
+        console.warn("[player] audio engine init failed; using streaming path:", e);
+        eng.destroy();
+        if (audioEngine === eng) setAudioEngine(null);
+      });
+    }
   });
 }
 

--- a/static/js/state.js
+++ b/static/js/state.js
@@ -52,6 +52,8 @@ export const footerThumb     = $("footer-thumb");
 
 export let eventSource = null;
 export let multitrack = null;
+// Web Audio decode-and-mix engine (Safari-safe playback). Null = legacy streaming path.
+export let audioEngine = null;
 export let currentJobId = null;
 
 // `mixerState` is mutated in place (never reassigned). renderMixerRow's
@@ -123,6 +125,7 @@ export let masterLimiter = null;
 
 export function setEventSource(v) { eventSource = v; }
 export function setMultitrack(v) { multitrack = v; }
+export function setAudioEngine(v) { audioEngine = v; }
 export function setCurrentJobId(v) { currentJobId = v; }
 export function setTrackIndex(v) { trackIndex = v; }
 export function setTotalDuration(v) { totalDuration = v; }

--- a/static/js/transport.js
+++ b/static/js/transport.js
@@ -2,7 +2,7 @@ import { fmtTime, fmtTickLabel } from "./utils.js";
 import {
   playBtn, playMiniBtn, stopBtn, loopBtn, timeEl, masterFader,
   rulerTime, wavesGrid, loopRegionEl, playheadMarker,
-  multitrack, totalDuration, loopEnabled, loopStart, loopEnd, masterVolume,
+  multitrack, audioEngine, totalDuration, loopEnabled, loopStart, loopEnd, masterVolume,
   waveScroll, waveCanvas, multitrackContainer,
   presenceRulerEl, presencePlayheadEl,
   footerTimeElapsed, footerTimeTotal, npScrubFill, footerWaveDrawFn,
@@ -45,9 +45,10 @@ function timeFromClientX(clientX) {
 }
 
 function setPlayheadTime(sec) {
-  if (!multitrack || !totalDuration) return;
+  const tx = audioEngine ?? multitrack;
+  if (!tx || !totalDuration) return;
   const next = Math.max(0, Math.min(totalDuration, sec));
-  multitrack.setTime(next);
+  tx.setTime(next);
   updatePlayheadMarker(next);
   updateFooterTimes(next);
   updatePresencePlayhead(next);
@@ -145,6 +146,9 @@ export function updateLoopRegionVisual() {
   const regionItem = document.getElementById("t-export-region");
   const hasRegion = loopEnabled && totalDuration > 0 && loopEnd > loopStart;
   if (regionItem) regionItem.setAttribute("aria-disabled", String(!hasRegion));
+  // Keep the engine's loop bounds in sync with every loop change (toggle/drag);
+  // the engine wraps playback itself off these values. No-op on streaming path.
+  audioEngine?.setLoop(loopEnabled, loopStart, loopEnd);
   if (!loopEnabled || !totalDuration) {
     loopRegionEl.classList.add("hidden");
     return;
@@ -203,12 +207,18 @@ function _playWhenReady() {
 }
 
 export function togglePlayPause() {
-  if (!multitrack) return;
-  if (multitrack.isPlaying()) {
-    multitrack.pause();
+  const eng = audioEngine;
+  const tx = eng ?? multitrack;
+  if (!tx) return;
+  if (tx.isPlaying()) {
+    tx.pause();
+    // The engine emits no play/pause events (the multitrack stays silent), so
+    // the play-button visual that the ws "pause" handler normally toggles must
+    // be driven here directly.
+    if (eng) playBtn.classList.remove("playing");
     return;
   }
-  const ctx = multitrack.audioContext;
+  const ctx = tx.audioContext;
   // Safari requires play() to be called synchronously within the user-gesture
   // handler. Resume the AudioContext fire-and-forget so the context becomes
   // live, then call play() immediately on the same tick.
@@ -217,15 +227,24 @@ export function togglePlayPause() {
   }
   // Snap playhead to loopStart on play (DAW convention).
   if (loopEnabled && totalDuration > 0) {
-    multitrack.setTime(loopStart);
+    tx.setTime(loopStart);
   }
-  _playWhenReady();
+  if (eng) {
+    eng.play();
+    playBtn.classList.add("playing");
+    stopBtn.classList.remove("stopped");
+  } else {
+    _playWhenReady();
+  }
 }
 
 export function stopTransport() {
-  if (!multitrack) return;
-  multitrack.pause();
-  multitrack.setTime(loopEnabled ? loopStart : 0);
+  const eng = audioEngine;
+  const tx = eng ?? multitrack;
+  if (!tx) return;
+  tx.pause();
+  tx.setTime(loopEnabled ? loopStart : 0); // engine: setTime → onTime → stop visual
+  if (eng) playBtn.classList.remove("playing");
 }
 
 export function toggleLoop() {


### PR DESCRIPTION
## Problem
Audio was choppy on Safari/WKWebView but smooth on Chrome. Playback ran **6 streaming `<audio>` elements** (one per stem) over HTTP/1.1. Safari's 6-connection-per-origin cap + small media buffers + the multitrack's `startSync()` nudging each element's `currentTime` (forcing re-seeks/re-buffers) caused periodic underruns. Chrome's larger buffers hid the same design flaw.

HTTP/2 isn't a cheap fix — browsers only do HTTP/2 over TLS, so it would mean standing up trusted localhost TLS for the desktop app, and only mitigates.

## Fix
Decode each **active** stem once into an `AudioBuffer` and play them all from a single `AudioContext` clock:

```
AudioBufferSourceNode → per-stem GainNode → AnalyserNode → masterGain → destination
```

- Sample-accurate, **zero streaming connections during playback**, no inter-stem drift.
- Works identically on WKWebView, Safari, and Chrome — no networking/TLS change.
- Restores **>1.0 per-stem gain** (the WKWebView native-volume path capped at 1.0).

The wavesurfer-multitrack stays mounted for **visuals only** and never plays. Every transport/mixer/VU read routes through `audioEngine ?? multitrack`, so the engine is a drop-in: with it off, behavior is byte-identical to the streaming path.

## Safety
- **Default on**; `localStorage "stemdeck.audioEngine" = "0"` falls back to streaming for A/B.
- **Memory guard** (`MAX_ENGINE_DECODED_BYTES`, ~1.2 GB): very long full-stem tracks skip the engine and stream instead, so decoded PCM can't exhaust WKWebView memory.
- Engine init failure or no decodable stems → transparent fallback to streaming.

## Files
- `static/js/audioEngine.js` (new) — the engine
- `static/js/state.js` — `audioEngine` + `setAudioEngine`
- `static/js/player.js` — flag + guard, engine creation in `canplay`, VU loop + stop-visual read the engine clock, cleanup in `destroyPlayer`
- `static/js/transport.js` — play/pause/stop/seek/loop route through the engine
- `static/js/mixer.js` — `applyMix` sets per-stem engine gain

## Testing
Verified on **Safari and Chrome**: clean playback (no chop), seek, loop, mute/solo, master gain, VU metering all correct; memory guard falls back to streaming.

## Follow-up (not in this PR)
Reuse wavesurfer's already-decoded `getDecodedData()` buffers to drop the load-time double fetch+decode.