### PR TITLE
docs: Code of Conduct, Contributing guide, and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,72 @@
+name: Bug report
+description: Something isn't working as expected.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for reporting a bug. Please fill in the details so we can reproduce it.
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before reporting
+      options:
+        - label: I'm on the latest release and the issue still happens.
+          required: true
+        - label: I searched existing issues and didn't find a duplicate.
+          required: true
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected instead.
+      placeholder: When I ..., StemDeck ... but I expected ...
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open StemDeck
+        2. Import ...
+        3. Click ...
+        4. See error
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS (Apple Silicon)
+        - macOS (Intel)
+        - Windows
+        - Linux
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: StemDeck version
+      description: Shown in the About dialog (Help icon).
+      placeholder: e.g. v0.7.0-alpha.12
+    validations:
+      required: true
+  - type: dropdown
+    id: install
+    attributes:
+      label: How did you install it?
+      options:
+        - macOS DMG
+        - Windows ZIP
+        - From source
+        - Docker / self-hosted
+    validations:
+      required: true
+  - type: textarea
+    id: extra
+    attributes:
+      label: Logs / screenshots
+      description: Drag in screenshots or a recording, and paste any error text as code.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & Discussion
+    url: https://github.com/stemdeckapp/stemdeck/discussions
+    about: Ask questions, share setups, or discuss ideas with the community.
+  - name: Discord
+    url: https://discord.gg/2MVsWqaPRe
+    about: Chat with the StemDeck community in real time.
+  - name: Report a security vulnerability
+    url: https://github.com/stemdeckapp/stemdeck/security/advisories/new
+    about: Please report security issues privately, not as a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: Feature request
+description: Suggest an idea or improvement.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for the suggestion! Tell us what you'd like and why.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: What are you trying to do that's hard or impossible today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement privately through the repository's Security tab using the "Report a vulnerability" option (the project's private reporting channel), or by direct message to a project maintainer. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,82 @@
+# Contributing to StemDeck
+
+Thanks for your interest in StemDeck - free, local stem separation for musicians. Contributions of
+all kinds are welcome, whether you write code or not.
+
+By participating you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Ways to contribute
+
+- **Report a bug** - open a [Bug report](https://github.com/stemdeckapp/stemdeck/issues/new/choose).
+  Include your OS, the StemDeck version (Help icon -> About), and clear steps to reproduce.
+- **Suggest a feature** - open a [Feature request](https://github.com/stemdeckapp/stemdeck/issues/new/choose).
+- **Improve the docs** - fixes and clarifications to the README or these guides are always useful.
+- **Write code** - bug fixes and features. For anything large, please open an issue or a
+  [Discussion](https://github.com/stemdeckapp/stemdeck/discussions) first so we can agree on the
+  approach before you invest time.
+- **Found a security issue?** Do not open a public issue - see [SECURITY.md](SECURITY.md).
+
+## Project layout
+
+- `app/` - FastAPI backend (the audio pipeline, job registry, and HTTP API).
+- `static/` - the web UI: plain ES-module JavaScript, HTML, and CSS. No build step, no bundler.
+- `desktop/` - the Tauri v2 desktop shell (Rust) that wraps the backend + UI.
+- `scripts/` - packaging scripts (macOS app/dmg, Windows portable, runtime pack).
+- `tests/` - the pytest suite for the backend.
+
+## Development setup
+
+You need [`uv`](https://docs.astral.sh/uv/) and `ffmpeg` on your PATH.
+
+```bash
+uv sync --python 3.12        # install the Python environment
+./run.sh start               # start the backend at http://localhost:8000
+```
+
+Other helpers:
+
+```bash
+./run.sh restart             # restart after backend changes
+./run.sh stop                # stop the server
+./run.sh status              # is it running?
+```
+
+Open `http://localhost:8000` in your browser to use the app. Frontend changes are picked up on
+reload (no build step).
+
+## Before you open a pull request
+
+Please run the same checks CI runs:
+
+```bash
+uv run ruff check app/ tests/        # lint
+uv run ruff format --check app/ tests/   # formatting
+node --check static/js/<changed>.js  # syntax-check any JS you touched
+uv run pytest tests/ -q              # backend tests
+```
+
+For Rust changes in `desktop/`, also run `cargo fmt --check` and `cargo clippy -- -D warnings`.
+
+## Pull request guidelines
+
+- Branch off `main`.
+- Use [Conventional Commits](https://www.conventionalcommits.org/) for messages
+  (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`, `ci:`).
+- Open the PR as a **draft** until it is ready for review.
+- Keep PRs focused - one logical change per PR makes review faster.
+- Describe what changed and why, and how you tested it.
+
+## Tests
+
+New API endpoints and pipeline stages should come with tests under `tests/`. The suite uses
+`pytest` with `httpx.AsyncClient`; see the existing `tests/test_*.py` files for patterns.
+
+## License
+
+StemDeck is licensed under the [Apache License 2.0](LICENSE). By contributing, you agree that your
+contributions are licensed under the same terms.
+
+## Questions
+
+Open a [Discussion](https://github.com/stemdeckapp/stemdeck/discussions) or join the
+[Discord](https://discord.gg/2MVsWqaPRe). Thanks for helping make StemDeck better.


### PR DESCRIPTION
Adds the community health files the GitHub `/community` page flags as missing.

## Added
- **CODE_OF_CONDUCT.md** - Contributor Covenant 2.1 (verbatim text, fetched from the canonical source). Violations are reported privately via the repo's Security tab -> "Report a vulnerability" (the project's private channel) or a maintainer DM - no email address invented.
- **CONTRIBUTING.md** - project layout (`app/`, `static/`, `desktop/`, `scripts/`, `tests/`), dev setup (`uv sync --python 3.12` + `./run.sh`), the CI gates (`ruff`, `node --check`, `pytest`; `cargo fmt`/`clippy` for Rust), Conventional Commits + draft-PR flow, security pointer, Apache-2.0 note.
- **.github/ISSUE_TEMPLATE/** - YAML issue forms:
  - `bug_report.yml` (OS, version, install method, steps; labels: bug)
  - `feature_request.yml` (problem / proposal / alternatives; labels: enhancement)
  - `config.yml` - disables blank issues; links Discussions, Discord, and private security reporting.

## Verification
- All three YAML forms parse (valid issue-form schema).
- All files ASCII-clean.
- After merge, the `/community` checklist shows Code of Conduct + Contributing + Issue templates present, and "New issue" shows the two forms plus the contact links.