### PR TITLE
fix: point runtime pack URL at stemdeckapp, not old thcp repo

### DIFF
--- a/scripts/macos/make-runtime-pack.sh
+++ b/scripts/macos/make-runtime-pack.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ARCH="${ARCH:-arm64}"
 VERSION="${VERSION:-LOCAL_DEV_TEST}"
 VERSION="${VERSION#v}"
-RELEASE_BASE_URL="${RELEASE_BASE_URL:-https://github.com/thcp/stemdeck/releases/download/v${VERSION}}"
+RELEASE_BASE_URL="${RELEASE_BASE_URL:-https://github.com/stemdeckapp/stemdeck/releases/download/v${VERSION}}"
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 BUILD_DIR="${REPO_ROOT}/.build"
 STAGING="${BUILD_DIR}/runtime-staging-${ARCH}"


### PR DESCRIPTION
## Problem

The runtime-pack download URL baked into every macOS release manifest defaulted to the old `thcp/stemdeck` repo:

\`scripts/macos/make-runtime-pack.sh:7\`
\`\`\`bash
RELEASE_BASE_URL="${RELEASE_BASE_URL:-https://github.com/thcp/stemdeck/releases/download/v${VERSION}}"
\`\`\`

CI (\`.woodpecker/macos-release.yml\`) never sets \`RELEASE_BASE_URL\`, so the fallback was always used. Every release, including alpha 11 and alpha 12, shipped a manifest pointing at \`thcp\`. It only kept working because GitHub's post-transfer redirect (\`thcp\` -> \`stemdeckapp\`) forwarded the asset download.

## Risk

That redirect is outside our control. It breaks permanently the moment anyone creates a repo named \`stemdeck\` under the \`thcp\` account, which would 404 the runtime download for every installed build that has not yet fetched its runtime, with no way to fix already-shipped binaries.

## Fix

Point the default at the repo we own (\`stemdeckapp/stemdeck\`). One line.

Affects future releases only; already-shipped manifests are frozen and continue to use the redirect.