### PR TITLE
feat: add Content-Security-Policy to the desktop webview (#171)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -149,14 +149,35 @@ def health() -> dict[str, object]:
     }
 
 
+# Content-Security-Policy. Defense-in-depth so an injected string in the webview
+# can't run script (and, in the desktop app, reach the exposed Tauri IPC) — #171.
+# script-src has no 'unsafe-inline'/'eval': all JS is same-origin modules and the
+# inline scripts/onclick were moved out. 'unsafe-inline' is allowed for *styles*
+# only (the UI sets many style attributes). Allowances:
+#   connect-src  -> same-origin API/SSE, the GitHub update check, Tauri IPC
+#   img-src https: -> remote YouTube/SoundCloud thumbnails
+#   style/font   -> the Google Fonts <link>
+_CSP = (
+    "default-src 'self'; "
+    "script-src 'self'; "
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+    "font-src 'self' https://fonts.gstatic.com data:; "
+    "img-src 'self' data: blob: https:; "
+    "media-src 'self' blob: data:; "
+    "connect-src 'self' https://api.github.com ipc: http://ipc.localhost; "
+    "object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'"
+)
+
+
 # Force browsers to revalidate static assets on every request. Without
 # this the JS/CSS modules can stick in disk cache across server
 # restarts -- updated HTML loads against stale modules and the form
 # silently breaks. `must-revalidate` keeps 304s working (cheap) while
 # guaranteeing the latest mtime is honored.
 @app.middleware("http")
-async def no_cache_static(request: Request, call_next):
+async def security_and_cache_headers(request: Request, call_next):
     response = await call_next(request)
+    response.headers["Content-Security-Policy"] = _CSP
     if not request.url.path.startswith("/api"):
         response.headers["Cache-Control"] = "no-cache, must-revalidate"
     return response

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: blob:; connect-src 'self' ipc: http://ipc.localhost; object-src 'none'; base-uri 'self'; frame-ancestors 'none'"
     }
   },
   "bundle": {

--- a/static/index.html
+++ b/static/index.html
@@ -52,7 +52,7 @@
               <span class="file-size" id="fileSize"></span>
               <button class="file-clear" id="fileClear" type="button" aria-label="Remove file">×</button>
             </div>
-            <button class="daw-upload-btn" type="button" title="Upload audio file" id="uploadFileBtn" aria-label="Upload audio file" onclick="document.getElementById('fileInput').click()">
+            <button class="daw-upload-btn" type="button" title="Upload audio file" id="uploadFileBtn" aria-label="Upload audio file">
               <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
                 <path d="M12 3v12 M7 8l5-5 5 5 M5 21h14"/>
               </svg>
@@ -100,7 +100,7 @@
 
         <!-- Notification bell -->
         <div class="daw-notif-wrap" style="position:relative;flex-shrink:0;">
-          <button class="daw-iconbtn daw-notif-btn" id="notifBtn" title="Notifications" type="button" aria-label="Notifications" aria-expanded="false" onclick="this.closest('.daw-notif-wrap').classList.toggle('open');this.setAttribute('aria-expanded',this.closest('.daw-notif-wrap').classList.contains('open'))">
+          <button class="daw-iconbtn daw-notif-btn" id="notifBtn" title="Notifications" type="button" aria-label="Notifications" aria-expanded="false">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
               <path d="M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9 M13.7 21a2 2 0 0 1-3.4 0"/>
             </svg>
@@ -109,7 +109,7 @@
           <div class="daw-notif-panel" role="menu" aria-label="Notifications">
             <div class="daw-notif-header">
               <span class="uplabel">Notifications</span>
-              <button class="daw-notif-close" type="button" aria-label="Close notifications" onclick="this.closest('.daw-notif-wrap').classList.remove('open');document.getElementById('notifBtn').setAttribute('aria-expanded','false')">
+              <button class="daw-notif-close" type="button" aria-label="Close notifications">
                 <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6 6 18M6 6l12 12"/></svg>
               </button>
             </div>
@@ -697,15 +697,6 @@
     </div>
 
     <script type="module" src="/js/main.js"></script>
-    <script>
-      /* Close notification panel on outside click */
-      document.addEventListener('click', (e) => {
-        const wrap = document.querySelector('.daw-notif-wrap.open');
-        if (wrap && !wrap.contains(e.target)) {
-          wrap.classList.remove('open');
-          document.getElementById('notifBtn')?.setAttribute('aria-expanded', 'false');
-        }
-      });
-    </script>
+    <script type="module" src="/js/ui-chrome.js"></script>
   </body>
 </html>

--- a/static/js/ui-chrome.js
+++ b/static/js/ui-chrome.js
@@ -1,0 +1,31 @@
+// Small UI-chrome handlers extracted from inline index.html scripts / onclick
+// attributes so the Content-Security-Policy can forbid inline script (#171).
+// Loaded as a module (deferred), so the DOM is parsed before this runs.
+
+// Upload button → trigger the hidden file input.
+document.getElementById("uploadFileBtn")?.addEventListener("click", () => {
+  document.getElementById("fileInput")?.click();
+});
+
+// Notification panel: toggle / close / close-on-outside-click.
+const notifBtn = document.getElementById("notifBtn");
+const notifWrap = notifBtn?.closest(".daw-notif-wrap");
+
+function setNotifOpen(open) {
+  notifWrap?.classList.toggle("open", open);
+  notifBtn?.setAttribute("aria-expanded", String(open));
+}
+
+notifBtn?.addEventListener("click", () => {
+  setNotifOpen(!notifWrap?.classList.contains("open"));
+});
+
+document
+  .querySelector(".daw-notif-close")
+  ?.addEventListener("click", () => setNotifOpen(false));
+
+document.addEventListener("click", (e) => {
+  if (notifWrap?.classList.contains("open") && !notifWrap.contains(e.target)) {
+    setNotifOpen(false);
+  }
+});


### PR DESCRIPTION
Closes #171.

The desktop webview ran with `csp: null` while `withGlobalTauri: true` exposed the Tauri API — so any markup injection could reach Tauri commands. Adds a strict CSP as defense-in-depth (the actual XSS hole, #170, is already fixed).

## Changes
- **FastAPI CSP header** (`app/main.py`) — the main app (where the library/folder UI and the `window.__TAURI__` surface live) is served by FastAPI at `127.0.0.1`, so a response header is the *effective* policy there, not just `tauri.conf.json`. `script-src 'self'`, no `unsafe-inline`/`eval`.
- **Removed inline JS** — moved the inline `<script>` + 3 inline `onclick` handlers out of `index.html` into a new `static/js/ui-chrome.js` module so the strict policy doesn't break them.
- **Tauri setup-shell CSP** (`tauri.conf.json`) — matching policy for the bundled `desktop/ui` shell (verified it has no inline scripts).

### Policy notes
- `style-src` keeps `'unsafe-inline'` (the UI sets many inline style attributes — low risk).
- `connect-src 'self' https://api.github.com ipc: http://ipc.localhost` — same-origin API/SSE, the update check, and Tauri IPC.
- `img-src … https:` — remote YouTube/SoundCloud thumbnails.
- `withGlobalTauri` kept — disabling it is a bigger refactor for marginal gain once #170 + CSP are in.

## Verification
- Served HTML has **no** inline `<script>`/`onclick` left; CSP header confirmed on `/`.
- Scanned app + vendor: no `eval`/`new Function`/`Worker`/wasm; the one `URL.createObjectURL` (vendor audio) is covered by `media-src blob:`.
- `node --check` all JS, ruff clean.
- ⚠️ **Needs on-device check before merge:** run the **desktop app** — confirm setup completes, the studio loads, playback/SSE work, Tauri calls (open link, save file) work, and there are **no CSP violations** in the WebView console. The plain-browser path can't exercise Tauri IPC / the setup shell.