### PR TITLE
feat: add Empress Effects to We Recommend (+ fix Thomann description)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ StemDeck is free and **does not accept any money, sponsorship, or funding** - no
 | Lisbon Guitar Works | Guitar building | [dlimaguitars.com](https://dlimaguitars.com) |
 | Joao Gaspar | Producer/Film Scorer, Touring/Session Musician | [@jay_glaspar](https://www.instagram.com/jay_glaspar) |
 | Kris Luthier | Luthier and Musical Instrument Repair, Lisboa | [@krisluthier](https://www.instagram.com/krisluthier) |
-| Thomann | Musical instruments & music gear | [@thomann.music](https://www.instagram.com/thomann.music) |
+| Thomann | Online Music Store | [@thomann.music](https://www.instagram.com/thomann.music) |
 | Analog4Lyfe | Analog music gear | [@analog4lyfe](https://www.instagram.com/analog4lyfe) |
 | Empress Effects | Effects pedals | [empresseffects.com](https://empresseffects.com) |
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ StemDeck is free and **does not accept any money, sponsorship, or funding** - no
 | Kris Luthier | Luthier and Musical Instrument Repair, Lisboa | [@krisluthier](https://www.instagram.com/krisluthier) |
 | Thomann | Musical instruments & music gear | [@thomann.music](https://www.instagram.com/thomann.music) |
 | Analog4Lyfe | Analog music gear | [@analog4lyfe](https://www.instagram.com/analog4lyfe) |
+| Empress Effects | Effects pedals | [empresseffects.com](https://empresseffects.com) |
 
 
 ---

--- a/static/js/catalog.js
+++ b/static/js/catalog.js
@@ -42,7 +42,7 @@ const FRIENDS = [
   },
   {
     name: "Thomann",
-    role: "Musical instruments & music gear",
+    role: "Online Music Store",
     url: "https://www.instagram.com/thomann.music",
     logo: "/img/friends/thomann.jpg",
     avatar: true,

--- a/static/js/catalog.js
+++ b/static/js/catalog.js
@@ -54,6 +54,12 @@ const FRIENDS = [
     logo: "/img/friends/analog4lyfe.jpg",
     avatar: true,
   },
+  {
+    name: "Empress Effects",
+    role: "Effects pedals",
+    url: "https://empresseffects.com",
+    logo: "/img/friends/empress-effects.png",
+  },
 ];
 
 // Instagram glyph (Simple Icons), shown under tiles that link to Instagram.


### PR DESCRIPTION
- **Add Empress Effects** ([empresseffects.com](https://empresseffects.com)) to the "We Recommend" grid + README table. It links to a website, so it follows the Lisbon Guitar Works pattern (logo style, no Instagram glyph). Image can be added at `static/img/friends/empress-effects.png` later; the monogram fallback shows until then.
- **Fix Thomann description** → "Online Music Store" (was "Musical instruments & music gear").

No behavior change beyond content. JS syntax checked.