### PR TITLE
fix(server): persistent library on self-hosted web server (no TTL sweep)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -102,14 +102,21 @@ def _sweep_disabled() -> bool:
     with its track list persisted permanently in ~/Documents/StemDeck. The 24h
     job TTL sweep -- a sensible disk-hygiene default for the shared server/Docker
     deployment -- would wrongly purge stems the user kept, leaving orphaned
-    library entries that ask to "re-upload to restore". So skip the sweep under
-    the desktop shell (STEMDECK_DESKTOP=1); the user manages disk via Trash."""
-    return os.environ.get("STEMDECK_DESKTOP") == "1"
+    library entries that ask to "re-upload to restore".
+
+    So skip the sweep under the desktop shell (STEMDECK_DESKTOP=1), or when a
+    self-hosted deployment opts into a persistent library
+    (STEMDECK_PERSIST_LIBRARY=1 -- set by default in run.sh). The user manages
+    disk via Trash. Shared/Docker deployments that set neither keep the sweep."""
+    return (
+        os.environ.get("STEMDECK_DESKTOP") == "1"
+        or os.environ.get("STEMDECK_PERSIST_LIBRARY") == "1"
+    )
 
 
 async def _sweep_loop() -> None:
     if _sweep_disabled():
-        _log.info("desktop mode: job TTL sweep disabled (library is user-managed)")
+        _log.info("job TTL sweep disabled (persistent library; user-managed)")
         return
     while True:
         try:

--- a/run.sh
+++ b/run.sh
@@ -8,6 +8,10 @@ cd "$(dirname "$0")"
 HOST="${HOST:-0.0.0.0}"
 PORT="${PORT:-8080}"
 RELOAD="${RELOAD:-0}"
+# Treat the self-hosted server as a persistent, user-managed library (like the
+# desktop app): opt out of the 24h job TTL sweep so processed tracks are not
+# auto-deleted. Override with STEMDECK_PERSIST_LIBRARY=0 for disk-hygiene mode.
+export STEMDECK_PERSIST_LIBRARY="${STEMDECK_PERSIST_LIBRARY:-1}"
 FOREGROUND="${FOREGROUND:-0}"
 PID_FILE=".run/uvicorn.pid"
 LOG_FILE=".run/uvicorn.log"

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -60,9 +60,22 @@ def test_sweep_disabled_under_desktop(monkeypatch):
     user's curated library isn't purged; the server/Docker default keeps it."""
     from app.main import _sweep_disabled
 
+    monkeypatch.delenv("STEMDECK_PERSIST_LIBRARY", raising=False)
     monkeypatch.setenv("STEMDECK_DESKTOP", "1")
     assert _sweep_disabled() is True
     monkeypatch.delenv("STEMDECK_DESKTOP", raising=False)
+    assert _sweep_disabled() is False
+
+
+def test_sweep_disabled_under_persistent_library(monkeypatch):
+    """A self-hosted server (run.sh) opts into a persistent library
+    (STEMDECK_PERSIST_LIBRARY=1) so its processed tracks aren't purged."""
+    from app.main import _sweep_disabled
+
+    monkeypatch.delenv("STEMDECK_DESKTOP", raising=False)
+    monkeypatch.setenv("STEMDECK_PERSIST_LIBRARY", "1")
+    assert _sweep_disabled() is True
+    monkeypatch.delenv("STEMDECK_PERSIST_LIBRARY", raising=False)
     assert _sweep_disabled() is False
 
 


### PR DESCRIPTION
## Problem

The 24h job TTL sweep is only disabled under the desktop shell (`STEMDECK_DESKTOP=1`). Running the bare web server via `run.sh` leaves the sweep active, so on startup (and hourly) it deletes any processed job older than 24h. Those tracks then show as "This track's audio is no longer available" / out-of-sync in the library, and local-file tracks can't be auto-restored (the original file isn't kept).

## Fix

- `_sweep_disabled()` now also opts out when `STEMDECK_PERSIST_LIBRARY=1`, alongside the existing desktop check.
- `run.sh` sets `STEMDECK_PERSIST_LIBRARY=1` by default, so the self-hosted server behaves like the desktop app: a persistent, user-managed library (disk managed via Trash).
- Overridable with `STEMDECK_PERSIST_LIBRARY=0`. Shared/Docker deployments that set neither flag keep the sweep for disk hygiene.

## Testing

- `pytest tests/test_sweep.py` -> 7 passed, incl. a new `test_sweep_disabled_under_persistent_library`.
- `ruff check` + `ruff format --check` clean.
- Verified the real `_sweep_disabled()` under `run.sh`'s env: default -> disabled; `=0` -> enabled.