### PR TITLE
fix: server network access and YouTube Shorts support

### DIFF
--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -34,12 +34,14 @@ DEFAULT_PORT = 8080
 
 
 def _default_allow_network() -> bool:
-    # Off by default everywhere — the user explicitly opts other devices in.
-    # STEMDECK_ALLOW_NETWORK=1 can pre-enable it (e.g. headless/Docker deploys).
+    # STEMDECK_ALLOW_NETWORK takes precedence when set explicitly.
+    # Otherwise: desktop keeps network off (user opts in via UI toggle);
+    # server/Docker deployments open it by default since network access is
+    # the entire point of a headless deployment.
     env = os.environ.get("STEMDECK_ALLOW_NETWORK")
     if env is not None:
         return env.strip() == "1"
-    return False
+    return os.environ.get("STEMDECK_DESKTOP") != "1"
 
 
 def _load() -> dict:

--- a/app/pipeline/download.py
+++ b/app/pipeline/download.py
@@ -148,7 +148,7 @@ def normalize_youtube_url(url: str) -> str:
             return f"https://www.youtube.com/watch?v={vid}"
 
     if host == "youtube.com" and parsed.path.startswith("/shorts/"):
-        vid = parsed.path[len("/shorts/"):].lstrip("/").split("/")[0]
+        vid = parsed.path[len("/shorts/") :].lstrip("/").split("/")[0]
         if _VIDEO_ID_RE.match(vid):
             return f"https://www.youtube.com/watch?v={vid}"
 

--- a/app/pipeline/download.py
+++ b/app/pipeline/download.py
@@ -115,6 +115,7 @@ def normalize_youtube_url(url: str) -> str:
         playlists embed the seed in the list ID; YouTube refuses to view the
         playlist directly with "This playlist type is unviewable.")
       * `youtu.be/<videoId>` -> `watch?v=<videoId>`
+      * `youtube.com/shorts/<videoId>` -> `watch?v=<videoId>`
     Everything else (PL/OL/algorithmic playlists with no derivable seed) is
     left alone -- yt-dlp will surface its own error.
     """
@@ -143,6 +144,11 @@ def normalize_youtube_url(url: str) -> str:
 
     if host == "youtu.be":
         vid = parsed.path.lstrip("/")
+        if _VIDEO_ID_RE.match(vid):
+            return f"https://www.youtube.com/watch?v={vid}"
+
+    if host == "youtube.com" and parsed.path.startswith("/shorts/"):
+        vid = parsed.path[len("/shorts/"):].lstrip("/").split("/")[0]
         if _VIDEO_ID_RE.match(vid):
             return f"https://www.youtube.com/watch?v={vid}"
 

--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -13,8 +13,7 @@ services:
     image: stemdeck
     container_name: stemdeck
     ports:
-      # Bind to loopback only -- StemDeck has no auth and is local-only.
-      - "127.0.0.1:8000:8000"
+      - "8000:8000"
     volumes:
       # Stems and downloaded audio land in <project root>/jobs on the
       # host so you can grab them without going through the container.

--- a/static/css/daw.css
+++ b/static/css/daw.css
@@ -811,6 +811,7 @@ input, textarea { font-family: inherit; }
 .settings-net-list { display: flex; flex-direction: column; gap: 5px; align-items: flex-start; }
 .settings-net-list code { color: var(--accent); background: rgba(244,183,64,0.1); padding: 3px 9px; border-radius: 5px; font-size: 11.5px; }
 .settings-net-empty { color: var(--muted); }
+.settings-server-note { font-size: 10.5px; color: var(--muted); margin: 0 0 12px; line-height: 1.5; }
 .settings-subhead { font-size: 10px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--muted); font-weight: 600; margin: 4px 0 7px; }
 
 .library-editor-foot { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-top: 11px; }

--- a/static/js/catalog.js
+++ b/static/js/catalog.js
@@ -2053,6 +2053,10 @@ function openLibraryEditor() {
     overlay.querySelector(".net-access-input")?.setAttribute("disabled", "");
     overlay.querySelector(".set-port")?.setAttribute("readonly", "");
     overlay.querySelector(".set-port")?.setAttribute("disabled", "");
+    const note = document.createElement("p");
+    note.className = "settings-server-note";
+    note.textContent = "These settings are read-only in server mode. To change them, update your server configuration (e.g. docker-compose.yml) and restart.";
+    overlay.querySelector("[data-pane='advanced']")?.prepend(note);
   }
 }
 

--- a/static/js/catalog.js
+++ b/static/js/catalog.js
@@ -1996,6 +1996,7 @@ function openLibraryEditor() {
         </div>
       </div>
       <div class="settings-pane hidden" data-pane="advanced">
+        ${Boolean(window.__TAURI__?.core?.invoke) ? `
         ${networkSettingsHtml()}
         <div class="settings-section">
           <div class="settings-row">
@@ -2005,7 +2006,7 @@ function openLibraryEditor() {
             </div>
             <input type="text" class="settings-num-input set-port" inputmode="numeric" maxlength="5" aria-label="Port" />
           </div>
-        </div>
+        </div>` : ""}
         <div class="settings-subhead">Out of sync tracks</div>
         <div class="library-editor-table-wrap">
           <table class="library-editor-table">
@@ -2047,7 +2048,7 @@ function openLibraryEditor() {
   libraryEditor = overlay;
   refreshLibrarySyncSummary();
   wireGeneralSettings(overlay);
-  wireNetworkSetting(overlay);
+  if (Boolean(window.__TAURI__?.core?.invoke)) wireNetworkSetting(overlay);
 }
 
 // Poll a job until it reaches a terminal state, so auto-restores run one at a

--- a/static/js/catalog.js
+++ b/static/js/catalog.js
@@ -1996,7 +1996,6 @@ function openLibraryEditor() {
         </div>
       </div>
       <div class="settings-pane hidden" data-pane="advanced">
-        ${Boolean(window.__TAURI__?.core?.invoke) ? `
         ${networkSettingsHtml()}
         <div class="settings-section">
           <div class="settings-row">
@@ -2006,7 +2005,7 @@ function openLibraryEditor() {
             </div>
             <input type="text" class="settings-num-input set-port" inputmode="numeric" maxlength="5" aria-label="Port" />
           </div>
-        </div>` : ""}
+        </div>
         <div class="settings-subhead">Out of sync tracks</div>
         <div class="library-editor-table-wrap">
           <table class="library-editor-table">
@@ -2047,8 +2046,14 @@ function openLibraryEditor() {
   document.body.appendChild(overlay);
   libraryEditor = overlay;
   refreshLibrarySyncSummary();
+  const isDesktop = Boolean(window.__TAURI__?.core?.invoke);
   wireGeneralSettings(overlay);
-  if (Boolean(window.__TAURI__?.core?.invoke)) wireNetworkSetting(overlay);
+  wireNetworkSetting(overlay);
+  if (!isDesktop) {
+    overlay.querySelector(".net-access-input")?.setAttribute("disabled", "");
+    overlay.querySelector(".set-port")?.setAttribute("readonly", "");
+    overlay.querySelector(".set-port")?.setAttribute("disabled", "");
+  }
 }
 
 // Poll a job until it reaches a terminal state, so auto-restores run one at a

--- a/tests/test_network_gate.py
+++ b/tests/test_network_gate.py
@@ -36,10 +36,18 @@ def test_host_request_recognizes_own_lan_ip(monkeypatch):
     assert _is_host_request("192.168.1.99") is False  # a different device
 
 
-def test_default_is_off(monkeypatch):
-    # Off by default everywhere — the user must opt in.
+def test_default_is_off_in_desktop_mode(monkeypatch):
+    # Desktop keeps network off; the user opts in via the UI toggle.
     monkeypatch.delenv("STEMDECK_ALLOW_NETWORK", raising=False)
+    monkeypatch.setenv("STEMDECK_DESKTOP", "1")
     assert settings_mod._default_allow_network() is False
+
+
+def test_default_is_on_in_server_mode(monkeypatch):
+    # Server/Docker deployments open the gate by default.
+    monkeypatch.delenv("STEMDECK_ALLOW_NETWORK", raising=False)
+    monkeypatch.delenv("STEMDECK_DESKTOP", raising=False)
+    assert settings_mod._default_allow_network() is True
 
 
 def test_env_var_pre_enables(monkeypatch):

--- a/tests/test_url_validation.py
+++ b/tests/test_url_validation.py
@@ -28,6 +28,14 @@ from app.pipeline.download import InvalidYouTubeURL, validate_youtube_url
             "  https://www.youtube.com/watch?v=dQw4w9WgXcQ  ",
             "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
         ),
+        (
+            "https://www.youtube.com/shorts/dQw4w9WgXcQ",
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        ),
+        (
+            "https://m.youtube.com/shorts/dQw4w9WgXcQ",
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        ),
     ],
 )
 def test_accepts_youtube_urls(url: str, expected: str) -> None:


### PR DESCRIPTION
## Summary

- **Server/Docker network fix** (discussion #216): two layers were blocking network clients from reaching headless deployments. `docker-compose.yml` was binding to `127.0.0.1` (Docker host level) and `_default_allow_network()` was returning `False` unconditionally (application level). Now `allow_network` defaults to `True` when `STEMDECK_DESKTOP` is not set, and the Docker port binding is `0.0.0.0`. `STEMDECK_ALLOW_NETWORK` still overrides either way.
- **YouTube Shorts**: `normalize_youtube_url()` now maps `youtube.com/shorts/<videoId>` to the standard `watch?v=` form before handing the URL to yt-dlp.

## Test plan

- [ ] Docker: `docker compose -f build/docker-compose.yml up --build`, access from another device on the LAN - should load without "not available on the network".
- [ ] `STEMDECK_DESKTOP=1` mode: `get_allow_network()` returns `False` (desktop keeps network off by default).
- [ ] `STEMDECK_ALLOW_NETWORK=0` with no `STEMDECK_DESKTOP`: explicit override still locks network off.
- [ ] Paste a YouTube Shorts URL (`https://www.youtube.com/shorts/<id>`) - should process successfully.
- [ ] `uv run pytest tests/test_url_validation.py -v` - all 18 tests pass.