### PR TITLE
fix: studio audio rendering — CSP data:/blob: + engine waveform visibility

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -164,7 +164,11 @@ _CSP = (
     "font-src 'self' https://fonts.gstatic.com data:; "
     "img-src 'self' data: blob: https:; "
     "media-src 'self' blob: data:; "
-    "connect-src 'self' https://api.github.com ipc: http://ipc.localhost; "
+    # data:/blob: are required by multitrack.js (it fetches a data: URI during
+    # track init); without them Multitrack.create throws and no audio loads
+    # (#186). They are inline/same-origin schemes, not network endpoints, so
+    # they add no exfiltration channel — script-src below stays locked.
+    "connect-src 'self' https://api.github.com ipc: http://ipc.localhost data: blob:; "
     "object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'"
 )
 

--- a/static/css/daw.css
+++ b/static/css/daw.css
@@ -1629,6 +1629,12 @@ input, textarea { font-family: inherit; }
 .daw .stem-waveform-layer {
   display: none !important;
 }
+/* When the Web Audio engine owns playback, the multitrack is mounted with null
+   URLs and never decodes audio, so the WaveSurfer canvas is empty. Show the SVG
+   overview layer (rendered from peaks.json) as the visual source instead. */
+.daw.engine-waveforms .stem-waveform-layer {
+  display: flex !important;
+}
 /* waves-column must size naturally now that multitrack is in flow */
 .daw .waves-column {
   height: auto !important;

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -522,6 +522,7 @@ function startStemVuLoop(stems, decodedMap, token) {
 
 export function destroyPlayer() {
   document.querySelector(".app")?.classList.remove("is-import");
+  document.querySelector(".app")?.classList.remove("engine-waveforms");
   document.querySelector(".app")?.classList.add("no-track");
   destroySections();
   stopVuLoop();
@@ -817,6 +818,9 @@ export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, ti
   const engineTooLarge =
     estimateDecodedBytes(totalDuration, engineStemCount) > MAX_ENGINE_DECODED_BYTES;
   const useEngine = audioEngineEnabled() && !engineTooLarge;
+  // The null-URL multitrack (engine path) has no WaveSurfer canvas, so reveal the
+  // SVG overview layer as the visible waveform (CSS hides it on the streaming path).
+  document.querySelector(".app")?.classList.toggle("engine-waveforms", useEngine);
   if (engineTooLarge) {
     console.warn(
       `[player] track too large for Web Audio engine `

--- a/tests/test_csp.py
+++ b/tests/test_csp.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def _csp_directive(name: str) -> str:
+    """Return the named directive from the served Content-Security-Policy header."""
+    with TestClient(app) as c:
+        resp = c.get("/")
+    csp = resp.headers["content-security-policy"]
+    return next(d.strip() for d in csp.split(";") if d.strip().startswith(name))
+
+
+def test_connect_src_permits_data_and_blob():
+    # Regression for #186: multitrack.js fetches a data: URI while initializing
+    # each track's audio. Without data:/blob: in connect-src the browser blocks
+    # it, Multitrack.create throws, and no audio/waveform/playback loads.
+    connect = _csp_directive("connect-src")
+    assert "data:" in connect
+    assert "blob:" in connect
+
+
+def test_script_src_stays_locked():
+    # Lock #171's intent: loosening connect-src must not weaken the XSS defense.
+    script = _csp_directive("script-src")
+    assert "'self'" in script
+    assert "unsafe-inline" not in script
+    assert "unsafe-eval" not in script


### PR DESCRIPTION
Fixes two studio-blocking defects in the processed-track player. Both must land for the studio to load + show waveforms.

## 1. CSP `connect-src` blocks the multitrack `data:` fetch (#186)
`multitrack.js` fetches a hardcoded `data:audio/mp3` placeholder URI while initializing each track. The #171 CSP had no `data:`/`blob:` in `connect-src`, so the browser blocked it, `Multitrack.create` threw, and no audio/waveform/playback loaded.

- Add `data: blob:` to `connect-src`. These are inline/same-origin schemes, not network endpoints — no exfiltration channel, and `script-src 'self'` stays locked (XSS defense from #171 intact).
- `tests/test_csp.py`: asserts `connect-src` permits `data:`/`blob:` and `script-src` stays locked.

## 2. Engine path shows no waveform (#185 regression)
#185 mounts the multitrack with **null URLs** when the Web Audio engine owns playback (avoids 12 concurrent stem fetches saturating the HTTP/1.1 6-connection limit, which froze WebView). With null URLs WaveSurfer never decodes, so its canvas — the normal visible waveform — is empty. The SVG overview layer (rendered from `peaks.json`) is CSS-hidden, so the studio showed **no waveform at all** when the engine was on. Most visible in Safari/WebKit.

- Add an `engine-waveforms` class on `.app` while the engine owns playback; unhide the SVG overview layer in that state so it becomes the visible source.

## Validation
End-to-end in **Playwright WebKit** (Safari's engine) with a real music track: waveforms render in every lane, playback advances, **zero CSP violations**. Verified visually, not just at the DOM level.