### PR TITLE
fix: overview waveforms - align to lanes and only show extracted stems

### DIFF
--- a/static/js/player.js
+++ b/static/js/player.js
@@ -350,6 +350,16 @@ function renderOverviewWaveformPath(stemName, peaks, norm, color, barCount) {
   }
   row.style.setProperty("--stem-color", color);
   row.style.order = String(TRACK_NAMES.indexOf(stemName));
+  // A row is created for every mixer lane, including stems with no audio (e.g.
+  // a subset extraction). The rows are flex-distributed across the lane stack,
+  // so they only stay 1:1 with the mixer lanes when their count matches; an
+  // empty lane renders nothing but keeps that alignment. Without this, fewer
+  // waveform rows than lanes stretch to fill the stack and drift off their
+  // tracks.
+  if (!peaks?.length) {
+    row.innerHTML = "";
+    return;
+  }
   const bars = barCount || overviewBarCount();
   row.innerHTML = `
     <svg class="stem-waveform-svg" viewBox="0 0 ${bars} 48" preserveAspectRatio="none" aria-hidden="true">
@@ -358,23 +368,30 @@ function renderOverviewWaveformPath(stemName, peaks, norm, color, barCount) {
   `;
 }
 
+// The lane set must mirror the mixer/multitrack lanes (orderedNames in
+// wireUpAudio): "original" plus the stems when an original lane is present,
+// otherwise just the stems. Rendering a row for every lane keeps the overlay
+// aligned even when only a subset of stems was extracted.
+function overviewLaneNames(stems) {
+  return stems.some((s) => s.name === "original") ? TRACK_NAMES : STEM_NAMES;
+}
+
 function renderAllOverviewWaveformsFromPeaks(stems, peaksData) {
+  const laneNames = overviewLaneNames(stems);
   let globalMax = 0;
-  for (const stem of stems) {
-    const pts = peaksData[stem.name];
+  for (const name of laneNames) {
+    const pts = peaksData[name];
     if (!pts?.length) continue;
     for (const [mn, mx] of pts) {
       if (mx > globalMax) globalMax = mx;
       if (-mn > globalMax) globalMax = -mn;
     }
   }
-  if (globalMax <= 0) return;
-  const norm = 1 / globalMax;
+  const norm = globalMax > 0 ? 1 / globalMax : 0;
   const bars = overviewBarCount();
-  for (const stem of stems) {
-    const pts = peaksData[stem.name];
-    if (!pts?.length) continue;
-    renderOverviewWaveformPath(stem.name, pts, norm, STEM_COLORS[stem.name] || "#a0a0a0", bars);
+  for (const name of laneNames) {
+    const pts = peaksData[name];
+    renderOverviewWaveformPath(name, pts, norm, STEM_COLORS[name] || "#a0a0a0", bars);
   }
 }
 
@@ -383,26 +400,23 @@ function renderAllOverviewWaveformsFromPeaks(stems, peaksData) {
 // matching what a DAW shows. Per-stem normalization made every lane
 // fill its row regardless of how loud the stem actually was.
 function renderAllOverviewWaveforms(stems, decodedMap) {
+  const laneNames = overviewLaneNames(stems);
   const peaksByStem = new Map();
   let globalMax = 0;
-  for (const stem of stems) {
-    const buf = decodedMap.get(stem.name);
+  for (const name of laneNames) {
+    const buf = decodedMap.get(name);
     if (!isAudioBufferLike(buf)) continue;
     const peaks = bufferMinMaxPeaks(buf, OVERVIEW_WAVE_POINTS);
-    peaksByStem.set(stem.name, peaks);
+    peaksByStem.set(name, peaks);
     for (const [mn, mx] of peaks) {
       if (mx > globalMax) globalMax = mx;
       if (-mn > globalMax) globalMax = -mn;
     }
   }
-  if (globalMax <= 0) return;
-  const norm = 1 / globalMax;
+  const norm = globalMax > 0 ? 1 / globalMax : 0;
   const bars = overviewBarCount();
-  for (const stem of stems) {
-    const peaks = peaksByStem.get(stem.name);
-    if (!peaks) continue;
-    const color = STEM_COLORS[stem.name] || "#a0a0a0";
-    renderOverviewWaveformPath(stem.name, peaks, norm, color, bars);
+  for (const name of laneNames) {
+    renderOverviewWaveformPath(name, peaksByStem.get(name), norm, STEM_COLORS[name] || "#a0a0a0", bars);
   }
 }
 

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -378,8 +378,14 @@ function overviewLaneNames(stems) {
 
 function renderAllOverviewWaveformsFromPeaks(stems, peaksData) {
   const laneNames = overviewLaneNames(stems);
+  // Only the extracted/selected stems (plus original) get a waveform, even if
+  // peaks.json carries data for stems the user didn't keep (Demucs separates
+  // all 6 internally). Every lane still gets a ROW so the overlay stays aligned;
+  // non-selected lanes just render empty.
+  const present = new Set(stems.map((s) => s.name));
   let globalMax = 0;
   for (const name of laneNames) {
+    if (!present.has(name)) continue;
     const pts = peaksData[name];
     if (!pts?.length) continue;
     for (const [mn, mx] of pts) {
@@ -390,7 +396,7 @@ function renderAllOverviewWaveformsFromPeaks(stems, peaksData) {
   const norm = globalMax > 0 ? 1 / globalMax : 0;
   const bars = overviewBarCount();
   for (const name of laneNames) {
-    const pts = peaksData[name];
+    const pts = present.has(name) ? peaksData[name] : null;
     renderOverviewWaveformPath(name, pts, norm, STEM_COLORS[name] || "#a0a0a0", bars);
   }
 }


### PR DESCRIPTION
Fixes two related issues with the studio waveform overlay on **subset** extractions (both reported via screenshots; full extractions looked fine).

## Issue 1 - misalignment
With a subset (e.g. drums + bass), waveforms didn't respect their lane boundaries and drifted across other tracks. The overlay created one `.stem-waveform-row` only per stem with audio, and those rows are `flex: 1 1 0`, so fewer rows than lanes stretched to fill the stack (~2.3 lanes each).

## Issue 2 - non-extracted stems showing
After the first fix, extracting e.g. **guitar only** still showed waveforms on Drums/Other. Cause: the overlay iterated `peaks.json` for every lane, but `peaks.json` carries data for all 6 stems (Demucs separates them all internally), so non-kept stems rendered.

## Fix
- Render a row for **every mixer lane** (`overviewLaneNames()` -> `TRACK_NAMES` when an original lane is present, else `STEM_NAMES`, mirroring `orderedNames`) so rows stay 1:1 with lanes -> alignment.
- Render **bars only for the present/selected stems** (the set passed to `wireUpAudio` = selection + original); non-selected lanes get an empty, aligned row.

## Verification (headless WebKit)
- drums+bass subset, before: 2 rows at 216px (misaligned). After: 6 rows at 72px (aligned).
- guitar-only selection: 6 rows at 72px each; **bars only on the guitar lane**, all others empty.
- Full extraction still renders all stems correctly.

File: `static/js/player.js`.