### PR TITLE
fix: refresh runtime pack on app upgrade + stop false update banner

### DIFF
--- a/desktop/ui/setup.js
+++ b/desktop/ui/setup.js
@@ -217,7 +217,17 @@ async function runSetup() {
       minDelay(350),
     ]);
 
-    if (runtime.pythonReady && runtime.ffmpegReady && runtime.torchDevice) {
+    // Compare the installed runtime against the version this app bundle expects.
+    // On a DMG upgrade the old runtime is still fully "ready", so this MUST be
+    // checked before the early-return below -- otherwise setup starts the stale
+    // backend + frontend and the new release (e.g. new features, version) never
+    // takes effect until the runtime is manually cleared.
+    const runtimeStatus = await invoke("runtime_pack_status");
+    const expectedVersion = runtimeStatus.manifest?.version;
+    const installedVersion = runtimeStatus.installedVersion;
+    const versionMismatch = expectedVersion && installedVersion && expectedVersion !== installedVersion;
+
+    if (runtime.pythonReady && runtime.ffmpegReady && runtime.torchDevice && !versionMismatch) {
       for (const step of steps) {
         step.classList.remove("active", "error");
         if (step.dataset.step === "backend") {
@@ -234,11 +244,6 @@ async function runSetup() {
       });
       return;
     }
-
-    const runtimeStatus = await invoke("runtime_pack_status");
-    const expectedVersion = runtimeStatus.manifest?.version;
-    const installedVersion = runtimeStatus.installedVersion;
-    const versionMismatch = expectedVersion && installedVersion && expectedVersion !== installedVersion;
 
     if (!runtime.pythonReady || versionMismatch) {
       if (versionMismatch) {

--- a/desktop/ui/setup.js
+++ b/desktop/ui/setup.js
@@ -225,7 +225,11 @@ async function runSetup() {
     const runtimeStatus = await invoke("runtime_pack_status");
     const expectedVersion = runtimeStatus.manifest?.version;
     const installedVersion = runtimeStatus.installedVersion;
-    const versionMismatch = expectedVersion && installedVersion && expectedVersion !== installedVersion;
+    // Mismatch when this build expects a version the installed runtime isn't.
+    // An unknown installedVersion (a runtime from a build that never recorded
+    // one) also counts, so an upgrade still refreshes it. Self-heals: after one
+    // refresh the install records the version and subsequent launches match.
+    const versionMismatch = Boolean(expectedVersion) && installedVersion !== expectedVersion;
 
     if (runtime.pythonReady && runtime.ffmpegReady && runtime.torchDevice && !versionMismatch) {
       for (const step of steps) {
@@ -247,7 +251,7 @@ async function runSetup() {
 
     if (!runtime.pythonReady || versionMismatch) {
       if (versionMismatch) {
-        setStatus(`Updating runtime from ${installedVersion} to ${expectedVersion}...`);
+        setStatus(`Updating runtime from ${installedVersion || "an older build"} to ${expectedVersion}...`);
       }
       await invoke("ensure_workspace");
       await installRuntimePack(runtime.appRoot);

--- a/static/js/catalog.js
+++ b/static/js/catalog.js
@@ -1482,6 +1482,20 @@ function normalizeVersion(value) {
   return String(value || "").trim().replace(/^v/i, "") || FALLBACK_VERSION;
 }
 
+// Fold a version into one canonical form so the GitHub release tag
+// ("0.7.0-alpha.9") and the backend's PEP440 package version ("0.7.0a9", from
+// hatch-vcs via /api/health) compare equal. Without this the update banner
+// shows on every release because the two strings never match literally.
+function canonicalVersion(value) {
+  return normalizeVersion(value)
+    .toLowerCase()
+    .replace(/[-_]/g, "")            // 0.7.0-alpha.9 -> 0.7.0alpha.9
+    .replace(/alpha/g, "a")
+    .replace(/beta/g, "b")
+    .replace(/preview|pre/g, "rc")
+    .replace(/(a|b|rc)\.?(\d)/g, "$1$2"); // alpha.9/a.9 -> a9
+}
+
 function setDisplayedVersion(version) {
   const brand = document.getElementById("brandVersion");
   const about = document.getElementById("aboutVersion");
@@ -1505,7 +1519,9 @@ async function checkForUpdate() {
     if (!res.ok) return;
     const data = await res.json();
     const latest = normalizeVersion(data.tag_name);
-    if (!latest || latest === currentVersion) return;
+    // Compare canonically so a PEP440 current version (0.7.0a9) matches the
+    // release tag form (0.7.0-alpha.9) and we don't nag an already-current app.
+    if (!latest || canonicalVersion(latest) === canonicalVersion(currentVersion)) return;
     // Dev/source builds report a git-derived version (e.g. 0.7.0a5.dev3+g…) that
     // is *ahead* of the last release — don't nag them with an "update" banner.
     if (/\bdev\b|\+/.test(currentVersion)) return;


### PR DESCRIPTION
Two upgrade bugs that left a freshly-installed alpha.9 DMG running old code (no FLAC, old version reported, a persistent "New release available" banner).

## 1. Stale runtime after a DMG upgrade (primary)
The macOS app downloads a "runtime pack" that contains **both the Python backend and the main static frontend**, cached under `~/Library/Application Support/StemDeck/runtime`.

`desktop/ui/setup.js` `runSetup()` checked the runtime version **after** an early-return that fires whenever an existing runtime is "ready" (`pythonReady && ffmpegReady && torchDevice`) - which is always true on an upgrade. So it started the **old** backend+frontend and never reached the `versionMismatch` branch that re-downloads the new pack.

Fix: compute the installed-vs-expected version comparison **before** the early-return and gate the early-return on `!versionMismatch`. The data was already exposed by `runtime_pack_status` (`installedVersion` + `manifest.version`, correctly camelCased); the existing mismatch branch (`installRuntimePack`) now runs and the backend starts as before.

Note: `setup.js` ships in the app bundle (not the runtime pack), so the fix takes effect on the first upgrade **into** a build that has it.

## 2. False "update available" banner (secondary)
`static/js/catalog.js` `checkForUpdate()` compared the backend's PEP440 version (`0.7.0a9`, from `/api/health` via hatch-vcs) against the GitHub tag (`0.7.0-alpha.9`) with a literal `!==`, so it nagged on every release. Added `canonicalVersion()` to fold both forms together (`alpha->a`, `beta->b`, `rc`, drop separators) and compare canonically.

## Verification
- `node --check` both files.
- `canonicalVersion()` maps `0.7.0-alpha.9`, `v0.7.0-alpha.9`, `0.7.0a9` all to `0.7.0a9`; `0.7.0-beta.2`->`0.7.0b2`, `0.7.0-rc.1`->`0.7.0rc1`; and genuine upgrades still differ (`a8` vs `a9`, `alpha6` vs `alpha9`).
- Confirmed the setup fall-through path still starts the backend (setup.js:358) after a runtime update.

## Immediate recovery for users already stuck on alpha.9
The installed shell + bundled manifest are already alpha.9; only the cached runtime is stale. Removing it forces a re-download of the alpha.9 runtime (with FLAC):
```
rm -rf ~/Library/Application\ Support/StemDeck/runtime ~/Library/Application\ Support/StemDeck/runtime.old
```
then relaunch.

Files: `desktop/ui/setup.js`, `static/js/catalog.js`.