### PR TITLE
feat: add FLAC support (import and export)

### DIFF
--- a/app/api/jobs.py
+++ b/app/api/jobs.py
@@ -33,7 +33,7 @@ from app.pipeline.download import InvalidYouTubeURL, validate_youtube_url
 router = APIRouter(tags=["jobs"])
 logger = logging.getLogger("stemdeck.api")
 
-_ALLOWED_EXTS = frozenset((".mp3", ".wav"))
+_ALLOWED_EXTS = frozenset((".mp3", ".wav", ".flac"))
 _MAX_UPLOAD_BYTES = 100 * 1024 * 1024  # 100 MB
 _WS_RE = re.compile(r"\s+")
 
@@ -177,7 +177,7 @@ async def _create_local_job(request: Request) -> dict[str, str]:
     if ext not in _ALLOWED_EXTS:
         raise HTTPException(
             status_code=422,
-            detail=f"Unsupported file type '{ext}': only .mp3 and .wav are accepted",
+            detail=f"Unsupported file type '{ext}': only .mp3, .wav, and .flac are accepted",
         )
 
     # Validate stems list from form field

--- a/app/api/stems.py
+++ b/app/api/stems.py
@@ -33,6 +33,16 @@ _ALLOWED_NAMES = frozenset(STEM_NAMES) | {"original", "mix"}
 _MIXDOWN_NAMES = frozenset(STEM_NAMES) | {"original"}
 _MIXDOWN_MAX_GAIN = 4.0
 
+# Output encoders by container/extension, shared by the dynamic mixdown and the
+# stems zip. WAV is lossless PCM, FLAC is lossless compressed, MP3 is VBR ~190 kbps.
+_ENCODE_ARGS = {
+    "wav": ["-c:a", "pcm_s16le"],
+    "mp3": ["-q:a", "2"],
+    "flac": ["-c:a", "flac"],
+}
+MIXDOWN_CODECS = {ext: [*args, "-f", ext] for ext, args in _ENCODE_ARGS.items()}
+MIXDOWN_MEDIA_TYPES = {"wav": "audio/wav", "mp3": "audio/mpeg", "flac": "audio/flac"}
+
 
 def _validate_stem_path(job_id: str, name: str):
     """Shared guard: validate job_id, name, job state, and path. Returns resolved Path."""
@@ -185,7 +195,7 @@ async def get_mixdown(
     exported file matches what is heard. The master fader is intentionally not
     applied -- it is a monitoring level, not part of the mix. Optional ?start=&end=
     trims to a loop region."""
-    if ext not in ("wav", "mp3"):
+    if ext not in ("wav", "mp3", "flac"):
         raise HTTPException(status_code=404, detail="not found")
 
     names = [s for s in stems.split(",") if s]
@@ -227,10 +237,10 @@ async def get_mixdown(
         out_label = "[mix]"
     else:
         out_label = "[a0]"
-    codec = ["-c:a", "pcm_s16le", "-f", "wav"] if ext == "wav" else ["-q:a", "2", "-f", "mp3"]
+    codec = MIXDOWN_CODECS[ext]
     cmd += ["-filter_complex", ";".join(filters), "-map", out_label, *post_seek, *codec, "pipe:1"]
 
-    media_type = "audio/wav" if ext == "wav" else "audio/mpeg"
+    media_type = MIXDOWN_MEDIA_TYPES[ext]
     return StreamingResponse(
         _stream_ffmpeg(cmd),
         media_type=media_type,
@@ -246,17 +256,18 @@ def _safe_title(title: str | None) -> str:
 
 
 def _build_stems_zip(sources: list[tuple[str, Path]], fmt: str, dest: Path) -> None:
-    """Blocking: write the stems into a ZIP. WAV files are stored as-is; MP3 is
-    transcoded per stem via ffmpeg. ZIP_STORED throughout — audio doesn't
+    """Blocking: write the stems into a ZIP. WAV files are stored as-is; MP3 and
+    FLAC are transcoded per stem via ffmpeg. ZIP_STORED throughout - audio doesn't
     meaningfully compress, and STORED keeps the build fast. Runs in a thread."""
     if fmt == "wav":
         with zipfile.ZipFile(dest, "w", zipfile.ZIP_STORED) as zf:
             for name, p in sources:
                 zf.write(p, arcname=f"{name}.wav")
         return
+    encode = _ENCODE_ARGS[fmt]
     with tempfile.TemporaryDirectory() as td, zipfile.ZipFile(dest, "w", zipfile.ZIP_STORED) as zf:
         for name, p in sources:
-            out = os.path.join(td, f"{name}.mp3")
+            out = os.path.join(td, f"{name}.{fmt}")
             cmd = [
                 ffmpeg_executable(),
                 "-nostdin",
@@ -264,10 +275,9 @@ def _build_stems_zip(sources: list[tuple[str, Path]], fmt: str, dest: Path) -> N
                 "error",
                 "-i",
                 str(p),
-                "-q:a",
-                "2",  # VBR ~190 kbps, matches the per-stem mp3 endpoint
+                *encode,
                 "-f",
-                "mp3",
+                fmt,
                 out,
             ]
             proc = subprocess.run(  # noqa: S603 — list args, no shell, trusted ffmpeg
@@ -280,7 +290,7 @@ def _build_stems_zip(sources: list[tuple[str, Path]], fmt: str, dest: Path) -> N
             if proc.returncode != 0:
                 tail = proc.stderr[-2000:].decode("utf-8", "replace")
                 raise RuntimeError(f"ffmpeg failed for {name}: {tail}")
-            zf.write(out, arcname=f"{name}.mp3")
+            zf.write(out, arcname=f"{name}.{fmt}")
 
 
 @router.get("/jobs/{job_id}/stems/all.zip")
@@ -295,8 +305,8 @@ async def get_all_stems_zip(
     every available stem is included."""
     if not JOB_ID_RE.match(job_id):
         raise HTTPException(status_code=404, detail="job not found")
-    if fmt not in ("wav", "mp3"):
-        raise HTTPException(status_code=422, detail="format must be 'wav' or 'mp3'")
+    if fmt not in ("wav", "mp3", "flac"):
+        raise HTTPException(status_code=422, detail="format must be 'wav', 'mp3', or 'flac'")
     job = registry_get(job_id)
     if job is None or job.status != "done":
         raise HTTPException(status_code=404, detail="job not ready")

--- a/static/index.html
+++ b/static/index.html
@@ -57,7 +57,7 @@
                 <path d="M12 3v12 M7 8l5-5 5 5 M5 21h14"/>
               </svg>
             </button>
-            <input id="fileInput" type="file" accept=".mp3,.wav,audio/mpeg,audio/wav" style="display:none" aria-hidden="true" />
+            <input id="fileInput" type="file" accept=".mp3,.wav,.flac,audio/mpeg,audio/wav,audio/flac" style="display:none" aria-hidden="true" />
           </div>
 
           <!-- Divider -->
@@ -595,6 +595,7 @@
                 <div class="export-format-toggle" role="radiogroup" aria-label="Export format">
                   <button class="export-fmt active" id="t-fmt-wav" type="button" role="radio" aria-checked="true">WAV</button>
                   <button class="export-fmt" id="t-fmt-mp3" type="button" role="radio" aria-checked="false">MP3</button>
+                  <button class="export-fmt" id="t-fmt-flac" type="button" role="radio" aria-checked="false">FLAC</button>
                 </div>
                 <button class="chip-panel-item export-item" id="t-export-mix" type="button" role="menuitem">
                   <span class="chip-item-icon" aria-hidden="true">

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -3,7 +3,7 @@ import {
   setLoopStart, setLoopEnd, selectedStems, saveSelectedStems, stemSelectionReady,
 } from "./state.js";
 import { STEM_NAMES, syncStemNamesFromAPI } from "./constants.js";
-import { renderEmptyShell, buildStripStems, downloadCurrentMix, downloadCurrentMixMp3, downloadAllStemsZip, downloadRegionMix, downloadRegionMixMp3, drawFooterPlaceholder } from "./player.js";
+import { renderEmptyShell, buildStripStems, downloadCurrentMix, downloadAllStemsZip, downloadRegionMix, drawFooterPlaceholder } from "./player.js";
 import { wireJobForm, showError } from "./job.js";
 import { wireTransportButtons } from "./transport.js";
 import { togglePlayPause, updateLoopRegionVisual } from "./transport.js";
@@ -129,6 +129,7 @@ function wireFooterControls() {
   const exportLabel = document.getElementById("t-export-label");
   const fmtWav   = document.getElementById("t-fmt-wav");
   const fmtMp3   = document.getElementById("t-fmt-mp3");
+  const fmtFlac  = document.getElementById("t-fmt-flac");
   const itemMix    = document.getElementById("t-export-mix");
   const itemStems  = document.getElementById("t-export-stems");
   const itemRegion = document.getElementById("t-export-region");
@@ -150,13 +151,14 @@ function wireFooterControls() {
 
   function setFormat(f) {
     format = f;
-    fmtWav?.classList.toggle("active", f === "wav");
-    fmtWav?.setAttribute("aria-checked", String(f === "wav"));
-    fmtMp3?.classList.toggle("active", f === "mp3");
-    fmtMp3?.setAttribute("aria-checked", String(f === "mp3"));
+    for (const [btn, val] of [[fmtWav, "wav"], [fmtMp3, "mp3"], [fmtFlac, "flac"]]) {
+      btn?.classList.toggle("active", f === val);
+      btn?.setAttribute("aria-checked", String(f === val));
+    }
   }
   fmtWav?.addEventListener("click", (e) => { e.stopPropagation(); setFormat("wav"); });
   fmtMp3?.addEventListener("click", (e) => { e.stopPropagation(); setFormat("mp3"); });
+  fmtFlac?.addEventListener("click", (e) => { e.stopPropagation(); setFormat("flac"); });
 
   function resetBusy() {
     busy = false;
@@ -187,7 +189,7 @@ function wireFooterControls() {
   itemMix?.addEventListener("click", (e) => {
     e.stopPropagation();
     if (busy) return;
-    const ok = format === "mp3" ? downloadCurrentMixMp3() : downloadCurrentMix();
+    const ok = downloadCurrentMix(format);
     if (!ok) { showError("All stems are muted - nothing to export."); return; }
     flashBusy();
   });
@@ -195,7 +197,7 @@ function wireFooterControls() {
   itemRegion?.addEventListener("click", (e) => {
     e.stopPropagation();
     if (busy || itemRegion.getAttribute("aria-disabled") === "true") return;
-    const ok = format === "mp3" ? downloadRegionMixMp3() : downloadRegionMix();
+    const ok = downloadRegionMix(format);
     if (!ok) { showError("All stems are muted - nothing to export."); return; }
     flashBusy();
   });
@@ -274,8 +276,8 @@ function wireFileDrop() {
   function applyFile(file) {
     if (!file) return;
     const lower = file.name.toLowerCase();
-    if (!lower.endsWith(".mp3") && !lower.endsWith(".wav")) {
-      showError("Only MP3 and WAV files are supported.");
+    if (!lower.endsWith(".mp3") && !lower.endsWith(".wav") && !lower.endsWith(".flac")) {
+      showError("Only MP3, WAV, and FLAC files are supported.");
       return;
     }
     if (file.size > MAX_UPLOAD_BYTES) {

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -1303,17 +1303,10 @@ function _exportFilename(ext) {
 // The download functions return true when a download was triggered and false
 // when there is nothing audible to export (every lane muted), so the caller can
 // surface a message.
-export function downloadCurrentMix() {
-  const url = _mixdownUrl("wav", false);
+export function downloadCurrentMix(ext = "wav") {
+  const url = _mixdownUrl(ext, false);
   if (!url) return false;
-  _triggerDownload(url, _exportFilename("wav"));
-  return true;
-}
-
-export function downloadCurrentMixMp3() {
-  const url = _mixdownUrl("mp3", false);
-  if (!url) return false;
-  _triggerDownload(url, _exportFilename("mp3"));
+  _triggerDownload(url, _exportFilename(ext));
   return true;
 }
 
@@ -1362,18 +1355,10 @@ function _regionFilename(ext) {
   return `${safe || "region"}_region.${ext}`;
 }
 
-export function downloadRegionMix() {
+export function downloadRegionMix(ext = "wav") {
   if (!loopEnabled || loopStart >= loopEnd) return false;
-  const url = _mixdownUrl("wav", true);
+  const url = _mixdownUrl(ext, true);
   if (!url) return false;
-  _triggerDownload(url, _regionFilename("wav"));
-  return true;
-}
-
-export function downloadRegionMixMp3() {
-  if (!loopEnabled || loopStart >= loopEnd) return false;
-  const url = _mixdownUrl("mp3", true);
-  if (!url) return false;
-  _triggerDownload(url, _regionFilename("mp3"));
+  _triggerDownload(url, _regionFilename(ext));
   return true;
 }

--- a/tests/test_jobs_api.py
+++ b/tests/test_jobs_api.py
@@ -173,6 +173,16 @@ def test_upload_wav_returns_job_id(upload_client):
     assert "job_id" in r.json()
 
 
+def test_upload_flac_returns_job_id(upload_client):
+    data = io.BytesIO(b"fLaC" + b"\x00" * 128)
+    r = upload_client.post(
+        "/api/jobs",
+        files={"file": ("my_track.flac", data, "audio/flac")},
+    )
+    assert r.status_code == 200
+    assert "job_id" in r.json()
+
+
 # ─── Sections endpoint ────────────────────────────────────────────────────────
 
 

--- a/tests/test_stems_api.py
+++ b/tests/test_stems_api.py
@@ -173,7 +173,7 @@ def test_all_stems_zip_rejects_bad_format(client, tmp_path):
     job.status = "done"
     _jobs[job.id] = job
     _make_stem_file(tmp_path, job.id, "vocals")
-    r = client.get(f"/api/jobs/{job.id}/stems/all.zip?format=flac")
+    r = client.get(f"/api/jobs/{job.id}/stems/all.zip?format=ogg")
     assert r.status_code == 422
 
 
@@ -355,3 +355,32 @@ def test_mixdown_region_trim(client, tmp_path):
     )
     assert r.status_code == 200
     assert r.content[:4] == b"RIFF"
+
+
+def test_mixdown_flac_happy(client, tmp_path):
+    _skip_without_ffmpeg()
+    job = _done_job_with_stems(tmp_path, "abcdef000014", ["vocals", "bass"])
+    r = client.get(f"/api/jobs/{job.id}/mixdown.flac?stems=vocals,bass&gains=1,1")
+    assert r.status_code == 200
+    assert r.headers["content-type"] == "audio/flac"
+    assert r.content[:4] == b"fLaC"  # FLAC stream marker
+
+
+def test_mixdown_rejects_unknown_ext_still(client):
+    # ogg remains unsupported even after adding flac.
+    r = client.get("/api/jobs/abcdef000001/mixdown.ogg?stems=vocals&gains=1")
+    assert r.status_code == 404
+
+
+def test_all_stems_zip_flac(client, tmp_path):
+    _skip_without_ffmpeg()
+    job = _done_job_with_stems(tmp_path, "abcdef000015", ["vocals"])
+    job.title = "Track"
+    import io
+    import zipfile
+
+    r = client.get(f"/api/jobs/{job.id}/stems/all.zip?format=flac")
+    assert r.status_code == 200
+    zf = zipfile.ZipFile(io.BytesIO(r.content))
+    assert zf.namelist() == ["vocals.flac"]
+    assert zf.read("vocals.flac")[:4] == b"fLaC"


### PR DESCRIPTION
Adds FLAC as a first-class audio format on both sides of StemDeck.

## Import
- Accept `.flac` uploads alongside `.mp3`/`.wav`.
- The upload is stored as `source.flac` and decoded by the existing ffmpeg/Demucs path, so **no pipeline change** is needed - only the allowlist (`app/api/jobs.py`), the file-picker `accept` attribute, and the user-facing messages.

## Export
- A third **WAV / MP3 / FLAC** toggle in the export menu, applied consistently to the **mix**, the **loop region**, and the **stems .zip**.
- Backend: a shared encoder map drives both the dynamic mixdown endpoint (`mixdown.flac` -> `-c:a flac`) and the stems-zip builder (per-stem FLAC transcode). Format validation accepts `wav|mp3|flac`.
- Frontend: the per-format `*Mp3` mix/region helpers are collapsed into `downloadCurrentMix(ext)` / `downloadRegionMix(ext)`, so adding FLAC (or any future format) is just one more toggle.

## Verification
- End-to-end against a real job: `mixdown.flac` and the FLAC stems zip return valid, ffprobe-decodable FLAC; WAV and MP3 still work (regression-checked).
- Tests: FLAC upload accepted; `mixdown.flac` happy path (FLAC marker `fLaC`); FLAC stems zip; format-validation. Full suite **100 passed**. ruff + `node --check` clean.

Files: `app/api/jobs.py`, `app/api/stems.py`, `static/index.html`, `static/js/main.js`, `static/js/player.js`, tests.