### PR TITLE
chore(unraid): pin CA template image to :0.8.0-alpha.6

### DIFF
--- a/templates/stemdeck.xml
+++ b/templates/stemdeck.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>StemDeck</Name>
-  <Repository>ghcr.io/stemdeckapp/stemdeck:edge</Repository>
+  <Repository>ghcr.io/stemdeckapp/stemdeck:0.8.0-alpha.6</Repository>
   <Registry>https://github.com/stemdeckapp/stemdeck/pkgs/container/stemdeck</Registry>
   <Network>bridge</Network>
   <Shell>sh</Shell>


### PR DESCRIPTION
Point the Unraid Community Applications template at the pinned `:0.8.0-alpha.6` image instead of the rolling `:edge`, so new installs get that exact release.