### PR TITLE
chore(unraid): pin template to 0.8.0-alpha.8

### DIFF
--- a/templates/stemdeck.xml
+++ b/templates/stemdeck.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>StemDeck</Name>
-  <Repository>ghcr.io/stemdeckapp/stemdeck:0.8.0-alpha.7</Repository>
+  <Repository>ghcr.io/stemdeckapp/stemdeck:0.8.0-alpha.8</Repository>
   <Registry>https://github.com/stemdeckapp/stemdeck/pkgs/container/stemdeck</Registry>
   <Network>bridge</Network>
   <Shell>sh</Shell>


### PR DESCRIPTION
Bumps the Unraid Community Applications template pin to the current pre-release.

- `templates/stemdeck.xml` `<Repository>`: `ghcr.io/stemdeckapp/stemdeck:0.8.0-alpha.7` -> `:0.8.0-alpha.8`

Unraid installs track the latest published pre-release tag. This must land (and the `:0.8.0-alpha.8` image must be published to GHCR) before Unraid users get alpha.8.