### PR TITLE
fix: default the Web Audio engine off (Windows/WebView2 regression)

### DIFF
--- a/static/js/player.js
+++ b/static/js/player.js
@@ -34,13 +34,16 @@ import { destroySections } from "./sections.js";
 
 // Feature flag for the Web Audio decode-and-mix engine (audioEngine.js).
 // Playback runs off decoded AudioBuffers on a single AudioContext clock instead
-// of N streaming <audio> elements — fixes Safari/WKWebView choppiness. Default
-// ON (the desktop app is WKWebView for every macOS user); set
-// localStorage "stemdeck.audioEngine" = "0" to opt back into the legacy
-// streaming path for A/B without a rebuild.
+// of N streaming <audio> elements — fixes Safari/WKWebView choppiness.
+//
+// Default OFF: shipping it default-on (alpha.4) regressed the Windows/WebView2
+// client — the engine's extra AudioContext + concurrent full-WAV decodes wedge
+// the multitrack media loads, so `canplay` never fires and neither the waveform
+// nor playback appear. Until the engine is made WebView2-safe, it's opt-in:
+// set localStorage "stemdeck.audioEngine" = "1" to enable it (e.g. on Safari).
 function audioEngineEnabled() {
-  try { return localStorage.getItem("stemdeck.audioEngine") !== "0"; }
-  catch (e) { console.warn("[player] audioEngine flag read failed:", e); return true; }
+  try { return localStorage.getItem("stemdeck.audioEngine") === "1"; }
+  catch (e) { console.warn("[player] audioEngine flag read failed:", e); return false; }
 }
 
 // Above this estimated decoded-PCM size the engine is skipped and playback


### PR DESCRIPTION
## Problem
alpha.4 shipped the Web Audio decode-and-mix engine (#165) **default-on**, which regressed the **Windows / WebView2** desktop client: clicking a track shows "loading waveform" for ~60s (the fallback timeout), then **no waveform and no playback**. macOS (WKWebView) and the Mac browser (Chromium) are fine.

## Root cause
Diff of `v0.7.0-alpha.3..v0.7.0-alpha.4` shows the only audio/load-path change is #165. The studio's waveform render and the engine creation are both gated on the multitrack `canplay` event; on WebView2 the engine's extra `AudioContext` + concurrent full-WAV `decodeAudioData` calls wedge the stem media loads, so `canplay` never fires and everything behind it (peaks waveform, audio engine) never runs.

## Fix (triage)
One-line revert of the **default** to the alpha.3 streaming path — the engine becomes opt-in:
- `audioEngineEnabled()` now returns true only when `localStorage stemdeck.audioEngine === "1"` (was: true unless `=== "0"`).

Near-zero risk, fully reversible, and doubles as confirmation: if the Windows build works again, #165 is confirmed. Safari users lose the smoothness *default* but can opt in with `stemdeck.audioEngine = "1"`.

## Test
- Mac browser (`./run.sh restart`): studio loads + plays via streaming path; setting `stemdeck.audioEngine="1"` still enables the engine.
- **Windows client: confirm waveform + playback are restored** → then cut **v0.7.0-alpha.5**.

## Follow-up (separate)
Make the engine WebView2-safe (decouple: engine owns audio off its own decode, peaks own visuals, multitrack stops loading stem media), verify on Windows, then re-enable default-on.