### PR TITLE
fix: OS-based default for the audio engine (on except Windows)

### DIFF
--- a/static/js/player.js
+++ b/static/js/player.js
@@ -36,14 +36,24 @@ import { destroySections } from "./sections.js";
 // Playback runs off decoded AudioBuffers on a single AudioContext clock instead
 // of N streaming <audio> elements — fixes Safari/WKWebView choppiness.
 //
-// Default OFF: shipping it default-on (alpha.4) regressed the Windows/WebView2
-// client — the engine's extra AudioContext + concurrent full-WAV decodes wedge
-// the multitrack media loads, so `canplay` never fires and neither the waveform
-// nor playback appear. Until the engine is made WebView2-safe, it's opt-in:
-// set localStorage "stemdeck.audioEngine" = "1" to enable it (e.g. on Safari).
+// Default is OS-based: the engine works on WKWebView (macOS) and Chromium, but
+// regresses Windows/WebView2 (the extra AudioContext + concurrent full-WAV
+// decodes wedge the multitrack media loads, so `canplay` never fires and the
+// waveform + playback never appear). So default ON everywhere except Windows.
+// This is a heuristic stopgap — the proper fix is a WebView2-safe engine
+// (tracked separately). An explicit localStorage "stemdeck.audioEngine" of
+// "1"/"0" always overrides the OS default.
 function audioEngineEnabled() {
-  try { return localStorage.getItem("stemdeck.audioEngine") === "1"; }
-  catch (e) { console.warn("[player] audioEngine flag read failed:", e); return false; }
+  try {
+    const pref = localStorage.getItem("stemdeck.audioEngine");
+    if (pref === "1") return true;
+    if (pref === "0") return false;
+  } catch (e) {
+    console.warn("[player] audioEngine flag read failed:", e);
+  }
+  const isWindows = /Windows/i.test(navigator.userAgent || "");
+  console.debug(`[player] audioEngine default — ${isWindows ? "Windows → off" : "non-Windows → on"}`);
+  return !isWindows;
 }
 
 // Above this estimated decoded-PCM size the engine is skipped and playback


### PR DESCRIPTION
Follow-up to #179. Instead of disabling the Web Audio engine everywhere, default it **on for macOS/WKWebView + Chromium** (where it fixes Safari chop and works) and **off on Windows/WebView2** (where it regressed — waveform + playback dead).

## Change (`static/js/player.js`)
`audioEngineEnabled()`:
- explicit `localStorage stemdeck.audioEngine` `"1"`/`"0"` → honored (manual override),
- otherwise default by platform: `/Windows/i.test(navigator.userAgent)` → **off**, else **on** (+ a `console.debug` of which default was chosen).

## Effect
- **macOS desktop / Safari:** engine back on → smooth playback (the #165 win returns).
- **Windows desktop:** stays on the streaming path → waveform + playback work (no regression).
- **Chrome/other:** engine on as before.

## Caveats
Heuristic stopgap — keys off OS, but the real culprit is WebView2 (a Windows-Chrome *browser* user would also get the engine disabled; harmless, streaming works). Proper WebView2-safe rework tracked in **#180**.

## Test
- Mac browser (`./run.sh restart`): smooth playback via engine; `stemdeck.audioEngine="0"` still forces streaming.
- **Windows client: confirm waveform + playback still work** (should match the current good state).