### PR TITLE
ci(docker): push :latest when a prerelease is promoted to Latest

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,7 +13,12 @@ on:
   push:
     branches: [main]
   release:
-    types: [published]
+    # prereleased: a prerelease is published -> push the version tag only.
+    # released:    a stable release is published, OR a prerelease is promoted to
+    #              a full/Latest release -> push the version tag AND :latest.
+    # (Listening to these two instead of `published` avoids a double run on a
+    # stable publish, which fires both `published` and `released`.)
+    types: [prereleased, released]
   # Same as a main push but on demand, from any ref.
   workflow_dispatch:
 
@@ -61,9 +66,9 @@ jobs:
         with:
           images: ${{ env.IMAGE }}
           tags: |
-            type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
-            type=raw,value=${{ steps.ver.outputs.value }},enable=${{ github.event_name == 'release' }}
             type=raw,value=edge,enable=${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+            type=raw,value=${{ steps.ver.outputs.value }},enable=${{ github.event_name == 'release' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' && github.event.action == 'released' }}
 
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
 


### PR DESCRIPTION
Implements the requested tag behavior:

| Trigger | Tag |
|---|---|
| merge to main | `:edge` |
| prerelease published | `:<version>` only |
| prerelease promoted to Latest (or stable published) | `:latest` + `:<version>` |

Switches the release trigger from `published` to `[prereleased, released]`. GitHub fires `released` when a prerelease is changed to a full/Latest release, so promoting a prerelease now pushes `:latest`. Using these two actions also avoids the double run a stable publish would cause (it fires both `published` and `released`).