### PR TITLE
fix: strip orphaned nvidia-* CUDA packages from Linux bundle (2.5GB->under 2GiB)

### DIFF
--- a/scripts/linux/make-portable.sh
+++ b/scripts/linux/make-portable.sh
@@ -114,6 +114,19 @@ echo "==> Baking CPU-only torch (NVIDIA variant downloads CUDA at first run)"
   --index-url https://download.pytorch.org/whl/cpu \
   --force-reinstall --no-deps
 
+# The project install above pulled the default Linux torch, which is the CUDA
+# build, dragging in nvidia-* CUDA runtime packages (cuDNN, cuBLAS, NCCL, ...) and
+# triton -- together ~2.5 GB. The CPU torch swap used --no-deps, so those packages
+# are now orphaned but still installed, bloating the tarball past GitHub's 2 GiB
+# asset limit. Remove them: CPU torch does not use them, and the NVIDIA variant
+# re-downloads CUDA at first run anyway.
+echo "==> Removing orphaned CUDA runtime packages"
+orphans=$("$BUNDLED_PYTHON" -m pip list --format=freeze 2>/dev/null \
+  | sed -n 's/^\(nvidia-[^=]*\)==.*/\1/p')
+orphans="$orphans triton"
+echo "    removing:$orphans"
+"$BUNDLED_PYTHON" -m pip uninstall -y $orphans 2>/dev/null || true
+
 echo "==> Verifying imports"
 "$BUNDLED_PYTHON" -c "import fastapi, uvicorn, yt_dlp, demucs, torch, torchaudio, librosa, pyloudnorm, soundfile; print('torch', torch.__version__, 'cuda', torch.version.cuda)"
 


### PR DESCRIPTION
## Problem

Both Linux tarballs were **2.5 GB**, failing the upload with GitHub's 2 GiB asset limit — even though torch was correctly `2.6.0+cpu`.

## Root cause

`uv pip install <project>` pulls the **default** Linux torch, which is the **CUDA** build, dragging in `nvidia-*` runtime packages (cuDNN, cuBLAS, NCCL, …) and `triton` — ~2.5 GB. The CPU torch swap uses `--force-reinstall --no-deps`, so torch becomes CPU but those CUDA packages stay installed and **orphaned**, still bloating the bundle.

(Windows never hits this because its default torch wheel is already CPU-only — no nvidia-* deps to begin with.)

## Fix

After the CPU torch swap, uninstall the orphaned `nvidia-*` packages and `triton`. CPU torch doesn't use them, and the NVIDIA variant re-downloads CUDA at first run. Expected size: well under 2 GiB.

## Status

Windows binaries already published to alpha.17. The Linux build now passes apt (skip-when-present) and builds both variants — this removes the last blocker (size) on the Linux upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)