### PR TITLE
fix(desktop): NVIDIA build silently falling back to CPU (#247)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -17,15 +17,15 @@ def _env_path(name: str, default: Path) -> Path:
     return Path(raw).expanduser().resolve() if raw else default
 
 
-def _detect_device() -> str:
-    """Pick best available Torch device for Demucs. Override via
-    STEMDECK_DEMUCS_DEVICE env var ('cuda' | 'mps' | 'cpu'). Apple Silicon
-    silently falls back to CPU otherwise -- demucs's CLI default is
-    "cuda if available else cpu" and macOS has no CUDA, leaving the
-    integrated GPU idle and processing 3-5x slower than necessary."""
-    forced = os.environ.get("STEMDECK_DEMUCS_DEVICE", "").strip().lower()
-    if forced in ("cuda", "mps", "cpu"):
-        return forced
+def detect_torch_device() -> str:
+    """Best available Torch device for Demucs by hardware probe: cuda > mps >
+    cpu. Apple Silicon needs the explicit MPS check -- demucs's CLI default is
+    "cuda if available else cpu" and macOS has no CUDA, leaving the integrated
+    GPU idle and processing 3-5x slower than necessary.
+
+    User-facing device selection lives in app.core.settings (demucs_device,
+    default "auto" -> this probe); the STEMDECK_DEMUCS_DEVICE env var seeds
+    that setting's default so env-based deployments keep working."""
     try:
         import torch
 
@@ -67,7 +67,6 @@ FFPROBE_BIN = _env_path(
     FFMPEG_DIR / ("ffprobe.exe" if sys.platform.startswith("win") else "ffprobe"),
 )
 DEMUCS_MODEL = os.environ.get("STEMDECK_DEMUCS_MODEL", "htdemucs_6s").strip() or "htdemucs_6s"
-DEMUCS_DEVICE = _detect_device()
 MAX_DURATION_SEC = max(60, _env_int("STEMDECK_MAX_DURATION_SEC", 1200))  # 20 min default
 JOB_TTL_SECONDS = max(300, _env_int("STEMDECK_JOB_TTL_SECONDS", 24 * 3600))  # 24 h default
 MAX_PENDING_JOBS = max(1, min(50, _env_int("STEMDECK_MAX_PENDING_JOBS", 3)))

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -17,6 +17,25 @@ def _env_path(name: str, default: Path) -> Path:
     return Path(raw).expanduser().resolve() if raw else default
 
 
+def available_torch_devices() -> list[str]:
+    """Compute devices this machine can actually use, best-first. CPU is always
+    present; cuda/mps depend on the hardware + installed torch build. The
+    Settings UI uses this to disable options that aren't available/detected so
+    a user can't pick an impossible device."""
+    devices: list[str] = []
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            devices.append("cuda")
+        if getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():
+            devices.append("mps")
+    except ImportError:
+        pass
+    devices.append("cpu")
+    return devices
+
+
 def detect_torch_device() -> str:
     """Best available Torch device for Demucs by hardware probe: cuda > mps >
     cpu. Apple Silicon needs the explicit MPS check -- demucs's CLI default is
@@ -26,16 +45,7 @@ def detect_torch_device() -> str:
     User-facing device selection lives in app.core.settings (demucs_device,
     default "auto" -> this probe); the STEMDECK_DEMUCS_DEVICE env var seeds
     that setting's default so env-based deployments keep working."""
-    try:
-        import torch
-
-        if torch.cuda.is_available():
-            return "cuda"
-        if getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():
-            return "mps"
-    except ImportError:
-        pass
-    return "cpu"
+    return available_torch_devices()[0]
 
 
 ROOT = Path(__file__).resolve().parent.parent.parent

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -19,7 +19,13 @@ import logging
 import os
 import threading
 
-from app.core.config import DATA_DIR, MAX_DURATION_SEC, VIDEO_MAX_HEIGHT, detect_torch_device
+from app.core.config import (
+    DATA_DIR,
+    MAX_DURATION_SEC,
+    VIDEO_MAX_HEIGHT,
+    available_torch_devices,
+    detect_torch_device,
+)
 
 _log = logging.getLogger("stemdeck.settings")
 
@@ -178,7 +184,7 @@ def set_demucs_device(value: str) -> str:
     choice = (value or "").strip().lower()
     if choice not in _DEVICE_CHOICES:
         raise ValueError("demucs_device must be one of: " + ", ".join(_DEVICE_CHOICES))
-    if choice in ("cuda", "mps") and detect_torch_device() != choice:
+    if choice in ("cuda", "mps") and choice not in available_torch_devices():
         raise ValueError(f"{choice} is not available on this machine")
     with _LOCK:
         _ensure()["demucs_device"] = choice

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -6,6 +6,7 @@ at startup), so the Settings UI can change them without a restart:
 - `allow_network`     — whether StemDeck answers requests from other devices.
 - `max_duration_sec`  — longest track accepted for processing.
 - `video_max_height`  — max video resolution for MP4 export / YouTube pulls.
+- `demucs_device`     — compute device for separation: auto | cuda | mps | cpu.
 
 Defaults fall back to the config.py constants (which honor their env vars), so
 nothing changes until the user overrides a value.
@@ -18,7 +19,7 @@ import logging
 import os
 import threading
 
-from app.core.config import DATA_DIR, MAX_DURATION_SEC, VIDEO_MAX_HEIGHT
+from app.core.config import DATA_DIR, MAX_DURATION_SEC, VIDEO_MAX_HEIGHT, detect_torch_device
 
 _log = logging.getLogger("stemdeck.settings")
 
@@ -138,3 +139,48 @@ def set_port(value: int) -> int:
         _ensure()["port"] = clamped
         _save()
         return clamped
+
+
+# ── demucs_device ──
+# Compute device for stem separation. "auto" (default) resolves to the best
+# available device via a hardware probe at job time; "cuda"/"mps"/"cpu" force
+# it. Read live per job (app/pipeline/separate.py), so changes apply to the
+# NEXT separation without a restart. STEMDECK_DEMUCS_DEVICE seeds the default
+# so existing env-based deployments keep their forced device.
+_DEVICE_CHOICES = ("auto", "cuda", "mps", "cpu")
+
+
+def _default_demucs_device() -> str:
+    env = os.environ.get("STEMDECK_DEMUCS_DEVICE", "").strip().lower()
+    return env if env in ("cuda", "mps", "cpu") else "auto"
+
+
+def get_demucs_device_choice() -> str:
+    """The persisted user choice ("auto" | "cuda" | "mps" | "cpu") -- what the
+    Settings UI displays, as opposed to what jobs run on (see below)."""
+    with _LOCK:
+        v = _ensure().get("demucs_device")
+        return v if isinstance(v, str) and v in _DEVICE_CHOICES else _default_demucs_device()
+
+
+def get_demucs_device() -> str:
+    """The device the next separation job will actually use: the forced choice,
+    or a fresh hardware probe when the choice is "auto"."""
+    choice = get_demucs_device_choice()
+    return detect_torch_device() if choice == "auto" else choice
+
+
+def set_demucs_device(value: str) -> str:
+    """Persist a device choice. Forcing "cuda"/"mps" verifies the device is
+    actually available first and raises ValueError if not -- rejecting the
+    write loudly beats persisting a device that would silently fall back or
+    crash the next job (the #247 lesson, applied to the server path)."""
+    choice = (value or "").strip().lower()
+    if choice not in _DEVICE_CHOICES:
+        raise ValueError("demucs_device must be one of: " + ", ".join(_DEVICE_CHOICES))
+    if choice in ("cuda", "mps") and detect_torch_device() != choice:
+        raise ValueError(f"{choice} is not available on this machine")
+    with _LOCK:
+        _ensure()["demucs_device"] = choice
+        _save()
+        return choice

--- a/app/main.py
+++ b/app/main.py
@@ -19,7 +19,6 @@ from fastapi.staticfiles import StaticFiles
 
 from app.api.router import router
 from app.core.config import (
-    DEMUCS_DEVICE,
     DEMUCS_MODEL,
     FFMPEG_BIN,
     JOBS_DIR,
@@ -30,10 +29,13 @@ from app.core.config import (
 from app.core.registry import restore as restore_registry
 from app.core.settings import (
     get_allow_network,
+    get_demucs_device,
+    get_demucs_device_choice,
     get_max_duration_sec,
     get_port,
     get_video_max_height,
     set_allow_network,
+    set_demucs_device,
     set_max_duration_sec,
     set_port,
     set_video_max_height,
@@ -45,7 +47,9 @@ from app.pipeline.collect import sweep_old_jobs
 # logger.info(...) call across the app, including the analyze
 # diagnostics ("chroma:", "key candidates:").
 logging.getLogger("stemdeck").setLevel(logging.INFO)
-logging.getLogger("stemdeck").info("demucs config: model=%s device=%s", DEMUCS_MODEL, DEMUCS_DEVICE)
+logging.getLogger("stemdeck").info(
+    "demucs config: model=%s device=%s", DEMUCS_MODEL, get_demucs_device()
+)
 
 configure_portable_environment()
 
@@ -211,7 +215,7 @@ def health() -> dict[str, object]:
         "version": app_version(),
         "ffmpeg_configured": FFMPEG_BIN.is_file(),
         "demucs_model": DEMUCS_MODEL,
-        "demucs_device": DEMUCS_DEVICE,
+        "demucs_device": get_demucs_device(),
     }
 
 
@@ -233,6 +237,10 @@ def _settings_payload() -> dict[str, object]:
         "max_duration_sec": get_max_duration_sec(),
         "video_max_height": get_video_max_height(),
         "port": get_port(),
+        # The user's choice ("auto" | "cuda" | "mps" | "cpu") drives the UI
+        # select; the resolved value shows what jobs will actually run on.
+        "demucs_device": get_demucs_device_choice(),
+        "demucs_device_resolved": get_demucs_device(),
     }
 
 
@@ -266,6 +274,13 @@ async def update_settings(request: Request) -> dict[str, object]:
                 setter(int(body[key]))
             except (TypeError, ValueError):
                 raise HTTPException(status_code=422, detail=f"{key} must be an integer") from None
+    if "demucs_device" in body:
+        try:
+            set_demucs_device(str(body["demucs_device"]))
+        except ValueError as e:
+            # set_demucs_device's messages are safe, user-actionable strings
+            # (invalid choice / device not available on this machine).
+            raise HTTPException(status_code=422, detail=str(e)) from None
     return _settings_payload()
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -23,6 +23,7 @@ from app.core.config import (
     FFMPEG_BIN,
     JOBS_DIR,
     STATIC_DIR,
+    available_torch_devices,
     configure_portable_environment,
     ensure_runtime_dirs,
 )
@@ -238,9 +239,11 @@ def _settings_payload() -> dict[str, object]:
         "video_max_height": get_video_max_height(),
         "port": get_port(),
         # The user's choice ("auto" | "cuda" | "mps" | "cpu") drives the UI
-        # select; the resolved value shows what jobs will actually run on.
+        # select; the resolved value shows what jobs will actually run on;
+        # available lets the UI gray out devices this machine can't use.
         "demucs_device": get_demucs_device_choice(),
         "demucs_device_resolved": get_demucs_device(),
+        "demucs_devices_available": available_torch_devices(),
     }
 
 

--- a/app/pipeline/separate.py
+++ b/app/pipeline/separate.py
@@ -9,9 +9,10 @@ import threading
 import time
 from pathlib import Path
 
-from app.core.config import DEMUCS_DEVICE, DEMUCS_MODEL, TIMEOUT_DEMUCS_STALL
+from app.core.config import DEMUCS_MODEL, TIMEOUT_DEMUCS_STALL
 from app.core.models import Job, JobCancelled, _set
 from app.core.registry import set_proc
+from app.core.settings import get_demucs_device
 
 logger = logging.getLogger("stemdeck.pipeline")
 
@@ -24,6 +25,10 @@ _PCT_RE = re.compile(r"(\d{1,3})%")
 def separate(job: Job, source: Path, job_dir: Path) -> Path:
     _set(job, status="separating", progress=0.0, stage="Separating stems...")
 
+    # Read the device fresh per job (not a frozen import) so a Settings change
+    # applies to the next separation without a restart.
+    device = get_demucs_device()
+    logger.info("[%s] separating on device=%s", job.id, device)
     cmd = [
         sys.executable,
         "-m",
@@ -31,7 +36,7 @@ def separate(job: Job, source: Path, job_dir: Path) -> Path:
         "-n",
         DEMUCS_MODEL,
         "-d",
-        DEMUCS_DEVICE,
+        device,
         "-o",
         str(job_dir),
         str(source),

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -102,6 +102,11 @@ struct RuntimeProbe {
     ffmpeg_ready: bool,
     /// Persisted from previous setup run; None means GPU step hasn't run yet.
     torch_device: Option<String>,
+    /// Why the persisted device was chosen (e.g. "verified", "no-gpu-detected",
+    /// "cuda-verify-failed", "cpu-only-package"). None on installs that predate
+    /// reason tracking -- the setup gate treats those as unsettled so a wrongly
+    /// pinned CPU heals itself on the next launch (#247).
+    torch_device_reason: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, Clone)]
@@ -166,6 +171,8 @@ struct GpuSetup {
     cuda_version: Option<String>,
     torch_device: String,
     cuda_verified: bool,
+    /// Why this device was chosen; mirrors the persisted torchDeviceReason.
+    reason: String,
 }
 
 fn main() {
@@ -330,6 +337,7 @@ fn probe_runtime() -> Result<RuntimeProbe, String> {
     }
     let ffmpeg = resolve_existing_ffmpeg(&data_dir);
     let torch_device = read_config_str(&data_dir, "torchDevice");
+    let torch_device_reason = read_config_str(&data_dir, "torchDeviceReason");
     Ok(RuntimeProbe {
         app_root: root.display().to_string(),
         data_dir: data_dir.display().to_string(),
@@ -338,6 +346,7 @@ fn probe_runtime() -> Result<RuntimeProbe, String> {
         ffmpeg_ready: ffmpeg.is_some(),
         ffmpeg_path: ffmpeg.map(|p| p.display().to_string()),
         torch_device,
+        torch_device_reason,
     })
 }
 
@@ -504,10 +513,6 @@ fn ensure_workspace() -> Result<(), String> {
     for dir in ["cache", "downloads", "ffmpeg", "jobs", "logs", "models"] {
         fs::create_dir_all(data.join(dir))
             .map_err(|e| format!("failed to create data/{dir}: {e}"))?;
-    }
-    if is_cpu_only_package(&root, &data) {
-        fs::write(data.join("cpu-only"), "")
-            .map_err(|e| format!("failed to write data/cpu-only: {e}"))?;
     }
     let config = data.join("config.json");
     if !config.exists() {
@@ -683,15 +688,20 @@ fn ensure_torch_device(state: tauri::State<BackendState>) -> Result<GpuSetup, St
     let root = app_root()?;
     let data_dir = local_data_dir()?;
 
+    // Self-heal installs poisoned by a previous CPU-build's data-dir marker
+    // before deciding anything (#247).
+    clear_stale_cpu_marker(&root, &data_dir);
+
     // CPU-only portable build: skip GPU detection and pip entirely.
-    if is_cpu_only_package(&root, &data_dir) {
-        persist_torch_device(&data_dir, "cpu");
+    if is_cpu_only_package(&root) {
+        persist_torch_device(&data_dir, "cpu", "cpu-only-package");
         return Ok(GpuSetup {
             gpu_detected: false,
             gpu_name: None,
             cuda_version: None,
             torch_device: "cpu".to_string(),
             cuda_verified: false,
+            reason: "cpu-only-package".to_string(),
         });
     }
 
@@ -703,8 +713,12 @@ fn ensure_torch_device(state: tauri::State<BackendState>) -> Result<GpuSetup, St
     #[cfg(target_os = "macos")]
     {
         let mps_available = verify_mps_torch(&python);
-        let device = if mps_available { "mps" } else { "cpu" };
-        persist_torch_device(&data_dir, device);
+        let (device, reason) = if mps_available {
+            ("mps", "mps")
+        } else {
+            ("cpu", "mps-unavailable")
+        };
+        persist_torch_device(&data_dir, device, reason);
         Ok(GpuSetup {
             gpu_detected: mps_available,
             gpu_name: if mps_available {
@@ -715,22 +729,29 @@ fn ensure_torch_device(state: tauri::State<BackendState>) -> Result<GpuSetup, St
             cuda_version: None,
             torch_device: device.to_string(),
             cuda_verified: false,
+            reason: reason.to_string(),
         })
     }
 
     #[cfg(not(target_os = "macos"))]
     {
-        let setup = match detect_nvidia_gpu() {
+        let setup = match detect_nvidia_gpu(&data_dir) {
             Some((gpu_name, cuda_version, compute_cap)) => {
                 let index_url = cuda_index_url(compute_cap.as_deref(), &cuda_version);
                 install_cuda_torch(&python, &index_url, &state)?;
                 let cuda_verified = verify_cuda_torch(&python);
+                let reason = if cuda_verified {
+                    "verified"
+                } else {
+                    "cuda-verify-failed"
+                };
                 GpuSetup {
                     gpu_detected: true,
                     gpu_name: Some(gpu_name),
                     cuda_version: Some(cuda_version),
                     torch_device: if cuda_verified { "cuda" } else { "cpu" }.to_string(),
                     cuda_verified,
+                    reason: reason.to_string(),
                 }
             }
             None => GpuSetup {
@@ -739,22 +760,64 @@ fn ensure_torch_device(state: tauri::State<BackendState>) -> Result<GpuSetup, St
                 cuda_version: None,
                 torch_device: "cpu".to_string(),
                 cuda_verified: false,
+                reason: "no-gpu-detected".to_string(),
             },
         };
-        // Persist so subsequent launches skip this step entirely.
-        persist_torch_device(&data_dir, &setup.torch_device);
+        // Persist device + reason. The setup gate only treats "cuda"/"mps" (or
+        // cpu on a cpu-only package) as settled -- a CPU result born from a
+        // failure is re-probed on the next launch instead of pinning the
+        // install to CPU forever (#247).
+        persist_torch_device(&data_dir, &setup.torch_device, &setup.reason);
+        append_to_setup_log(
+            &data_dir,
+            &format!(
+                "GPU setup decision: device={} reason={} gpu={:?}",
+                setup.torch_device, setup.reason, setup.gpu_name
+            ),
+        );
         Ok(setup)
     }
 }
 
-fn is_cpu_only_package(root: &Path, data_dir: &Path) -> bool {
-    root.join("cpu-only").is_file() || data_dir.join("cpu-only").is_file()
+/// The `cpu-only` marker is trusted ONLY in the app root: it ships inside the
+/// package, so it is always correct for the running build. The per-user data
+/// dir is shared across installs -- honoring a marker there let a previously
+/// installed CPU build permanently force the NVIDIA build onto CPU (#247).
+fn is_cpu_only_package(root: &Path) -> bool {
+    root.join("cpu-only").is_file()
 }
 
-fn persist_torch_device(data_dir: &std::path::Path, device: &str) {
+/// Deletes a stale `cpu-only` marker left in the shared data dir by an older
+/// CPU-build install (which used to write/migrate it there). Without this, the
+/// NVIDIA build would keep re-reading it forever on builds that trusted the
+/// data-dir copy. Best-effort; logs so setup.log tells the story (#247).
+fn clear_stale_cpu_marker(root: &Path, data_dir: &Path) {
+    let stale = data_dir.join("cpu-only");
+    if !is_cpu_only_package(root) && stale.is_file() {
+        match fs::remove_file(&stale) {
+            Ok(()) => append_to_setup_log(
+                data_dir,
+                "removed stale cpu-only marker left by a previous CPU-build install; \
+                 GPU detection will run",
+            ),
+            Err(e) => append_to_setup_log(
+                data_dir,
+                &format!("could not remove stale cpu-only marker: {e}"),
+            ),
+        }
+    }
+}
+
+fn persist_torch_device(data_dir: &std::path::Path, device: &str, reason: &str) {
     let _ = update_setup_config(
         data_dir,
-        [("torchDevice", serde_json::Value::String(device.to_string()))],
+        [
+            ("torchDevice", serde_json::Value::String(device.to_string())),
+            (
+                "torchDeviceReason",
+                serde_json::Value::String(reason.to_string()),
+            ),
+        ],
     );
 }
 
@@ -772,39 +835,93 @@ fn verify_mps_torch(python: &Path) -> bool {
         .unwrap_or(false)
 }
 
+/// Finds nvidia-smi.exe under a DriverStore FileRepository directory. Modern
+/// NVIDIA DCH drivers sometimes ship it ONLY there (no System32 copy), e.g.
+/// `...\FileRepository\nv_dispi.inf_amd64_<hash>\nvidia-smi.exe`. Scans the
+/// `nv*`-prefixed package dirs and returns the most recently modified hit, so
+/// after a driver update the current package wins (#247).
+#[cfg(any(windows, test))]
+fn find_driver_store_nvidia_smi(file_repository: &Path) -> Option<PathBuf> {
+    let entries = fs::read_dir(file_repository).ok()?;
+    let mut best: Option<(std::time::SystemTime, PathBuf)> = None;
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy().to_ascii_lowercase();
+        if !name.starts_with("nv") {
+            continue;
+        }
+        let candidate = entry.path().join("nvidia-smi.exe");
+        if !candidate.is_file() {
+            continue;
+        }
+        let modified = candidate
+            .metadata()
+            .and_then(|m| m.modified())
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+        if best.as_ref().is_none_or(|(t, _)| modified > *t) {
+            best = Some((modified, candidate));
+        }
+    }
+    best.map(|(_, path)| path)
+}
+
 #[cfg(not(target_os = "macos"))]
-fn nvidia_smi_exe() -> &'static str {
+fn nvidia_smi_exe() -> String {
     // nvidia-smi.exe lives in System32 on Windows but Tauri child processes
-    // inherit a stripped PATH that may not include it.
+    // inherit a stripped PATH that may not include it. Some DCH driver installs
+    // only place it in the DriverStore, so scan there before falling back to
+    // PATH (#247).
     #[cfg(windows)]
     {
         const SYSTEM32: &str = r"C:\Windows\System32\nvidia-smi.exe";
         if std::path::Path::new(SYSTEM32).is_file() {
-            return SYSTEM32;
+            return SYSTEM32.to_string();
+        }
+        let file_repository =
+            std::path::Path::new(r"C:\Windows\System32\DriverStore\FileRepository");
+        if let Some(found) = find_driver_store_nvidia_smi(file_repository) {
+            return found.display().to_string();
         }
     }
-    "nvidia-smi"
+    "nvidia-smi".to_string()
 }
 
 #[cfg(not(target_os = "macos"))]
-fn detect_nvidia_gpu() -> Option<(String, String, Option<String>)> {
+fn detect_nvidia_gpu(data_dir: &Path) -> Option<(String, String, Option<String>)> {
     let smi = nvidia_smi_exe();
-    let mut cmd = Command::new(smi);
+    append_to_setup_log(data_dir, &format!("GPU detection using: {smi}"));
+    let mut cmd = Command::new(&smi);
     cmd.args(["--query-gpu=name", "--format=csv,noheader"])
         .stdout(Stdio::piped())
         .stderr(Stdio::null());
     hide_console_window(&mut cmd);
-    let name_out = command_output_with_timeout(cmd, Duration::from_secs(10), "nvidia-smi").ok()?;
+    // 30s (vs 10s elsewhere): the first nvidia-smi call can be slow on Optimus
+    // laptops that have to wake a sleeping dGPU (#247).
+    let name_out = match command_output_with_timeout(cmd, Duration::from_secs(30), "nvidia-smi") {
+        Ok(out) => out,
+        Err(e) => {
+            append_to_setup_log(data_dir, &format!("nvidia-smi failed to run: {e}"));
+            return None;
+        }
+    };
     if !name_out.status.success() {
+        append_to_setup_log(
+            data_dir,
+            &format!(
+                "nvidia-smi exited with {}; treating as no GPU",
+                name_out.status
+            ),
+        );
         return None;
     }
     let gpu_name = String::from_utf8_lossy(&name_out.stdout).trim().to_string();
     if gpu_name.is_empty() {
+        append_to_setup_log(data_dir, "nvidia-smi reported no GPU name");
         return None;
     }
 
     // Read CUDA version from the standard nvidia-smi header.
-    let mut smi_cmd = Command::new(smi);
+    let mut smi_cmd = Command::new(&smi);
     smi_cmd.stdout(Stdio::piped()).stderr(Stdio::null());
     hide_console_window(&mut smi_cmd);
     let smi_out =
@@ -816,7 +933,7 @@ fn detect_nvidia_gpu() -> Option<(String, String, Option<String>)> {
     // "8.9" for Ada). Drives the wheel choice: stock torch 2.6 cu12x wheels
     // have no sm_120 kernels, so Blackwell needs a cu128 / torch 2.7 build.
     // Failure here is non-fatal — we fall back to the CUDA-version heuristic.
-    let compute_cap = detect_compute_cap(smi);
+    let compute_cap = detect_compute_cap(&smi);
 
     Some((gpu_name, cuda_version, compute_cap))
 }
@@ -1416,10 +1533,13 @@ fn migrate_legacy_data(root: &Path, data_dir: &Path) {
             let _ = fs::rename(&src, data_dir.join(name));
         }
     }
-    for name in ["config.json", "cpu-only"] {
-        let src = old.join(name);
+    // NOTE: deliberately does NOT migrate `cpu-only` -- the marker is only
+    // trusted in the app root (see is_cpu_only_package); carrying it into the
+    // shared data dir poisoned later NVIDIA installs (#247).
+    {
+        let src = old.join("config.json");
         if src.exists() {
-            let _ = fs::copy(&src, data_dir.join(name));
+            let _ = fs::copy(&src, data_dir.join("config.json"));
         }
     }
 }
@@ -2750,5 +2870,87 @@ b6052160df96b31c9b1e33854a4dcda3d4b57641b880270f31736fb9f445d384  ffmpeg-n7.1-la
         // Missing / unparseable compute capability also falls back.
         assert_eq!(super::wheel_tag(None, "12.1"), "cu121");
         assert_eq!(super::wheel_tag(Some("N/A"), "12.4"), "cu124");
+    }
+
+    // --- cpu-only marker precedence + self-heal (#247) ---
+
+    #[test]
+    fn cpu_only_marker_trusted_in_root_only() {
+        let root = make_tmp();
+        let data = make_tmp();
+        // Marker only in the data dir (a previous CPU-build install) must NOT
+        // mark this package CPU-only.
+        fs::write(data.path().join("cpu-only"), "").unwrap();
+        assert!(!super::is_cpu_only_package(root.path()));
+        // Marker in the app root (ships with the package) does.
+        fs::write(root.path().join("cpu-only"), "").unwrap();
+        assert!(super::is_cpu_only_package(root.path()));
+    }
+
+    #[test]
+    fn stale_data_dir_marker_is_removed_for_gpu_builds() {
+        let root = make_tmp();
+        let data = make_tmp();
+        let stale = data.path().join("cpu-only");
+        fs::write(&stale, "").unwrap();
+        // GPU build (no root marker): the stale data-dir marker is deleted.
+        super::clear_stale_cpu_marker(root.path(), data.path());
+        assert!(!stale.exists());
+        // And the cleanup is recorded in setup.log.
+        let log = fs::read_to_string(data.path().join("logs").join("setup.log")).unwrap();
+        assert!(log.contains("stale cpu-only marker"));
+    }
+
+    #[test]
+    fn cpu_build_keeps_its_data_dir_marker() {
+        let root = make_tmp();
+        let data = make_tmp();
+        fs::write(root.path().join("cpu-only"), "").unwrap();
+        let legacy = data.path().join("cpu-only");
+        fs::write(&legacy, "").unwrap();
+        // CPU build (root marker present): nothing to heal, no churn.
+        super::clear_stale_cpu_marker(root.path(), data.path());
+        assert!(legacy.exists());
+        assert!(!data.path().join("logs").join("setup.log").exists());
+    }
+
+    // --- nvidia-smi DriverStore discovery (#247) ---
+
+    #[test]
+    fn driver_store_scan_finds_newest_nv_package() {
+        let repo = make_tmp();
+        // Non-NVIDIA package dirs are ignored.
+        fs::create_dir_all(repo.path().join("intelgpu.inf_amd64_aaa")).unwrap();
+        fs::write(
+            repo.path()
+                .join("intelgpu.inf_amd64_aaa")
+                .join("nvidia-smi.exe"),
+            b"x",
+        )
+        .unwrap();
+        // Older NVIDIA package.
+        let old_pkg = repo.path().join("nv_dispi.inf_amd64_old");
+        fs::create_dir_all(&old_pkg).unwrap();
+        fs::write(old_pkg.join("nvidia-smi.exe"), b"x").unwrap();
+        // Newer NVIDIA package (later mtime via explicit set).
+        let new_pkg = repo.path().join("nvmdi.inf_amd64_new");
+        fs::create_dir_all(&new_pkg).unwrap();
+        let new_exe = new_pkg.join("nvidia-smi.exe");
+        fs::write(&new_exe, b"x").unwrap();
+        let later = std::time::SystemTime::now() + std::time::Duration::from_secs(60);
+        let f = fs::OpenOptions::new().write(true).open(&new_exe).unwrap();
+        f.set_modified(later).unwrap();
+
+        let found = super::find_driver_store_nvidia_smi(repo.path());
+        assert_eq!(found, Some(new_exe));
+    }
+
+    #[test]
+    fn driver_store_scan_handles_missing_dir() {
+        let repo = make_tmp();
+        let missing = repo.path().join("does-not-exist");
+        assert_eq!(super::find_driver_store_nvidia_smi(&missing), None);
+        // Present but empty: also None.
+        assert_eq!(super::find_driver_store_nvidia_smi(repo.path()), None);
     }
 }

--- a/desktop/ui/setup.js
+++ b/desktop/ui/setup.js
@@ -237,7 +237,18 @@ async function runSetup() {
     // refresh the install records the version and subsequent launches match.
     const versionMismatch = Boolean(expectedVersion) && installedVersion !== expectedVersion;
 
-    if (runtime.pythonReady && runtime.ffmpegReady && runtime.torchDevice && !versionMismatch) {
+    // A persisted torch device only counts as settled when it is a positive
+    // result ("cuda"/"mps") or the package itself is CPU-only. A CPU device
+    // born from a failure (no GPU found, CUDA verify failed) -- or from a build
+    // that predates reason tracking -- re-runs the GPU step on this launch, so
+    // a single bad first run can't pin the install to CPU forever (#247).
+    // Cost when nothing changed: one fast nvidia-smi probe.
+    const torchDeviceSettled =
+      runtime.torchDevice === "cuda" ||
+      runtime.torchDevice === "mps" ||
+      (runtime.torchDevice === "cpu" && runtime.torchDeviceReason === "cpu-only-package");
+
+    if (runtime.pythonReady && runtime.ffmpegReady && torchDeviceSettled && !versionMismatch) {
       for (const step of steps) {
         step.classList.remove("active", "error");
         if (step.dataset.step === "backend") {

--- a/scripts/windows/make-portable.ps1
+++ b/scripts/windows/make-portable.ps1
@@ -169,8 +169,10 @@ foreach ($Dir in @("cache", "downloads", "ffmpeg", "jobs", "logs", "models")) {
   New-Item -ItemType Directory -Force (Join-Path $Stage "data\$Dir") | Out-Null
 }
 if ($CpuOnly) {
+  # Root marker only: the app trusts cpu-only solely in the app root (#247).
+  # A data\cpu-only copy used to leak into the shared per-user data dir and
+  # silently forced later NVIDIA installs onto CPU.
   New-Item -ItemType File -Force (Join-Path $Stage "cpu-only") | Out-Null
-  New-Item -ItemType File -Force (Join-Path $Stage "data\cpu-only") | Out-Null
 }
 
 Copy-Tree (Join-Path $Root "app") (Join-Path $BackendDir "app")

--- a/static/css/daw.css
+++ b/static/css/daw.css
@@ -779,7 +779,17 @@ input, textarea { font-family: inherit; }
 .settings-tab.active { color: var(--fg); border-bottom-color: var(--accent); }
 .settings-pane { display: flex; flex-direction: column; min-height: 0; }
 .settings-pane[data-pane="general"] { flex: 1; }
-.settings-pane[data-pane="advanced"] { flex: 1; overflow-y: auto; }
+.settings-pane[data-pane="advanced"] {
+  flex: 1; overflow-y: auto;
+  /* Reserve a gutter for the scrollbar so it never overlaps the right-aligned
+     controls (Port, Compute device). padding-right insets the content; the
+     equal negative margin lets that gutter sit in the card's own 12px padding,
+     so scrolling content stays aligned with the fixed header/tabs/footer.
+     Handles overlay scrollbars (macOS/WebKit, which draw over the padding box)
+     and reserves space for classic scrollbars (Windows/Linux). */
+  scrollbar-gutter: stable;
+  padding-right: 12px; margin-right: -12px;
+}
 .settings-pane.hidden { display: none; }
 .settings-pane[data-pane="advanced"] .library-editor-table-wrap { flex: none; max-height: 240px; margin-bottom: 2px; }
 .settings-empty { color: var(--muted); font-size: 12px; text-align: center; padding: 28px 10px; }

--- a/static/js/catalog.js
+++ b/static/js/catalog.js
@@ -1853,12 +1853,27 @@ async function wireGeneralSettings(overlay) {
   const durInput = overlay.querySelector(".set-max-duration");
   const heightSel = overlay.querySelector(".set-video-height");
   const portInput = overlay.querySelector(".set-port");
-  if (!durInput && !heightSel && !portInput) return;
+  const deviceSel = overlay.querySelector(".set-demucs-device");
+  const deviceResolved = overlay.querySelector(".set-demucs-resolved");
+  if (!durInput && !heightSel && !portInput && !deviceSel) return;
+
+  // Last server-confirmed device choice, to revert the select when the server
+  // rejects a forced device (e.g. CUDA not available on this machine).
+  let lastDevice = "auto";
 
   const apply = (d) => {
     if (durInput && d.max_duration_sec) durInput.value = String(Math.round(d.max_duration_sec / 60));
     if (heightSel && d.video_max_height) heightSel.value = String(d.video_max_height);
     if (portInput && d.port) portInput.value = String(d.port);
+    if (deviceSel && d.demucs_device) {
+      deviceSel.value = d.demucs_device;
+      lastDevice = d.demucs_device;
+    }
+    if (deviceResolved) {
+      deviceResolved.textContent = d.demucs_device_resolved
+        ? ` (currently: ${d.demucs_device_resolved})`
+        : "";
+    }
   };
 
   // Keep the text inputs digit-only as the user types (maxlength caps the rest).
@@ -1893,8 +1908,35 @@ async function wireGeneralSettings(overlay) {
     post({ video_max_height: parseInt(heightSel.value, 10) });
   });
   portInput?.addEventListener("change", () => {
-    const port = Math.max(1024, Math.min(65535, parseInt(portInput.value, 10) || 8080));
+    const port = Math.max(1024, Math.min(65535, parseInt(portInput.value, 10) || 8000));
     post({ port });
+  });
+  // Compute device needs its own POST path: unlike the clamped numeric
+  // settings, the server can REJECT a forced device (422 with a reason, e.g.
+  // "cuda is not available on this machine") -- surface that and revert.
+  deviceSel?.addEventListener("change", async () => {
+    try {
+      const r = await fetch("/api/settings", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ demucs_device: deviceSel.value }),
+      });
+      if (r.ok) {
+        apply(await r.json());
+        return;
+      }
+      let detail = "Could not change the compute device.";
+      try {
+        detail = (await r.json()).detail || detail;
+      } catch (err) {
+        console.warn("settings error body parse failed:", err);
+      }
+      showError(detail);
+      deviceSel.value = lastDevice;
+    } catch (err) {
+      console.warn("compute device update failed:", err);
+      deviceSel.value = lastDevice;
+    }
   });
 }
 
@@ -2031,6 +2073,20 @@ function openLibraryEditor() {
               <div class="settings-row-desc">Port StemDeck runs on. Restart to apply.</div>
             </div>
             <input type="text" class="settings-num-input set-port" inputmode="numeric" maxlength="5" aria-label="Port" />
+          </div>
+        </div>
+        <div class="settings-section">
+          <div class="settings-row">
+            <div class="settings-row-text">
+              <div class="settings-row-title">Compute device</div>
+              <div class="settings-row-desc">Device used for stem separation. Applies to the next track<span class="set-demucs-resolved"></span>.</div>
+            </div>
+            <select class="settings-select set-demucs-device" aria-label="Compute device">
+              <option value="auto">Auto</option>
+              <option value="cuda">CUDA (NVIDIA)</option>
+              <option value="mps">MPS (Apple Silicon)</option>
+              <option value="cpu">CPU</option>
+            </select>
           </div>
         </div>
         <div class="settings-subhead">Out of sync tracks</div>

--- a/static/js/catalog.js
+++ b/static/js/catalog.js
@@ -1865,9 +1865,20 @@ async function wireGeneralSettings(overlay) {
     if (durInput && d.max_duration_sec) durInput.value = String(Math.round(d.max_duration_sec / 60));
     if (heightSel && d.video_max_height) heightSel.value = String(d.video_max_height);
     if (portInput && d.port) portInput.value = String(d.port);
-    if (deviceSel && d.demucs_device) {
-      deviceSel.value = d.demucs_device;
-      lastDevice = d.demucs_device;
+    if (deviceSel) {
+      // Gray out devices this machine can't use (Auto and CPU are always
+      // available). Label disabled options so it's clear WHY they're greyed.
+      const avail = new Set(d.demucs_devices_available || []);
+      for (const opt of deviceSel.options) {
+        const base = opt.textContent.replace(/ — not available$/, "");
+        const ok = opt.value === "auto" || avail.has(opt.value);
+        opt.disabled = !ok;
+        opt.textContent = ok ? base : `${base} — not available`;
+      }
+      if (d.demucs_device) {
+        deviceSel.value = d.demucs_device;
+        lastDevice = d.demucs_device;
+      }
     }
     if (deviceResolved) {
       deviceResolved.textContent = d.demucs_device_resolved

--- a/tests/test_network_gate.py
+++ b/tests/test_network_gate.py
@@ -115,15 +115,15 @@ def test_demucs_device_env_seeds_default(monkeypatch, _isolated_settings):
 def test_demucs_device_force_verified_before_persist(monkeypatch, _isolated_settings):
     # Forcing a device that isn't available must be rejected loudly, not
     # persisted to silently fail later (#247 lesson applied to the server).
-    monkeypatch.setattr(settings_mod, "detect_torch_device", lambda: "cpu")
+    monkeypatch.setattr(settings_mod, "available_torch_devices", lambda: ["cpu"])
     with pytest.raises(ValueError):
         settings_mod.set_demucs_device("cuda")
     assert settings_mod.get_demucs_device_choice() == "auto"  # nothing persisted
     # Forcing CPU is always allowed; forcing an available GPU is allowed.
     assert settings_mod.set_demucs_device("cpu") == "cpu"
-    monkeypatch.setattr(settings_mod, "detect_torch_device", lambda: "cuda")
+    monkeypatch.setattr(settings_mod, "available_torch_devices", lambda: ["cuda", "cpu"])
     assert settings_mod.set_demucs_device("cuda") == "cuda"
-    assert settings_mod.get_demucs_device() == "cuda"
+    assert settings_mod.get_demucs_device() == "cuda"  # forced, no probe
 
 
 def test_demucs_device_rejects_unknown_choice(_isolated_settings):
@@ -133,10 +133,14 @@ def test_demucs_device_rejects_unknown_choice(_isolated_settings):
 
 def test_demucs_device_api_round_trip_and_422(monkeypatch, _isolated_settings):
     monkeypatch.setattr(settings_mod, "detect_torch_device", lambda: "cpu")
+    monkeypatch.setattr(settings_mod, "available_torch_devices", lambda: ["cpu"])
+    monkeypatch.setattr("app.main.available_torch_devices", lambda: ["cpu"])
     with TestClient(app) as c:
         body = c.get("/api/settings").json()
         assert body["demucs_device"] == "auto"
         assert body["demucs_device_resolved"] == "cpu"
+        # UI availability: cuda/mps grayed out when only cpu is present.
+        assert body["demucs_devices_available"] == ["cpu"]
         # Valid change round-trips.
         r = c.post("/api/settings", json={"demucs_device": "cpu"})
         assert r.status_code == 200

--- a/tests/test_network_gate.py
+++ b/tests/test_network_gate.py
@@ -84,6 +84,72 @@ def test_settings_reject_non_integer():
         assert c.post("/api/settings", json={"max_duration_sec": "abc"}).status_code == 422
 
 
+# ── demucs_device (compute device) ──
+
+
+@pytest.fixture()
+def _isolated_settings(monkeypatch, tmp_path):
+    """Point the settings store at a temp file with a fresh in-memory state, so
+    device tests neither read nor pollute the developer's real settings.json."""
+    monkeypatch.setattr(settings_mod, "_SETTINGS_PATH", tmp_path / "settings.json")
+    monkeypatch.setattr(settings_mod, "_state", None)
+    monkeypatch.delenv("STEMDECK_DEMUCS_DEVICE", raising=False)
+
+
+def test_demucs_device_defaults_to_auto_and_resolves(monkeypatch, _isolated_settings):
+    monkeypatch.setattr(settings_mod, "detect_torch_device", lambda: "cpu")
+    assert settings_mod.get_demucs_device_choice() == "auto"
+    assert settings_mod.get_demucs_device() == "cpu"  # auto -> hardware probe
+    # A different probe result flows through without any persisted change.
+    monkeypatch.setattr(settings_mod, "detect_torch_device", lambda: "cuda")
+    assert settings_mod.get_demucs_device() == "cuda"
+
+
+def test_demucs_device_env_seeds_default(monkeypatch, _isolated_settings):
+    # Existing env-based deployments keep their forced device as the default.
+    monkeypatch.setenv("STEMDECK_DEMUCS_DEVICE", "cuda")
+    assert settings_mod.get_demucs_device_choice() == "cuda"
+    assert settings_mod.get_demucs_device() == "cuda"  # forced, no probe
+
+
+def test_demucs_device_force_verified_before_persist(monkeypatch, _isolated_settings):
+    # Forcing a device that isn't available must be rejected loudly, not
+    # persisted to silently fail later (#247 lesson applied to the server).
+    monkeypatch.setattr(settings_mod, "detect_torch_device", lambda: "cpu")
+    with pytest.raises(ValueError):
+        settings_mod.set_demucs_device("cuda")
+    assert settings_mod.get_demucs_device_choice() == "auto"  # nothing persisted
+    # Forcing CPU is always allowed; forcing an available GPU is allowed.
+    assert settings_mod.set_demucs_device("cpu") == "cpu"
+    monkeypatch.setattr(settings_mod, "detect_torch_device", lambda: "cuda")
+    assert settings_mod.set_demucs_device("cuda") == "cuda"
+    assert settings_mod.get_demucs_device() == "cuda"
+
+
+def test_demucs_device_rejects_unknown_choice(_isolated_settings):
+    with pytest.raises(ValueError):
+        settings_mod.set_demucs_device("bogus")
+
+
+def test_demucs_device_api_round_trip_and_422(monkeypatch, _isolated_settings):
+    monkeypatch.setattr(settings_mod, "detect_torch_device", lambda: "cpu")
+    with TestClient(app) as c:
+        body = c.get("/api/settings").json()
+        assert body["demucs_device"] == "auto"
+        assert body["demucs_device_resolved"] == "cpu"
+        # Valid change round-trips.
+        r = c.post("/api/settings", json={"demucs_device": "cpu"})
+        assert r.status_code == 200
+        assert r.json()["demucs_device"] == "cpu"
+        # Unavailable device -> 422 with a user-actionable detail, not persisted.
+        r = c.post("/api/settings", json={"demucs_device": "cuda"})
+        assert r.status_code == 422
+        assert "not available" in r.json()["detail"]
+        assert c.get("/api/settings").json()["demucs_device"] == "cpu"
+        # Unknown value -> 422.
+        assert c.post("/api/settings", json={"demucs_device": "bogus"}).status_code == 422
+
+
 def test_gate_blocks_non_loopback_when_off():
     settings_mod.set_allow_network(False)
     # TestClient's client host ("testclient") is treated as non-loopback.


### PR DESCRIPTION
Closes #247.

## Verdict: still valid
Nothing has touched GPU selection since the issue was filed (only FFmpeg/Unraid commits since 2026-07-04). Code inspection confirmed three concrete, independent defects -- stronger than the issue's own hypotheses.

## Root causes

**1. Cross-install poisoning (primary).** `is_cpu_only_package` trusted a `cpu-only` marker in the *shared* per-user data dir, not just the app root. The CPU build wrote that marker there on every `ensure_workspace`, and the legacy migration copied it too. Result: run the CPU build once, then install the NVIDIA build -> GPU detection never runs, permanent silent CPU. Explains "works on some NVIDIA PCs but not others."

**2. One bad first run pins CPU forever.** A CPU result from a transient failure (no GPU detected, CUDA verify failed) was persisted identically to a real CPU-only package, and the setup gate treated any truthy `torchDevice` as "done" -- never re-probing.

**3. Fragile nvidia-smi discovery.** Only checked System32 and PATH; some DCH driver installs place it only under `DriverStore\FileRepository\nv*\`. 10s timeout also tight for Optimus laptops waking a sleeping dGPU.

## Fix

- `is_cpu_only_package`: app root only. Stale data-dir marker is auto-deleted and logged (self-heals a poisoned install).
- Persist `torchDeviceReason` alongside the device; the setup gate (`setup.js`) only treats `cuda`/`mps`, or `cpu` on a genuine cpu-only package, as settled. A failure-born CPU or a legacy reason-less install re-probes the GPU on the next launch -- **existing affected installs self-heal just by relaunching**, no user action needed.
- `nvidia_smi_exe`: scan `DriverStore\FileRepository\nv*\` (newest package wins) before falling back to PATH; first probe timeout 10s -> 30s.
- Every GPU-detection decision now logged to `setup.log` (today a silent CPU leaves zero trace).
- Windows CPU-only portable package no longer stages `data\cpu-only` (the source of the poisoned marker).

## Deliberately out of scope
- A "Redo GPU setup" settings button -- redundant now that relaunch self-heals.
- WMI/PowerShell GPU fallback -- DriverStore scan + PATH covers the known failure modes.
- No Blackwell-specific changes (already shipped in #239/#240); this fix is GPU-model-agnostic.

## Verify
- `cargo test` (desktop/src-tauri): 16/16 pass, including 5 new tests (marker precedence, self-heal + setup.log line, CPU build doesn't churn its own marker, DriverStore newest-wins scan, missing-dir handling).
- `cargo fmt --check`: clean.
- `node --check desktop/ui/setup.js`: clean.
- Manual matrix (Windows NVIDIA machine, not yet run by me):
  - Fresh NVIDIA build -> CUDA enabled, setup.log shows detection lines.
  - Poisoned install (place `cpu-only` in `%LOCALAPPDATA%\StemDeck`) -> launch NVIDIA build -> marker auto-removed (logged), GPU probed, CUDA enabled.
  - Pinned install (`"torchDevice": "cpu"`, no reason, in config.json) -> relaunch -> GPU step re-runs and heals to `cuda`.
  - CPU build -> root marker settles it, no repeated probing.
  - GPU-less machine, NVIDIA build -> "No NVIDIA GPU" summary each launch, ~1s added, no error dialogs.

## Follow-up
After merge + a release, comment on #247 explaining the three causes and the self-heal (relaunch fixes pinned installs), and ask the reporter to confirm before closing further.

---

## Added in this PR: compute device selector for the self-hosted server

Companion to the desktop fix above, covering the server/Docker/Unraid path (which is a completely separate code path and was NOT touched by the desktop fix):

- New **Settings -> Advanced -> Compute device** dropdown: Auto (default, hardware probe) / CPU / CUDA (NVIDIA) / MPS (Apple Silicon). Shows the currently resolved device.
- Read **fresh per job** (`app/pipeline/separate.py`) -- changes apply to the next separation, no restart. Previously the device was a frozen constant readable only via the `STEMDECK_DEMUCS_DEVICE` env var + restart.
- **Verify-before-persist**: forcing CUDA/MPS checks availability first and rejects with a clear 422 ("cuda is not available on this machine") instead of persisting a device that would silently fall back later -- the same principle as the desktop fix, applied to the server.
- `STEMDECK_DEMUCS_DEVICE` still seeds the default, so existing env-based deployments are unaffected.
- `/api/settings` gains `demucs_device` (user choice) + `demucs_device_resolved` (what jobs run on); `/api/health`'s `demucs_device` now reflects the live value.

**Tests**: 5 new (auto-resolution, env seeding, verify-before-persist rejection, unknown choice, API round trip + 422s) -- 148 total pass. ruff clean, `node --check` clean.