### PR TITLE
fix(desktop): rotate backend.log instead of truncating it on launch

### DIFF
--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -1068,13 +1068,34 @@ fn patch_pyvenv_cfg(python: &Path) {
     let _ = fs::write(&cfg_path, patched);
 }
 
+/// Rotate backend.log -> backend.log.1 -> backend.log.2, dropping the oldest.
+///
+/// The log used to be truncated on every launch (#278), which destroyed the
+/// evidence exactly when it was needed: the natural response to a crashed
+/// session is "restart and retry", and the restart wiped the previous
+/// session's log. All renames are best-effort -- a locked file on Windows
+/// must never block launch; worst case we append to the old file, which
+/// still beats truncating it.
+fn rotate_log(log_path: &Path, keep: usize) {
+    if keep < 2 {
+        return; // nothing to rotate into
+    }
+    let numbered = |i: usize| log_path.with_extension(format!("log.{i}"));
+    // Windows fs::rename fails when the destination exists, so drop the
+    // oldest generation first, then shift the rest up.
+    let _ = fs::remove_file(numbered(keep - 1));
+    for i in (1..keep - 1).rev() {
+        let _ = fs::rename(numbered(i), numbered(i + 1));
+    }
+    let _ = fs::rename(log_path, numbered(1));
+}
+
 fn prepare_backend_stdio(log_path: &Path) -> Result<(Stdio, Stdio), String> {
     if let Some(parent) = log_path.parent() {
         fs::create_dir_all(parent)
             .map_err(|e| format!("failed to create backend log directory: {e}"))?;
     }
-    fs::File::create(log_path)
-        .map_err(|e| format!("failed to create backend log {}: {e}", log_path.display()))?;
+    rotate_log(log_path, 3);
     let stdout = fs::OpenOptions::new()
         .create(true)
         .append(true)


### PR DESCRIPTION
Closes #278. Phase 1 of #272 — plan: https://github.com/stemdeckapp/stemdeck/issues/272#issuecomment-4994101773 (PR-1B).

## What

`prepare_backend_stdio` ran `fs::File::create(log_path)`, truncating the previous session's `backend.log` on every launch. The natural user response to a crash is "restart and retry" — which erased exactly the evidence needed to diagnose it (this is why the Mac Mini "Audio processing failed" reporter had nothing to paste).

New `rotate_log(log_path, 3)`: `backend.log` → `backend.log.1` → `backend.log.2`, oldest dropped, then the session opens a fresh append-mode log as before.

Two Windows-specific details handled:
- `fs::rename` fails when the destination exists on Windows → the oldest generation is `remove_file`'d first, then the rest shift up.
- All operations are best-effort (`let _ =`) — a locked file must never block app launch; worst case we append to the old log, which still beats truncating it.

## Validation

- `cargo clippy` via WSL: compiles clean; the 3 existing warnings are pre-existing (`main.rs:72/232/972`), none in this change. (PR CI does not build the Rust desktop app.)
- Manual check after merge: launch the app twice → `backend.log.1` holds the prior session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)