### PR TITLE
fix: use powershell shell on Windows runner

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -19,7 +19,7 @@ jobs:
       contents: write
     defaults:
       run:
-        shell: pwsh
+        shell: powershell
     steps:
       - name: clean workspace
         run: |


### PR DESCRIPTION
pwsh (PowerShell Core) is not installed on the self-hosted Windows runner. Switching to powershell (Windows PowerShell) which is available.