### PR TITLE
fix: stop the lane stack shaking on vertical scroll (#182)

### DIFF
--- a/static/css/daw.css
+++ b/static/css/daw.css
@@ -1594,11 +1594,13 @@ input, textarea { font-family: inherit; }
   border-radius: 0 !important;
   border: none !important;
   overflow-y: auto;
-  /* Reserve the vertical scrollbar gutter so its appearance never reflows the
-     content width. With offsetWidth driving the zoom calc this is polish, not
-     load-bearing, but it keeps the lanes from shifting when the scrollbar shows
-     (part of the #182 shake fix). Ignored harmlessly on older WebKit. */
-  scrollbar-gutter: stable;
+  /* waves.css sets scroll-behavior: smooth. In the studio the mixer column and
+     the wave lanes mirror each other's scrollTop (wireLaneScrollSync), and a
+     smooth programmatic scroll turns that mirror into a feedback loop: each
+     echo re-targets the in-flight animation, so a vertical wheel-scroll to the
+     middle oscillates instead of settling, i.e. the lanes shake (#182). Instant
+     scrolling makes the mirror a no-op once both panes match. */
+  scroll-behavior: auto;
 }
 
 /* Canvas fills the panel when lanes fit, but grows with the track stack when

--- a/static/css/daw.css
+++ b/static/css/daw.css
@@ -1594,6 +1594,11 @@ input, textarea { font-family: inherit; }
   border-radius: 0 !important;
   border: none !important;
   overflow-y: auto;
+  /* Reserve the vertical scrollbar gutter so its appearance never reflows the
+     content width. With offsetWidth driving the zoom calc this is polish, not
+     load-bearing, but it keeps the lanes from shifting when the scrollbar shows
+     (part of the #182 shake fix). Ignored harmlessly on older WebKit. */
+  scrollbar-gutter: stable;
 }
 
 /* Canvas fills the panel when lanes fit, but grows with the track stack when

--- a/static/js/transport.js
+++ b/static/js/transport.js
@@ -349,12 +349,7 @@ export function applyWaveZoom() {
     lanes?.style.setProperty("--wave-playhead-h", `${wavesColumn.clientHeight}px`);
   }
   if (multitrack && totalDuration > 0 && waveScroll) {
-    // Measure from offsetWidth (border-box), not clientWidth. clientWidth shrinks
-    // when the vertical scrollbar appears; feeding that into the zoom calc let the
-    // scrollbar toggle re-zoom the waveform, which toggled the scrollbar again, a
-    // feedback loop that showed as the waveform shaking while scrolled (#182).
-    // offsetWidth is the layout width and does not change when a scrollbar appears.
-    const baseWidth = waveScroll.offsetWidth;
+    const baseWidth = waveScroll.clientWidth;
     if (baseWidth > 0) {
       // Fit to the visible width, but never compress below WAVE_MIN_WIDTH.
       const contentWidth = Math.max(baseWidth, WAVE_MIN_WIDTH);
@@ -379,15 +374,8 @@ export function applyWaveZoom() {
 function wireZoomButtons() {
   if (waveScroll) {
     let rafId = null;
-    let lastWidth = 0;
     const ro = new ResizeObserver(() => {
       if (!multitrack || totalDuration <= 0) return;
-      // Only re-zoom on real width changes. Height-only changes (e.g. the
-      // horizontal scrollbar appearing) do not affect the zoom and must not
-      // trigger a re-render, which is part of avoiding the shake loop (#182).
-      const width = waveScroll.offsetWidth;
-      if (width === lastWidth) return;
-      lastWidth = width;
       if (rafId) cancelAnimationFrame(rafId);
       rafId = requestAnimationFrame(() => { rafId = null; applyWaveZoom(); });
     });

--- a/static/js/transport.js
+++ b/static/js/transport.js
@@ -349,7 +349,12 @@ export function applyWaveZoom() {
     lanes?.style.setProperty("--wave-playhead-h", `${wavesColumn.clientHeight}px`);
   }
   if (multitrack && totalDuration > 0 && waveScroll) {
-    const baseWidth = waveScroll.clientWidth;
+    // Measure from offsetWidth (border-box), not clientWidth. clientWidth shrinks
+    // when the vertical scrollbar appears; feeding that into the zoom calc let the
+    // scrollbar toggle re-zoom the waveform, which toggled the scrollbar again, a
+    // feedback loop that showed as the waveform shaking while scrolled (#182).
+    // offsetWidth is the layout width and does not change when a scrollbar appears.
+    const baseWidth = waveScroll.offsetWidth;
     if (baseWidth > 0) {
       // Fit to the visible width, but never compress below WAVE_MIN_WIDTH.
       const contentWidth = Math.max(baseWidth, WAVE_MIN_WIDTH);
@@ -374,8 +379,15 @@ export function applyWaveZoom() {
 function wireZoomButtons() {
   if (waveScroll) {
     let rafId = null;
+    let lastWidth = 0;
     const ro = new ResizeObserver(() => {
       if (!multitrack || totalDuration <= 0) return;
+      // Only re-zoom on real width changes. Height-only changes (e.g. the
+      // horizontal scrollbar appearing) do not affect the zoom and must not
+      // trigger a re-render, which is part of avoiding the shake loop (#182).
+      const width = waveScroll.offsetWidth;
+      if (width === lastWidth) return;
+      lastWidth = width;
       if (rafId) cancelAnimationFrame(rafId);
       rafId = requestAnimationFrame(() => { rafId = null; applyWaveZoom(); });
     });


### PR DESCRIPTION
Fixes #182 (lanes shake when rolling the wheel to the middle).

## What it actually is
Not a zoom or scrollbar issue. The reporter's video shows the waveform fully zoomed out and fitting the panel, so there is no horizontal scroll at all. The panel is short, the six stems overflow vertically, and "rolling the wheel" is a vertical scroll.

`waves.css` sets `scroll-behavior: smooth` on `.wave-scroll`. The studio mirrors `scrollTop` between the mixer column and the wave lanes (`wireLaneScrollSync`, `transport.js`). A smooth programmatic scroll turns that mirror into a feedback loop: each echo re-targets the in-flight smooth animation, so the scroll never settles and the lanes oscillate.

## Fix
One line: override `scroll-behavior: auto` on `.daw .wave-scroll`, so the mirror becomes an instant no-op once both panes match. Scoped to the studio; the import view has `overflow-y: hidden` and never hits this.

## Verification (Playwright WebKit, real track)
Reproduced and measured by sampling `scrollTop` every frame while scrolling to the middle and counting direction reversals (forward-then-back = the shake):

- Before: `scrollTop` bounces `0,24,59,31,54,32,52,32...`, **147 reversals / 150 frames**.
- After: `scrollTop` jumps to the target and stays, **0 reversals**.

Both panes stay aligned in both cases.

## Note
This branch first carried a different change (drive zoom from `offsetWidth` plus `scrollbar-gutter`) based on a wrong, code-reading-only diagnosis. That was reverted after reproducing the real bug in WebKit. The final diff is only the one CSS line above.