### PR TITLE
feat: Export Mix reflects the mixer (volume, mute, solo) (#183)

### DIFF
--- a/app/api/stems.py
+++ b/app/api/stems.py
@@ -26,6 +26,13 @@ router = APIRouter(tags=["stems"])
 # amix of the user's selected stems.
 _ALLOWED_NAMES = frozenset(STEM_NAMES) | {"original", "mix"}
 
+# Lanes the dynamic mixdown may sum: the 6 stems plus "original" (the complement
+# track shown when the user picked a subset). "mix" is excluded -- it is the
+# static pre-render this endpoint replaces. Gains are linear; the studio caps a
+# lane at 2.0, so this generous bound just rejects abusive values.
+_MIXDOWN_NAMES = frozenset(STEM_NAMES) | {"original"}
+_MIXDOWN_MAX_GAIN = 4.0
+
 
 def _validate_stem_path(job_id: str, name: str):
     """Shared guard: validate job_id, name, job state, and path. Returns resolved Path."""
@@ -161,6 +168,73 @@ async def get_stem_mp3(
         _stream_ffmpeg(cmd),
         media_type="audio/mpeg",
         headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+@router.get("/jobs/{job_id}/mixdown.{ext}", response_model=None)
+async def get_mixdown(
+    job_id: str,
+    ext: str,
+    stems: str = Query(..., description="Comma-separated lane names to sum"),
+    gains: str = Query(..., description="Comma-separated linear gains, parallel to stems"),
+    start: float | None = Query(default=None, ge=0, description="Trim start in seconds"),
+    end: float | None = Query(default=None, gt=0, description="Trim end in seconds"),
+) -> StreamingResponse:
+    """Render a fresh mixdown of the given lanes at the given gains, streamed as
+    WAV or MP3. Mirrors the studio mixer (per-stem volume, mute, solo) so the
+    exported file matches what is heard. The master fader is intentionally not
+    applied -- it is a monitoring level, not part of the mix. Optional ?start=&end=
+    trims to a loop region."""
+    if ext not in ("wav", "mp3"):
+        raise HTTPException(status_code=404, detail="not found")
+
+    names = [s for s in stems.split(",") if s]
+    raw_gains = [g for g in gains.split(",") if g]
+    if not names or len(names) != len(raw_gains):
+        raise HTTPException(
+            status_code=422, detail="stems and gains must be non-empty and equal length"
+        )
+    try:
+        parsed_gains = [float(g) for g in raw_gains]
+    except ValueError:
+        raise HTTPException(status_code=422, detail="gains must be numbers") from None
+    if any(g < 0 or g > _MIXDOWN_MAX_GAIN for g in parsed_gains):
+        raise HTTPException(status_code=422, detail="gain out of range")
+    if not set(names) <= _MIXDOWN_NAMES:
+        raise HTTPException(status_code=422, detail="unknown stem requested")
+    if (start is None) != (end is None) or (start is not None and start >= end):
+        raise HTTPException(
+            status_code=422,
+            detail="start and end are both required and start must be less than end",
+        )
+
+    # Validates job_id (404), job done (404), and path traversal (404) per stem.
+    paths = [_validate_stem_path(job_id, name) for name in names]
+
+    pre_seek = ["-ss", str(start)] if start is not None else []
+    post_seek = ["-t", str(end - start)] if start is not None else []
+
+    cmd: list[str] = [ffmpeg_executable(), "-nostdin", "-loglevel", "error"]
+    for p in paths:
+        cmd += [*pre_seek, "-i", str(p)]
+    # Apply each lane's gain, then sum with amix (normalize=0 keeps levels faithful,
+    # matching collect.py). A single audible lane skips amix (a 1-input amix is a no-op).
+    filters = [f"[{i}:a]volume={g:.6f}[a{i}]" for i, g in enumerate(parsed_gains)]
+    n = len(paths)
+    if n > 1:
+        labels = "".join(f"[a{i}]" for i in range(n))
+        filters.append(f"{labels}amix=inputs={n}:normalize=0[mix]")
+        out_label = "[mix]"
+    else:
+        out_label = "[a0]"
+    codec = ["-c:a", "pcm_s16le", "-f", "wav"] if ext == "wav" else ["-q:a", "2", "-f", "mp3"]
+    cmd += ["-filter_complex", ";".join(filters), "-map", out_label, *post_seek, *codec, "pipe:1"]
+
+    media_type = "audio/wav" if ext == "wav" else "audio/mpeg"
+    return StreamingResponse(
+        _stream_ffmpeg(cmd),
+        media_type=media_type,
+        headers={"Content-Disposition": f'attachment; filename="mixdown.{ext}"'},
     )
 
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -187,14 +187,16 @@ function wireFooterControls() {
   itemMix?.addEventListener("click", (e) => {
     e.stopPropagation();
     if (busy) return;
-    if (format === "mp3") downloadCurrentMixMp3(); else downloadCurrentMix();
+    const ok = format === "mp3" ? downloadCurrentMixMp3() : downloadCurrentMix();
+    if (!ok) { showError("All stems are muted - nothing to export."); return; }
     flashBusy();
   });
 
   itemRegion?.addEventListener("click", (e) => {
     e.stopPropagation();
     if (busy || itemRegion.getAttribute("aria-disabled") === "true") return;
-    if (format === "mp3") downloadRegionMixMp3(); else downloadRegionMix();
+    const ok = format === "mp3" ? downloadRegionMixMp3() : downloadRegionMix();
+    if (!ok) { showError("All stems are muted - nothing to export."); return; }
     flashBusy();
   });
 

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -2,7 +2,7 @@ import Multitrack from "/vendor/multitrack.js";
 import { fmtTime } from "./utils.js";
 import {
   STEM_NAMES, TRACK_NAMES, STEM_COLORS, PROGRESS_COLOR,
-  LOOP_DEFAULT_START_FRAC, LOOP_DEFAULT_END_FRAC,
+  LOOP_DEFAULT_START_FRAC, LOOP_DEFAULT_END_FRAC, LANE_VOLUME_MAX,
 } from "./constants.js";
 import {
   mixerEl, multitrackContainer, bpmChip, keyChip, stemsChip, timeEl,
@@ -1253,10 +1253,42 @@ function _triggerDownload(url, filename) {
   a.remove();
 }
 
-function _exportMixUrl() {
-  if (_mixUrl) return _mixUrl;
-  const orig = _currentStems.find((s) => s.name === "original");
-  return orig?.url ?? null;
+// Per-lane effective gain mirroring mixer.js applyMix (volume + mute + solo),
+// minus the master fader (a monitoring level, not part of the mix). Returns the
+// audible lanes and their gains so the backend can render a mixdown matching what
+// is heard. _currentStems already includes "original" when the user picked a
+// subset, so summing these lanes reconstructs the adjusted full song.
+function _effectiveMixGains() {
+  const anySolo = _currentStems.some((s) => mixerState[s.name]?.soloed);
+  const names = [];
+  const gains = [];
+  for (const s of _currentStems) {
+    if (s.name === "mix") continue;
+    const m = mixerState[s.name];
+    if (!m) continue;
+    const g = m.muted ? 0 : (anySolo && !m.soloed ? 0 : m.volume);
+    if (g <= 0) continue;
+    names.push(s.name);
+    gains.push(Math.max(0, Math.min(LANE_VOLUME_MAX, g)));
+  }
+  return { names, gains };
+}
+
+// Dynamic mixdown URL for the current mixer state. Returns null (no download)
+// when every lane is silenced; `region` appends the loop bounds.
+function _mixdownUrl(ext, region) {
+  if (!currentJobId) return null;
+  const { names, gains } = _effectiveMixGains();
+  if (!names.length) return null;
+  const q = new URLSearchParams({
+    stems: names.join(","),
+    gains: gains.map((g) => g.toFixed(3)).join(","),
+  });
+  if (region) {
+    q.set("start", loopStart.toFixed(3));
+    q.set("end", loopEnd.toFixed(3));
+  }
+  return `/api/jobs/${currentJobId}/mixdown.${ext}?${q}`;
 }
 
 function _exportFilename(ext) {
@@ -1268,16 +1300,21 @@ function _exportFilename(ext) {
   return safe ? `${safe}_exported_mix.${ext}` : `exported_mix.${ext}`;
 }
 
+// The download functions return true when a download was triggered and false
+// when there is nothing audible to export (every lane muted), so the caller can
+// surface a message.
 export function downloadCurrentMix() {
-  const url = _exportMixUrl();
-  if (!url) return;
+  const url = _mixdownUrl("wav", false);
+  if (!url) return false;
   _triggerDownload(url, _exportFilename("wav"));
+  return true;
 }
 
 export function downloadCurrentMixMp3() {
-  const url = _exportMixUrl();
-  if (!url) return;
-  _triggerDownload(url.replace(/\.wav$/, ".mp3"), _exportFilename("mp3"));
+  const url = _mixdownUrl("mp3", false);
+  if (!url) return false;
+  _triggerDownload(url, _exportFilename("mp3"));
+  return true;
 }
 
 export function downloadCurrentStems(format = "wav", onProgress) {
@@ -1326,16 +1363,17 @@ function _regionFilename(ext) {
 }
 
 export function downloadRegionMix() {
-  if (!loopEnabled || loopStart >= loopEnd) return;
-  const url = _exportMixUrl();
-  if (!url) return;
-  _triggerDownload(`${url}?start=${loopStart.toFixed(3)}&end=${loopEnd.toFixed(3)}`, _regionFilename("wav"));
+  if (!loopEnabled || loopStart >= loopEnd) return false;
+  const url = _mixdownUrl("wav", true);
+  if (!url) return false;
+  _triggerDownload(url, _regionFilename("wav"));
+  return true;
 }
 
 export function downloadRegionMixMp3() {
-  if (!loopEnabled || loopStart >= loopEnd) return;
-  const url = _exportMixUrl();
-  if (!url) return;
-  const mp3Url = url.replace(/\.wav$/, ".mp3");
-  _triggerDownload(`${mp3Url}?start=${loopStart.toFixed(3)}&end=${loopEnd.toFixed(3)}`, _regionFilename("mp3"));
+  if (!loopEnabled || loopStart >= loopEnd) return false;
+  const url = _mixdownUrl("mp3", true);
+  if (!url) return false;
+  _triggerDownload(url, _regionFilename("mp3"));
+  return true;
 }

--- a/tests/test_stems_api.py
+++ b/tests/test_stems_api.py
@@ -230,3 +230,128 @@ def test_all_stems_zip_mp3(client, tmp_path):
     zf = zipfile.ZipFile(io.BytesIO(r.content))
     assert zf.namelist() == ["vocals.mp3"]
     assert len(zf.read("vocals.mp3")) > 0
+
+
+# --- dynamic mixdown endpoint (#183) ---
+
+
+def _tiny_wav(seconds: float = 0.2, sr: int = 8000) -> bytes:
+    """A minimal silent PCM16 mono WAV so ffmpeg can decode/mix it."""
+    import struct
+
+    nframes = int(sr * seconds)
+    data = b"\x00\x00" * nframes
+    hdr = b"RIFF" + struct.pack("<I", 36 + len(data)) + b"WAVE"
+    hdr += b"fmt " + struct.pack("<IHHIIHH", 16, 1, 1, sr, sr * 2, 2, 16)
+    hdr += b"data" + struct.pack("<I", len(data))
+    return hdr + data
+
+
+def _done_job_with_stems(tmp_path, job_id: str, names) -> Job:
+    job = Job(id=job_id)
+    job.status = "done"
+    job.title = "Track"
+    _jobs[job.id] = job
+    for name in names:
+        _make_stem_file(tmp_path, job_id, name, _tiny_wav())
+    return job
+
+
+def test_mixdown_rejects_bad_ext(client):
+    r = client.get("/api/jobs/abcdef000001/mixdown.ogg?stems=vocals&gains=1")
+    assert r.status_code == 404
+
+
+def test_mixdown_rejects_length_mismatch(client):
+    r = client.get("/api/jobs/abcdef000001/mixdown.wav?stems=vocals,drums&gains=1")
+    assert r.status_code == 422
+
+
+def test_mixdown_rejects_empty(client):
+    r = client.get("/api/jobs/abcdef000001/mixdown.wav?stems=&gains=")
+    assert r.status_code == 422
+
+
+def test_mixdown_rejects_bad_gain(client):
+    for gains in ("abc", "-1", "99"):
+        r = client.get(f"/api/jobs/abcdef000001/mixdown.wav?stems=vocals&gains={gains}")
+        assert r.status_code == 422, f"gains={gains!r} should 422"
+
+
+def test_mixdown_rejects_unknown_stem(client):
+    # "mix" is intentionally excluded (it is the static pre-render we replace).
+    for stem in ("banjo", "mix"):
+        r = client.get(f"/api/jobs/abcdef000001/mixdown.wav?stems={stem}&gains=1")
+        assert r.status_code == 422, f"stem={stem!r} should 422"
+
+
+def test_mixdown_rejects_bad_region(client):
+    r = client.get("/api/jobs/abcdef000001/mixdown.wav?stems=vocals&gains=1&start=5&end=2")
+    assert r.status_code == 422
+
+
+def test_mixdown_rejects_malformed_job_id(client):
+    r = client.get("/api/jobs/ZZZ/mixdown.wav?stems=vocals&gains=1")
+    assert r.status_code == 404
+
+
+def test_mixdown_requires_done(client, tmp_path):
+    job = Job(id="abcdef000002")
+    job.status = "separating"
+    _jobs[job.id] = job
+    _make_stem_file(tmp_path, job.id, "vocals", _tiny_wav())
+    r = client.get(f"/api/jobs/{job.id}/mixdown.wav?stems=vocals&gains=1")
+    assert r.status_code == 404
+
+
+def test_mixdown_404_for_missing_stem_file(client, tmp_path):
+    job = Job(id="abcdef000003")
+    job.status = "done"
+    _jobs[job.id] = job  # no stem files on disk
+    r = client.get(f"/api/jobs/{job.id}/mixdown.wav?stems=vocals&gains=1")
+    assert r.status_code == 404
+
+
+def _skip_without_ffmpeg():
+    import shutil
+
+    if shutil.which("ffmpeg") is None:
+        import pytest
+
+        pytest.skip("ffmpeg not available")
+
+
+def test_mixdown_wav_happy(client, tmp_path):
+    _skip_without_ffmpeg()
+    job = _done_job_with_stems(tmp_path, "abcdef000010", ["vocals", "drums"])
+    r = client.get(f"/api/jobs/{job.id}/mixdown.wav?stems=vocals,drums&gains=1.000,0.500")
+    assert r.status_code == 200
+    assert r.headers["content-type"] == "audio/wav"
+    assert r.content[:4] == b"RIFF"
+
+
+def test_mixdown_single_lane_skips_amix(client, tmp_path):
+    _skip_without_ffmpeg()
+    job = _done_job_with_stems(tmp_path, "abcdef000011", ["bass"])
+    r = client.get(f"/api/jobs/{job.id}/mixdown.wav?stems=bass&gains=1.500")
+    assert r.status_code == 200
+    assert r.content[:4] == b"RIFF"
+
+
+def test_mixdown_mp3_happy(client, tmp_path):
+    _skip_without_ffmpeg()
+    job = _done_job_with_stems(tmp_path, "abcdef000012", ["vocals", "bass"])
+    r = client.get(f"/api/jobs/{job.id}/mixdown.mp3?stems=vocals,bass&gains=1,1")
+    assert r.status_code == 200
+    assert r.headers["content-type"] == "audio/mpeg"
+    assert len(r.content) > 0
+
+
+def test_mixdown_region_trim(client, tmp_path):
+    _skip_without_ffmpeg()
+    job = _done_job_with_stems(tmp_path, "abcdef000013", ["vocals", "drums"])
+    r = client.get(
+        f"/api/jobs/{job.id}/mixdown.wav?stems=vocals,drums&gains=1,1&start=0.05&end=0.15"
+    )
+    assert r.status_code == 200
+    assert r.content[:4] == b"RIFF"


### PR DESCRIPTION
Fixes #183.

## Problem
Export Mix downloaded the static pre-rendered `mix.wav`/`original` and ignored the mixer, so per-stem volume, mute, and solo never reached the exported file (it came out close to the original). On Windows the reporter expected the export to match what they hear.

## Solution
Build the mix on demand from the current mixer state.

**Backend** (`app/api/stems.py`) - new streaming endpoint:
```
GET /jobs/{job_id}/mixdown.{ext}?stems=a,b&gains=1.0,0.5[&start&end]
```
Applies each lane's gain (`volume=g`) then sums (`amix=...:normalize=0`), streamed as WAV (`pcm_s16le`) or MP3 (`-q:a 2`). Mirrors `get_stem_mp3`'s streaming and `collect.py`'s amix. Reuses `_validate_stem_path` (job-id / done / path-traversal guards) and `_stream_ffmpeg`. Validates `ext`, equal-length `stems`/`gains`, numeric gains in range, the stem whitelist (`STEM_NAMES` + `original`, excludes `mix`), and the region bounds. A single audible lane skips amix.

**Frontend** (`static/js/player.js`) - the four Export Mix functions (WAV/MP3, full + region) compute the audible lanes and gains from `mixerState`, mirroring `mixer.js` (volume + mute + solo). They return `false` when everything is muted; `main.js` then shows a friendly message instead of downloading silence.

## Product decisions (confirmed)
- **Per-stem only** - the master fader is NOT baked in (it is a monitoring level; default 50% must not make exports 6 dB quiet).
- **Export Mix only** - Export All Stems (.zip) stays raw isolated stems, unchanged.
- **Always reflect** - muted stems excluded, solo means only soloed lanes. No toggle UI.

## Verification
- 13 new backend tests (happy WAV/MP3, single-lane, region trim, plus 404/422 guards); full suite 96 passed; ruff + `node --check` clean.
- End-to-end against a real job: gain 0.5 yields exactly half RMS; `amix` sums two stems with max error 0.000000 (faithful, `normalize=0`); MP3 works; bad gain returns 422.

Files: `app/api/stems.py`, `static/js/player.js`, `static/js/main.js`, `tests/test_stems_api.py`.