### PR TITLE
feat(docker): honor PUID/PGID for Unraid nobody:users ownership

### DIFF
--- a/build/docker-entrypoint.sh
+++ b/build/docker-entrypoint.sh
@@ -1,8 +1,22 @@
 #!/bin/sh
 set -e
-# Re-chown /app/jobs in case the bind-mount was created by Docker as root
-# on first run (before the host directory existed). Safe no-op if already
-# owned by app:app.
-chown -R app:app /app/jobs 2>/dev/null || true
-# Drop to the non-root app user and exec the CMD.
-exec gosu app "$@"
+# Run as the requested UID/GID so files written to the mounted appdata paths are
+# owned consistently. This matches the Unraid/NAS convention (defaults there are
+# nobody:users = 99:100). When PUID/PGID are unset, fall back to the image's
+# original non-root app user (1001), preserving prior behaviour.
+PUID="${PUID:-1001}"
+PGID="${PGID:-1001}"
+
+# Chown the only paths the app writes to before dropping privileges:
+#   /app/jobs           registry.json, downloaded audio, and stems
+#   /cache              torch/Demucs model weights (TORCH_HOME, XDG_CACHE_HOME)
+#   /app/settings.json  best-effort settings persistence (created on demand)
+# App code and the venv under /app stay world-readable, so a different UID can
+# still import and run them. Re-chowning is also what fixes a bind mount that
+# Docker created as root on first run.
+chown -R "${PUID}:${PGID}" /app/jobs /cache 2>/dev/null || true
+touch /app/settings.json 2>/dev/null && chown "${PUID}:${PGID}" /app/settings.json 2>/dev/null || true
+
+# Drop to the target user and exec the CMD. gosu accepts a numeric UID:GID even
+# when no matching named user exists.
+exec gosu "${PUID}:${PGID}" "$@"

--- a/templates/stemdeck.xml
+++ b/templates/stemdeck.xml
@@ -51,6 +51,10 @@
 
   <Config Name="Max concurrent jobs" Target="STEMDECK_MAX_PENDING_JOBS" Default="3" Description="How many separations may be queued/running at once (1-50)." Type="Variable" Display="advanced" Required="false" Mask="false">3</Config>
 
+  <Config Name="PUID" Target="PUID" Default="99" Description="User ID the app runs as. Unraid's default is 99 (nobody), so files written to appdata are owned correctly." Type="Variable" Display="advanced" Required="false" Mask="false">99</Config>
+
+  <Config Name="PGID" Target="PGID" Default="100" Description="Group ID the app runs as. Unraid's default is 100 (users)." Type="Variable" Display="advanced" Required="false" Mask="false">100</Config>
+
   <Config Name="NVIDIA GPUs" Target="NVIDIA_VISIBLE_DEVICES" Default="all" Description="GPU(s) exposed to the container. Requires the Unraid Nvidia Driver plugin and Extra Parameters set to --runtime=nvidia. Use 'all' or a specific GPU UUID." Type="Variable" Display="advanced" Required="false" Mask="false">all</Config>
 
   <Config Name="NVIDIA driver capabilities" Target="NVIDIA_DRIVER_CAPABILITIES" Default="all" Description="Driver features exposed to the container. Leave as 'all' for CUDA compute." Type="Variable" Display="advanced" Required="false" Mask="false">all</Config>


### PR DESCRIPTION
## What

Makes the container honor `PUID`/`PGID` so files written to mounted appdata are owned by the requested user. On Unraid that's `nobody:users` (99:100). Addresses discussion #255.

## Why

The container hardcoded UID 1001 (`gosu app`). Setting `PUID`/`PGID` did nothing, so appdata files came out owned by 1001 - the exact ownership friction raised in #255.

## Changes

- **build/docker-entrypoint.sh**: read `PUID`/`PGID` (default 1001, so plain `docker run` is unchanged), `chown` the writable paths to them, then `gosu ${PUID}:${PGID}`.
- **templates/stemdeck.xml**: add `PUID` (default 99) and `PGID` (default 100) variables.

## Why only those paths get chowned

Traced every runtime write: registry.json, downloaded audio, and stems all land under `/app/jobs`; torch/Demucs weights under `/cache`; best-effort settings in `/app/settings.json`. App code and the venv under `/app` stay world-readable, so a non-1001 UID can still import and run them. No Dockerfile change needed - the entrypoint runs as root (no `USER` directive) and `gosu` accepts a numeric UID:GID.

## Verify

```sh
docker build -f build/Dockerfile --build-arg VERSION=0.0.0 -t stemdeck:puid ..
docker run --rm -e PUID=99 -e PGID=100 -v "\$PWD/jobs:/app/jobs" stemdeck:puid \
  sh -c 'id; ls -lan /app/jobs'   # expect uid=99 gid=100, /app/jobs owned 99:100
```

Unset PUID/PGID -> runs as 1001 (unchanged).