### PR TITLE
feat: Edit Library window with out-of-sync detection and auto-restore

### DIFF
--- a/static/css/daw.css
+++ b/static/css/daw.css
@@ -430,18 +430,6 @@ input, textarea { font-family: inherit; }
 .rail-btn.active { color: var(--accent); background: var(--panel); }
 .rail-btn svg { flex-shrink: 0; }
 .rail-btn span { white-space: nowrap; }
-.settings-coming-soon {
-  position: fixed;
-  display: none;
-  background: var(--panel-2); border: 1px solid var(--border-strong);
-  border-radius: var(--radius); padding: 8px 12px;
-  font-size: 12px; color: var(--muted); white-space: nowrap;
-  box-shadow: 0 4px 16px rgba(0,0,0,0.4); z-index: 300;
-  pointer-events: none;
-}
-#settingsBtn:hover .settings-coming-soon {
-  display: block;
-}
 
 /* Sidebar body */
 .sidebar-body {
@@ -742,6 +730,47 @@ input, textarea { font-family: inherit; }
 .folder-editor-actions button { min-height: 30px; border-radius: 7px; font-family: var(--font-mono); font-size: 11px; cursor: pointer; padding: 0 11px; }
 .folder-editor-cancel { border: 1px solid var(--border); background: rgba(21,31,39,0.52); color: var(--muted); }
 .folder-editor-save { border: 1px solid rgba(244,183,64,0.3); background: rgba(244,183,64,0.16); color: var(--accent); }
+
+/* Edit Library modal (Settings → opens this centered window) */
+.library-editor-backdrop {
+  position: fixed; inset: 0; z-index: 80;
+  display: grid; place-items: center;
+  background: rgba(3,8,13,0.42); backdrop-filter: blur(2px);
+}
+.library-editor {
+  width: min(560px, calc(100vw - 32px));
+  max-height: min(70vh, 620px);
+  display: flex; flex-direction: column;
+  border: 1px solid var(--border-strong);
+  border-radius: 10px;
+  background: linear-gradient(180deg, rgba(28,39,48,0.98), rgba(13,21,29,0.98));
+  box-shadow: var(--shadow-panel);
+  padding: 12px; color: var(--fg); font-family: var(--font-mono);
+}
+.library-editor-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 10px; font-size: 13px; font-weight: 600; }
+.library-editor-close { width: 24px; height: 24px; border: 1px solid transparent; border-radius: 6px; background: transparent; color: var(--muted); cursor: pointer; display: grid; place-items: center; padding: 0; }
+.library-editor-close:hover { background: rgba(21,31,39,0.8); color: var(--fg); }
+.library-editor-table-wrap { flex: 1; min-height: 0; overflow-y: auto; border: 1px solid var(--border); border-radius: 7px; background: rgba(10,17,24,0.5); }
+.library-editor-table { width: 100%; border-collapse: collapse; font-size: 11.5px; }
+.library-editor-table thead th {
+  position: sticky; top: 0;
+  text-align: left; font-weight: 600; font-size: 10px;
+  text-transform: uppercase; letter-spacing: 0.04em;
+  color: var(--muted); background: rgba(13,21,29,0.96);
+  padding: 8px 10px; border-bottom: 1px solid var(--border);
+}
+.library-editor-table tbody td { padding: 7px 10px; border-bottom: 1px solid rgba(148,163,184,0.07); color: var(--fg-2); vertical-align: middle; }
+.library-editor-table tbody tr:last-child td { border-bottom: none; }
+.library-editor-table .le-name { color: var(--fg); max-width: 220px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.library-editor-table .le-loc { max-width: 200px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.library-editor-table tr.unavailable .le-name { color: var(--danger); }
+.le-badge { margin-left: 7px; padding: 1px 6px; border-radius: 5px; font-size: 9px; text-transform: uppercase; letter-spacing: 0.04em; background: rgba(214,90,74,0.16); color: var(--danger); }
+.library-editor-empty { color: var(--muted); text-align: center; padding: 22px 10px !important; }
+.library-editor-foot { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-top: 11px; }
+.library-editor-status { font-size: 10.5px; color: var(--muted); }
+.library-editor-status.out-of-sync { color: var(--danger); font-weight: 600; }
+.library-editor-sync { min-height: 30px; border-radius: 7px; border: 1px solid rgba(244,183,64,0.3); background: rgba(244,183,64,0.16); color: var(--accent); font-family: var(--font-mono); font-size: 11px; padding: 0 13px; cursor: pointer; }
+.library-editor-sync:disabled { opacity: 0.55; cursor: default; }
 
 /* Color picker popover */
 .color-picker-popover {

--- a/static/index.html
+++ b/static/index.html
@@ -168,13 +168,12 @@
               <span>Trash</span>
             </button>
             <div style="flex:1"></div>
-            <button class="rail-btn" id="settingsBtn" type="button" aria-label="Settings">
+            <button class="rail-btn" id="settingsBtn" type="button" aria-label="Settings" aria-haspopup="dialog">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
                 <circle cx="12" cy="12" r="3"/>
                 <path d="M12 2v2 M12 20v2 M4 12H2 M22 12h-2 M5 5l1.5 1.5 M17.5 17.5 19 19 M5 19l1.5-1.5 M17.5 6.5 19 5"/>
               </svg>
               <span>Settings</span>
-              <div class="settings-coming-soon" id="settingsComingSoon" role="tooltip">More features coming soon</div>
             </button>
             <button class="rail-btn" id="aboutBtn" type="button" title="Help" aria-label="Help">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
@@ -707,19 +706,6 @@
           document.getElementById('notifBtn')?.setAttribute('aria-expanded', 'false');
         }
       });
-      /* Settings button: position the fixed tooltip on hover enter.
-         Visibility is controlled entirely by CSS (#settingsBtn:hover .settings-coming-soon). */
-      (function() {
-        const btn = document.getElementById('settingsBtn');
-        const tip = document.getElementById('settingsComingSoon');
-        if (!btn || !tip) return;
-        btn.addEventListener('mouseenter', () => {
-          const rect = btn.getBoundingClientRect();
-          tip.style.top = (rect.top + rect.height / 2) + 'px';
-          tip.style.left = (rect.right + 8) + 'px';
-          tip.style.transform = 'translateY(-50%)';
-        });
-      })();
     </script>
   </body>
 </html>

--- a/static/js/catalog.js
+++ b/static/js/catalog.js
@@ -3,7 +3,7 @@ import { STEM_NAMES } from "./constants.js";
 import { wireUpAudio, updateFooterTrack } from "./player.js";
 import { initSections } from "./sections.js";
 import { bpmChip, keyChip, saveSelectedStems, selectedStems, titleEl } from "./state.js";
-import { showError } from "./job.js";
+import { showError, importFromUrl } from "./job.js";
 import { fmtTime, storeGet, storeSet } from "./utils.js";
 
 // Escape user-supplied strings before inserting into innerHTML.
@@ -1538,6 +1538,231 @@ async function syncWithServer() {
   } catch (e) { console.warn("[catalog] failed to load jobs from backend:", e); }
 }
 
+// ─── Settings menu + Library editor ───
+
+let libraryEditor = null;
+let libraryEditorOnKey = null;
+
+// Human-readable "Location" for a track: the imported filename for local
+// uploads, otherwise the source URL.
+function libraryLocation(sourceUrl) {
+  if (!sourceUrl) return "—";
+  if (sourceUrl.startsWith("local:")) return sourceUrl.slice(6) || "Imported file";
+  return sourceUrl;
+}
+
+// Count library tracks (excluding Trash) whose audio is gone.
+function libraryUnavailableCount() {
+  const trashIds = new Set(getTrashFolder()?.items || []);
+  return Object.entries(tracks)
+    .filter(([id, t]) => !trashIds.has(id) && t.status === "unavailable").length;
+}
+
+// Update the editor's footer line with the out-of-sync count (red) or an
+// all-clear message. Safe no-op when the editor isn't open.
+function refreshLibrarySyncSummary() {
+  const statusEl = libraryEditor?.querySelector(".library-editor-status");
+  if (!statusEl) return;
+  const n = libraryUnavailableCount();
+  statusEl.classList.toggle("out-of-sync", n > 0);
+  statusEl.textContent = n > 0
+    ? `${n} ${n === 1 ? "track is" : "tracks are"} out of sync`
+    : "All tracks in sync";
+}
+
+function closeLibraryEditor() {
+  if (libraryEditorOnKey) {
+    document.removeEventListener("keydown", libraryEditorOnKey);
+    libraryEditorOnKey = null;
+  }
+  libraryEditor?.remove();
+  libraryEditor = null;
+}
+
+// Fill the editor's table body from `tracks` (skips Trash). Built via DOM +
+// textContent — titles/URLs are untrusted (YouTube/SoundCloud) so never
+// interpolate them into innerHTML.
+function renderLibraryRows(tbody) {
+  tbody.textContent = "";
+  const trashIds = new Set(getTrashFolder()?.items || []);
+  const entries = Object.entries(tracks)
+    .filter(([id]) => !trashIds.has(id))
+    .sort((a, b) => (b[1].createdAt || 0) - (a[1].createdAt || 0));
+
+  if (!entries.length) {
+    const tr = document.createElement("tr");
+    const td = document.createElement("td");
+    td.colSpan = 3;
+    td.className = "library-editor-empty";
+    td.textContent = "No tracks in your library yet.";
+    tr.appendChild(td);
+    tbody.appendChild(tr);
+    return;
+  }
+
+  for (const [id, t] of entries) {
+    const tr = document.createElement("tr");
+    tr.dataset.id = id;
+    if (t.status === "unavailable") tr.className = "unavailable";
+
+    const name = document.createElement("td");
+    name.className = "le-name";
+    name.textContent = t.title || "—";
+    name.title = t.title || "";
+    if (t.status === "unavailable") {
+      const badge = document.createElement("span");
+      badge.className = "le-badge";
+      badge.textContent = "unavailable";
+      name.appendChild(badge);
+    }
+
+    const source = document.createElement("td");
+    source.className = "le-source";
+    source.textContent = deriveSource(t.sourceUrl);
+
+    const loc = document.createElement("td");
+    loc.className = "le-loc";
+    const locText = libraryLocation(t.sourceUrl);
+    loc.textContent = locText;
+    loc.title = locText;
+
+    tr.append(name, source, loc);
+    tbody.appendChild(tr);
+  }
+}
+
+function openLibraryEditor() {
+  closeFolderEditor();
+  closeLibraryEditor();
+
+  const overlay = document.createElement("div");
+  overlay.className = "library-editor-backdrop";
+  overlay.innerHTML = `
+    <div class="library-editor" role="dialog" aria-modal="true" aria-label="Edit library">
+      <div class="library-editor-head">
+        <span>Edit Library</span>
+        <button class="library-editor-close" type="button" aria-label="Close">
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M18 6 6 18M6 6l12 12"></path></svg>
+        </button>
+      </div>
+      <div class="library-editor-table-wrap">
+        <table class="library-editor-table">
+          <thead><tr><th>Name</th><th>Source</th><th>Location</th></tr></thead>
+          <tbody class="library-editor-body"></tbody>
+        </table>
+      </div>
+      <div class="library-editor-foot">
+        <span class="library-editor-status" aria-live="polite"></span>
+        <button class="library-editor-sync" type="button">Sync again</button>
+      </div>
+    </div>
+  `;
+
+  renderLibraryRows(overlay.querySelector(".library-editor-body"));
+
+  overlay.addEventListener("mousedown", (e) => { if (e.target === overlay) closeLibraryEditor(); });
+  // (status summary is filled in after the overlay is in the DOM, below)
+  overlay.querySelector(".library-editor-close")?.addEventListener("click", closeLibraryEditor);
+  overlay.querySelector(".library-editor-sync")?.addEventListener("click", () => resyncLibrary());
+  // Escape closes from anywhere (the overlay isn't focused, so listen on document).
+  libraryEditorOnKey = (e) => { if (e.code === "Escape") closeLibraryEditor(); };
+  document.addEventListener("keydown", libraryEditorOnKey);
+
+  document.body.appendChild(overlay);
+  libraryEditor = overlay;
+  refreshLibrarySyncSummary();
+}
+
+// Poll a job until it reaches a terminal state, so auto-restores run one at a
+// time (applyState/connectEvents drive a single active studio job — overlapping
+// restores would fight over the studio). Caps at 30 min as a safety net.
+async function waitForJobTerminal(jobId) {
+  const deadline = Date.now() + 30 * 60 * 1000;
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 1500));
+    try {
+      const r = await fetch(`/api/jobs/${jobId}`, { cache: "no-store" });
+      if (r.status === 404) return;
+      const s = await r.json();
+      if (s.status === "done" || s.status === "error" || s.status === "cancelled") return;
+    } catch { /* transient — keep waiting */ }
+  }
+}
+
+// "Sync again": reconcile the library with the backend, then auto-restore the
+// tracks that fell out of sync.
+//   forward  — add server jobs missing locally (syncWithServer)
+//   reverse  — flag local "done" tracks the server no longer has as
+//              "unavailable"; restore ones that reappeared on the server.
+//   restore  — re-import every currently-unavailable URL-sourced track
+//              (re-download + re-separate). Local-file tracks can't be
+//              auto-restored (the original file isn't kept) — they stay flagged.
+// Only done↔unavailable are reconciled, so in-progress imports are never
+// mis-flagged (they aren't on the server's done-list yet).
+async function resyncLibrary() {
+  const statusEl = libraryEditor?.querySelector(".library-editor-status");
+  const syncBtn = libraryEditor?.querySelector(".library-editor-sync");
+  if (statusEl) statusEl.textContent = "Syncing…";
+  if (syncBtn) syncBtn.disabled = true;
+
+  try {
+    const res = await fetch("/api/jobs", { cache: "no-store" });
+    if (!res.ok) throw new Error(`status ${res.status}`);
+    const jobs = await res.json();
+    const serverIds = new Set(jobs.map((j) => j.job_id));
+
+    await syncWithServer(); // forward: pull in any new server jobs
+
+    const trashIds = new Set(getTrashFolder()?.items || []);
+    for (const [id, t] of Object.entries(tracks)) {
+      if (trashIds.has(id)) continue;
+      if (t.status === "done" && !serverIds.has(id)) t.status = "unavailable";
+      else if (t.status === "unavailable" && serverIds.has(id)) t.status = "done";
+    }
+    saveState();
+    render();
+    if (libraryEditor) renderLibraryRows(libraryEditor.querySelector(".library-editor-body"));
+
+    // Collect what's still unavailable; auto-restore the ones with a URL source.
+    const unavailable = Object.entries(tracks)
+      .filter(([id, t]) => !trashIds.has(id) && t.status === "unavailable")
+      .map(([, t]) => t);
+    const restorable = unavailable.filter((t) => t.sourceUrl && !t.sourceUrl.startsWith("local:"));
+
+    if (restorable.length) {
+      // Re-import each from its source. Close the editor so the studio overlay
+      // shows progress; restore sequentially (single active studio job).
+      closeLibraryEditor();
+      for (const t of restorable) {
+        const jobId = await importFromUrl(t.sourceUrl, {
+          title: t.title,
+          stems: t.selectedStems,
+        });
+        if (jobId) await waitForJobTerminal(jobId);
+      }
+      return;
+    }
+
+    // Nothing auto-restorable left — show the out-of-sync count (local-file
+    // tracks can't be re-fetched and stay flagged).
+    refreshLibrarySyncSummary();
+  } catch (e) {
+    console.warn("[catalog] resync failed:", e);
+    if (statusEl) statusEl.textContent = "Sync failed — check your connection.";
+  } finally {
+    if (syncBtn) syncBtn.disabled = false;
+  }
+}
+
+function wireSettingsMenu() {
+  const btn = document.getElementById("settingsBtn");
+  if (!btn || btn.dataset.menuReady === "1") return;
+  btn.dataset.menuReady = "1";
+  // The only setting today is the library, so Settings opens the Edit Library
+  // window directly (a centered modal, like the About dialog).
+  btn.addEventListener("click", openLibraryEditor);
+}
+
 export async function initCatalog() {
   await loadState();
   wireCatalogToggle();
@@ -1549,6 +1774,7 @@ export async function initCatalog() {
   wireRailLibraryDrop();
   wireLibraryDeleteKeys();
   wireAboutDialog();
+  wireSettingsMenu();
   setDisplayedVersion(currentVersion);
   render();
 

--- a/static/js/job.js
+++ b/static/js/job.js
@@ -360,6 +360,64 @@ function sanitizeFilename(name) {
     .slice(0, 120);
 }
 
+// Programmatic URL import — re-uses the full studio/SSE pipeline (same as the
+// import form's URL path). Used by the library "Sync again" auto-restore to
+// re-download + re-separate a track whose backend audio was swept. Takes over
+// the studio like a normal import. Returns the new job id, or null on failure.
+export async function importFromUrl(url, { title, stems } = {}) {
+  if (!url || url.startsWith("local:")) return null; // local files can't auto-restore
+  reset();
+  setSubmitProcessing(true);
+  setWaveformLoading(true, "");
+  const stemSel = stems?.length ? stems : [...selectedStems];
+
+  let jobId;
+  try {
+    const res = await fetch("/api/jobs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url, stems: stemSel }),
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.detail || res.statusText);
+    jobId = data.job_id;
+  } catch (err) {
+    showError(`Failed to restore track: ${err.message}`);
+    setSubmitProcessing(false);
+    return null;
+  }
+
+  setCurrentJobId(jobId);
+  jobSources.set(jobId, url);
+  // Merges into the existing library entry by sourceUrl (replaceTrackId),
+  // preserving its folder placement; status updates as SSE frames arrive.
+  addTrackToLibrary({
+    id: jobId,
+    title: title || url || "Processing track",
+    channel: "Processing",
+    thumb: "",
+    stems: stemSel,
+    selectedStems: stemSel,
+    audioStems: [],
+    status: "processing",
+    bpm: null,
+    key: null,
+    scale: null,
+    keyConfidence: null,
+    lufs: null,
+    peakDb: null,
+    sourceUrl: url,
+  });
+  setCurrentTrack(jobId);
+
+  jobBox.classList.add("hidden");
+  jobCancelBtn.classList.add("hidden");
+  startPhraseRotation("queued");
+  lastStatus = "queued";
+  connectEvents(jobId);
+  return jobId;
+}
+
 export function wireJobForm() {
   jobCancelBtn.addEventListener("click", cancelCurrentJob);
 


### PR DESCRIPTION
## What
A **Settings → Edit Library** window (centered modal, like the About dialog) to inspect and reconcile the library.

- **Track list** — scrollable table of every library track: **Name**, **Source** (YouTube / SoundCloud / local file, via the existing `deriveSource`), **Location** (imported filename or URL). Rows built via DOM `textContent` (titles/URLs are untrusted).
- **Out-of-sync detection** — tracks whose backend audio was swept after the job retention window (the *"This track's audio is no longer available"* case) are flagged in red with an at-a-glance count.
- **Sync again** — reconciles the library with `GET /api/jobs`:
  - forward: adds new server jobs missing locally (`syncWithServer`),
  - reverse: flags local `done` tracks the server no longer has as `unavailable`, restores ones that reappeared,
  - **auto-restore**: re-imports every unavailable **URL-sourced** track from its source (re-download + re-separate) through the existing studio/SSE pipeline. Restores run **sequentially** because `applyState` drives a single active studio job. Local-file imports can't be auto-restored (the original file isn't kept) and stay flagged for manual re-upload.

## How
- Settings button now opens this window directly; removed the old "coming soon" tooltip + its inline script and CSS.
- New `importFromUrl()` in `job.js` factors the URL-import path so the restore flow reuses the full pipeline.
- All editor code is module-private in `catalog.js` (reuses `tracks`/`folders`/`saveState`/`render`/`deriveSource`/`syncWithServer`) — no new state exports.

## Files
`static/index.html`, `static/css/daw.css`, `static/js/catalog.js`, `static/js/job.js`.

## Testing
Verified headlessly (no console errors): window opens centered; X / Esc / backdrop dismiss; Name/Source/Location render and classify correctly; list scrolls (flex `min-height: 0`); out-of-sync count shows red. Auto-restore re-import (Demucs) verified by ear in the desktop app.