### PR TITLE
fix(ci): source release tag from github.ref_name on all self-hosted runners

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -56,11 +56,15 @@ jobs:
       - name: write version files
         env:
           DISPATCH_VERSION: ${{ inputs.version }}
+          # github.ref_name (evaluated by Actions) instead of $GITHUB_REF_NAME,
+          # which is only injected by runner >= 2.290 — empty on older
+          # self-hosted runners.
+          REF_NAME: ${{ github.ref_name }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             VERSION="${DISPATCH_VERSION#v}"
           else
-            VERSION="${GITHUB_REF_NAME#v}"
+            VERSION="${REF_NAME#v}"
           fi
           if [ -z "$VERSION" ]; then
             echo "Could not determine a version" >&2

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -27,12 +27,17 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: write version files
+        env:
+          # github.ref_name (evaluated by Actions) instead of $GITHUB_REF_NAME,
+          # which is only injected by runner >= 2.290 — empty on older
+          # self-hosted runners.
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ -z "${GITHUB_REF_NAME:-}" ]; then
-            echo "GITHUB_REF_NAME is not set" >&2
+          if [ -z "${REF_NAME:-}" ]; then
+            echo "REF_NAME is not set" >&2
             exit 1
           fi
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${REF_NAME#v}"
           printf '{ "version": "%s" }\n' "$VERSION" > static/version.json
           sed -i '' "s/^version = \".*\"/version = \"$VERSION\"/" desktop/src-tauri/Cargo.toml
           sed -i '' "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" desktop/src-tauri/tauri.conf.json

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -17,6 +17,11 @@ jobs:
     timeout-minutes: 90
     permissions:
       contents: write
+    # Source the tag from the github context (evaluated by Actions) rather than
+    # $env:GITHUB_REF_NAME, which is only injected by runner >= 2.290. Keeps the
+    # build working on older self-hosted runners. (#212 follow-up)
+    env:
+      REF_NAME: ${{ github.ref_name }}
     defaults:
       run:
         shell: powershell
@@ -29,8 +34,8 @@ jobs:
 
       - name: write version files
         run: |
-          $tag = $env:GITHUB_REF_NAME
-          if (-not $tag) { throw "GITHUB_REF_NAME is not set" }
+          $tag = $env:REF_NAME
+          if (-not $tag) { throw "REF_NAME is not set" }
           $version = $tag -replace '^v', ''
           $json = "{`"version`": `"$version`"}"
           Set-Content -Path "static/version.json" -Value $json -Encoding UTF8
@@ -48,14 +53,14 @@ jobs:
         run: |
           powershell -NoProfile -ExecutionPolicy Bypass -File scripts/windows/make-portable.ps1 `
             -PackageName StemDeck-Windows-x64.NVIDIA `
-            -PackageVersion "$env:GITHUB_REF_NAME" `
+            -PackageVersion "$env:REF_NAME" `
             -StripVenv
 
       - name: build Windows CPU
         run: |
           powershell -NoProfile -ExecutionPolicy Bypass -File scripts/windows/make-portable.ps1 `
             -PackageName StemDeck-Windows-x64 `
-            -PackageVersion "$env:GITHUB_REF_NAME" `
+            -PackageVersion "$env:REF_NAME" `
             -CpuOnly `
             -StripVenv
 


### PR DESCRIPTION
## Problem

Every **release** job for `v0.7.0-alpha.17` failed (or would fail) at `write version files`:

```
GITHUB_REF_NAME is not set        # Windows
Could not determine a version     # Linux (same cause)
```

Both the `win` and `wsl2` self-hosted runners leave `$GITHUB_REF_NAME` **empty**.

## Cause

`GITHUB_REF_NAME` is injected by the **runner**, and only exists on Actions runner **>= 2.290**. Your self-hosted runners — recently re-registered at org level — are older, so the variable is empty. The previous runners that built alpha.16 had it.

## Fix

Read the tag from the **`${{ github.ref_name }}` context** (evaluated by Actions before the step runs), via a `REF_NAME` env var, instead of the runner-injected `$GITHUB_REF_NAME`. Independent of runner version.

Applied to all three release workflows for consistency, since all three run on the same class of self-hosted runner:
- **windows-release.yml** — job-level `REF_NAME`; version step + both build steps.
- **linux-release.yml** — version step (release branch).
- **macos-release.yml** — version step.

## Notes

- Root-cause hygiene (separate from this PR): update the self-hosted runners to the latest Actions runner version; GitHub auto-update may be disabled on them.
- This won't retroactively fix the already-published alpha.17 — re-firing `release: published` (or cutting alpha.18) after merge is needed to rebuild assets with the fixed workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)