### PR TITLE
feat(library): add More Notes Less Talk to We Recommend

### DIFF
--- a/static/js/catalog.js
+++ b/static/js/catalog.js
@@ -60,6 +60,11 @@ const FRIENDS = [
     url: "https://empresseffects.com",
     logo: "/img/friends/empress-effects.png",
   },
+  {
+    name: "More Notes Less Talk",
+    role: "YouTube channel",
+    url: "https://www.youtube.com/@morenoteslesstalk",
+  },
 ];
 
 // Instagram glyph (Simple Icons), shown under tiles that link to Instagram.


### PR DESCRIPTION
Adds the YouTube channel https://www.youtube.com/@morenoteslesstalk to the Our Friends / We Recommend list in the library. Renders with the monogram fallback (no logo bundled yet).