### PR TITLE
fix(ci): target the macOS runner's default macOS/ARM64 labels

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   build-and-upload:
     # Runner must be darwin/arm64 with Rosetta 2, Xcode CLT, Homebrew, rustup, and zstd.
-    runs-on: [self-hosted, osx, arm64]
+    runs-on: [self-hosted, macOS, ARM64]
     timeout-minutes: 120
     permissions:
       contents: write


### PR DESCRIPTION
The self-hosted macOS runner advertises **`self-hosted` / `macOS` / `ARM64`** (GitHub's default macOS labels — its *name* is "osx", which is not a label). The workflow required a custom **`osx`** label the runner no longer carries, so every **macOS Release since alpha.15** sat queued with no matching runner (while Windows/Linux worked, since they target the default `windows`/`linux` labels).

Change `runs-on` to `[self-hosted, macOS, ARM64]` to match the runner's actual labels, consistent with the windows/linux release workflows.

```diff
-    runs-on: [self-hosted, osx, arm64]
+    runs-on: [self-hosted, macOS, ARM64]
```

Note: this fixes **future** releases (alpha.19+). The already-published **alpha.18** macOS run is tied to the tag's workflow, so to build that one, add a temporary `osx` label to the runner (or re-tag) — separate from this change.