### PR TITLE
fix: Linux NVIDIA tarball exceeds GitHub's 2 GiB asset limit

### DIFF
--- a/packaging/linux/README-LINUX.txt
+++ b/packaging/linux/README-LINUX.txt
@@ -38,17 +38,20 @@ expects FFmpeg on your PATH. Install both with your package manager.
 NVIDIA variant
 --------------
 
-The NVIDIA/CUDA build bundles a CUDA-enabled PyTorch. To use the GPU you also
-need a working NVIDIA driver on the host such that `nvidia-smi` runs and reports
-your GPU. The CUDA runtime itself is bundled — you do NOT need a separate CUDA
-toolkit install, only the driver.
+To use the GPU you need a working NVIDIA driver on the host such that
+`nvidia-smi` runs and reports your GPU.
 
   Check your driver:
     nvidia-smi
 
-If no usable GPU is detected, the NVIDIA build still runs but falls back to CPU.
-If you do not have an NVIDIA GPU, use the CPU-only tarball instead — it is
-smaller and avoids downloading the CUDA runtime.
+On first launch, the NVIDIA build detects your GPU and downloads the matching
+CUDA-enabled PyTorch (a few GB) into your data directory — so the first run
+needs an internet connection and some disk space. You do NOT need a separate
+CUDA toolkit install, only the driver.
+
+If no usable GPU is detected, the NVIDIA build still runs and falls back to CPU.
+If you do not have an NVIDIA GPU, use the CPU-only tarball instead — it skips
+the CUDA download entirely.
 
 Notes
 -----

--- a/scripts/linux/make-portable.sh
+++ b/scripts/linux/make-portable.sh
@@ -97,19 +97,22 @@ if [[ -n "$PACKAGE_VERSION" ]]; then
 fi
 uv pip install --system --python "$BUNDLED_PYTHON" "$REPO_ROOT"
 
-if [[ "$CPU_ONLY" == "1" ]]; then
-  # Linux PyPI torch wheels bundle CUDA. Force-reinstall the CPU-only variant
-  # afterwards: pip strips the local '+cpu' version when resolving, so the project
-  # install pulls the CUDA wheel even if a CPU wheel was requested. Mirrors the
-  # proven Windows swap (--force-reinstall --no-deps replaces just torch wheels).
-  echo "==> Forcing CPU-only torch"
-  "$BUNDLED_PYTHON" -m pip install \
-    "torch==${TORCH_VERSION}+cpu" "torchaudio==${TORCH_VERSION}+cpu" \
-    --index-url https://download.pytorch.org/whl/cpu \
-    --force-reinstall --no-deps
-else
-  echo "==> Keeping CUDA torch (NVIDIA variant)"
-fi
+# Always bake the small CPU-only torch wheel — for BOTH variants. On Linux the
+# default PyPI torch wheel bundles the full CUDA runtime (~2.5 GB), which makes
+# the packaged tarball exceed GitHub's 2 GiB per-asset release limit. So we
+# mirror what the Windows NVIDIA package actually does: ship CPU torch, and let
+# the desktop shell download the matching CUDA wheel at first run on GPU
+# machines (install_cuda_torch, gated cfg(not(macos)) so it covers Linux). The
+# NVIDIA variant differs only by omitting the cpu-only marker below.
+#
+# pip strips the local '+cpu' version when resolving, so the project install
+# pulls the CUDA wheel even if a CPU wheel was requested; --force-reinstall
+# --no-deps replaces just the torch/torchaudio wheels (proven on Windows).
+echo "==> Baking CPU-only torch (NVIDIA variant downloads CUDA at first run)"
+"$BUNDLED_PYTHON" -m pip install \
+  "torch==${TORCH_VERSION}+cpu" "torchaudio==${TORCH_VERSION}+cpu" \
+  --index-url https://download.pytorch.org/whl/cpu \
+  --force-reinstall --no-deps
 
 echo "==> Verifying imports"
 "$BUNDLED_PYTHON" -c "import fastapi, uvicorn, yt_dlp, demucs, torch, torchaudio, librosa, pyloudnorm, soundfile; print('torch', torch.__version__, 'cuda', torch.version.cuda)"


### PR DESCRIPTION
## Problem

The `Linux Release` job built both variants successfully but **failed at upload**:

```
Validation Failed: ReleaseAsset size must be less than 2147483648
```

`StemDeck-Linux-x64.NVIDIA.tar.gz` exceeds GitHub's **2 GiB per-asset** release limit.

## Cause — a wrong assumption in the original NVIDIA design

We baked the project's default torch into the NVIDIA variant, assuming it mirrored the Windows NVIDIA package. But:

- On **Linux**, the default PyPI torch wheel bundles the **full CUDA runtime (~2.5 GB)**.
- On **Windows**, the default wheel is **CPU-only** (that's why the Windows NVIDIA zip is only ~243 MB).

So the Windows NVIDIA package **never baked CUDA** — it ships CPU torch and downloads the CUDA wheel at first run via the desktop shell's `install_cuda_torch` (already `cfg(not(macos))`, so it covers Linux). Baking CUDA on Linux is fundamentally incompatible with GitHub releases.

## Fix

Bake the small **CPU torch in both variants**. The NVIDIA variant differs only by omitting the `cpu-only` marker, so on first launch the shell detects the GPU and downloads the matching CUDA wheel — genuinely mirroring Windows. Both tarballs now stay well under 2 GiB.

- `make-portable.sh`: always force the CPU torch wheel; marker stays CPU-only-conditional.
- `README-LINUX.txt`: NVIDIA section now notes CUDA is downloaded on first run (needs internet + disk).

## Validated

The failed run proved the rest of the pipeline works end-to-end: version step (post-#221), CPU build, **NVIDIA build, and ClamAV scan all passed** on the `wsl2` runner — only the oversized upload failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)