### PR TITLE
ci: trigger release workflows only on release published

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -1,9 +1,6 @@
 name: macOS Release
 
 on:
-  push:
-    tags:
-      - 'v*'
   release:
     types: [published]
 
@@ -115,7 +112,6 @@ jobs:
           done
 
       - name: upload artifacts
-        if: github.event_name == 'release'
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           files: |

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -1,9 +1,6 @@
 name: Windows Release
 
 on:
-  push:
-    tags:
-      - 'v*'
   release:
     types: [published]
 
@@ -92,7 +89,6 @@ jobs:
           Write-Host "ClamAV scan completed successfully. No infected files reported."
 
       - name: upload artifacts
-        if: github.event_name == 'release'
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           files: |


### PR DESCRIPTION
Removes the push:tags trigger. Workflows now only run when a release (or prerelease) is published on GitHub - no more double builds.