### PR TITLE
fix: don't auto-purge the desktop library (skip job TTL sweep)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -83,7 +83,20 @@ def app_version() -> str:
         return "0.0.0-dev"
 
 
+def _sweep_disabled() -> bool:
+    """The desktop app is a personal, user-curated library (folders + Trash),
+    with its track list persisted permanently in ~/Documents/StemDeck. The 24h
+    job TTL sweep -- a sensible disk-hygiene default for the shared server/Docker
+    deployment -- would wrongly purge stems the user kept, leaving orphaned
+    library entries that ask to "re-upload to restore". So skip the sweep under
+    the desktop shell (STEMDECK_DESKTOP=1); the user manages disk via Trash."""
+    return os.environ.get("STEMDECK_DESKTOP") == "1"
+
+
 async def _sweep_loop() -> None:
+    if _sweep_disabled():
+        _log.info("desktop mode: job TTL sweep disabled (library is user-managed)")
+        return
     while True:
         try:
             await asyncio.to_thread(sweep_old_jobs, JOBS_DIR)

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -55,6 +55,29 @@ def test_sweeps_terminal_old_job(tmp_path: Path):
     assert job.id not in _jobs
 
 
+def test_sweep_disabled_under_desktop(monkeypatch):
+    """The desktop shell (STEMDECK_DESKTOP=1) opts out of the TTL sweep so a
+    user's curated library isn't purged; the server/Docker default keeps it."""
+    from app.main import _sweep_disabled
+
+    monkeypatch.setenv("STEMDECK_DESKTOP", "1")
+    assert _sweep_disabled() is True
+    monkeypatch.delenv("STEMDECK_DESKTOP", raising=False)
+    assert _sweep_disabled() is False
+
+
+@pytest.mark.asyncio
+async def test_sweep_loop_returns_immediately_under_desktop(monkeypatch):
+    """In desktop mode the loop returns at once instead of entering the hourly
+    cycle (wait_for would time out if it looped)."""
+    import asyncio
+
+    from app.main import _sweep_loop
+
+    monkeypatch.setenv("STEMDECK_DESKTOP", "1")
+    await asyncio.wait_for(_sweep_loop(), timeout=2)
+
+
 def test_keeps_recent_terminal_job(tmp_path: Path):
     d = _mkdir(tmp_path, "abcdefabcded")
     job = Job(id="abcdefabcded")


### PR DESCRIPTION
### Problem
On desktop, the library track list is persisted **permanently** in `~/Documents/StemDeck/user-data.json`, but the stems under `jobs/<id>/` are subject to the **24h job TTL sweep** that runs at every server startup. So a day later — or whenever the app restarts past the TTL, e.g. **installing a new release** — the sweep deletes the stems while the library entries survive, leaving orphaned tracks that show:

> This track's audio is no longer available. Re-upload to restore it.

Users read this as "every new release loses my songs", but it's really the TTL firing on the post-update restart (reopening the app the next day does the same).

### Fix
The TTL is a sensible disk-hygiene default for the **shared server / Docker** deployment. On **desktop** the library is user-curated (folders + Trash), so the sweep shouldn't auto-purge it. Skip the sweep when running under the desktop shell — `STEMDECK_DESKTOP=1`, which the Tauri launcher sets unconditionally on **Windows, macOS, and Linux** ([main.rs:595](../blob/main/desktop/src-tauri/src/main.rs#L595)). Disk usage stays under the user's control via the existing Trash/delete UI. The server/Docker path is unchanged.

### Scope
- One-file backend change (`app/main.py`): `_sweep_loop` returns early when `_sweep_disabled()` (desktop).
- Applies to all three desktop platforms (shared Python backend + platform-agnostic env var).

### Tests
- `_sweep_disabled()` true under `STEMDECK_DESKTOP=1`, false otherwise.
- `_sweep_loop()` returns immediately (doesn't enter the hourly loop) in desktop mode.
- Full suite: **109 passed**, ruff check + `ruff format --check` clean.