### PR TITLE
fix(deps): pin demucs<4.1 to keep tested 4.0.1 (fixes macOS x64 build)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,12 @@ dependencies = [
     "fastapi>=0.115,!=0.136.3",
     "uvicorn[standard]>=0.30",
     "yt-dlp>=2024.12.0",
-    "demucs>=4.0.1",
+    # Pin below 4.1: demucs 4.1.0 (2026-07-11) added a dependency on `sphn`, a
+    # Rust/CMake native package with no Intel-macOS wheel, so the x64 macOS
+    # build compiles it from source and fails (CMake dropped <3.5 support).
+    # 4.0.1 is what every prior release shipped and what the torch/torchaudio
+    # pins below were written for.
+    "demucs>=4.0.1,<4.1",
     # Pin torch/torchaudio to 2.6.x where available — torchaudio 2.7+ removed its built-in
     # audio writer and now requires the separate `torchcodec` package, which
     # has ABI issues with torch 2.11. Demucs 4.0.1 calls torchaudio.save() to

--- a/uv.lock
+++ b/uv.lock
@@ -1812,7 +1812,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "demucs", specifier = ">=4.0.1" },
+    { name = "demucs", specifier = ">=4.0.1,<4.1" },
     { name = "fastapi", specifier = ">=0.115,!=0.136.3" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "librosa", specifier = ">=0.10" },


### PR DESCRIPTION
demucs 4.1.0 (2026-07-11) added a native `sphn` dependency with no Intel-macOS wheel, breaking the x64 macOS release build (CMake <3.5 removed). The release install path resolves fresh (ignores uv.lock), so it grabbed 4.1.0. Linux/Windows survived on sphn wheels but silently shipped the untested 4.1.0.

Pin `demucs>=4.0.1,<4.1` - the version every prior release shipped and the one the torch pins target. uv.lock unchanged at 4.0.1.