### PR TITLE
fix(desktop): watchdog shutdown must not hard-kill on Windows

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -144,9 +144,12 @@ async def _desktop_parent_watchdog(parent_pid: int) -> None:
     while True:
         if not _process_exists(parent_pid):
             _log.info("desktop parent process exited; stopping backend")
-            # Send SIGTERM to ourselves so uvicorn runs its shutdown sequence
-            # instead of bypassing cleanup with os._exit().
-            os.kill(os.getpid(), signal.SIGTERM)
+            # Raise SIGTERM in-process so uvicorn's handler runs its shutdown
+            # sequence. os.kill(pid, SIGTERM) would be wrong here: on Windows
+            # it is TerminateProcess -- a hard kill that bypasses cleanup
+            # (#282). raise_signal triggers the Python-level handler on both
+            # platforms.
+            signal.raise_signal(signal.SIGTERM)
             return
         await asyncio.sleep(1)
 

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -1,0 +1,50 @@
+"""Tests for the desktop parent watchdog's shutdown path (#282)."""
+
+from __future__ import annotations
+
+import signal
+
+import pytest
+
+from app import main as main_mod
+
+
+@pytest.mark.asyncio
+async def test_watchdog_raises_sigterm_in_process(monkeypatch):
+    """When the parent dies, the watchdog must raise SIGTERM in-process
+    (uvicorn's handler runs) -- NOT os.kill, which on Windows is
+    TerminateProcess and bypasses the shutdown sequence."""
+    raised: list[int] = []
+    monkeypatch.setattr(main_mod, "_process_exists", lambda _pid: False)
+    monkeypatch.setattr(main_mod.signal, "raise_signal", raised.append)
+
+    killed: list = []
+    monkeypatch.setattr(main_mod.os, "kill", lambda *a: killed.append(a))
+
+    await main_mod._desktop_parent_watchdog(12345)
+
+    assert raised == [signal.SIGTERM]
+    assert killed == []  # the hard-kill path must be gone
+
+
+@pytest.mark.asyncio
+async def test_watchdog_keeps_waiting_while_parent_alive(monkeypatch):
+    """While the parent lives, the watchdog sleeps and loops -- no signal."""
+    checks: list[int] = []
+
+    def alive(pid: int) -> bool:
+        checks.append(pid)
+        return len(checks) < 3  # alive twice, then gone
+
+    async def instant_sleep(_delay):
+        return None
+
+    raised: list[int] = []
+    monkeypatch.setattr(main_mod, "_process_exists", alive)
+    monkeypatch.setattr(main_mod.asyncio, "sleep", instant_sleep)
+    monkeypatch.setattr(main_mod.signal, "raise_signal", raised.append)
+
+    await main_mod._desktop_parent_watchdog(999)
+
+    assert len(checks) == 3
+    assert raised == [signal.SIGTERM]


### PR DESCRIPTION
Closes #282. Phase 2 of #273 — plan: https://github.com/stemdeckapp/stemdeck/issues/273#issuecomment-4994102059 (PR-2D).

## What

`_desktop_parent_watchdog` stopped the backend with `os.kill(os.getpid(), signal.SIGTERM)`, commented as "so uvicorn runs its shutdown sequence." That's only true on POSIX — on Windows, `os.kill` with SIGTERM is `TerminateProcess`, a hard kill that bypasses every cleanup path. Low impact today (the registry persists per-job), but any future shutdown hook would silently never run on Windows desktop.

One-line root-cause fix: `signal.raise_signal(signal.SIGTERM)` triggers the in-process Python-level handler uvicorn installed via `signal.signal`, with identical semantics on both platforms. Comment updated to say why.

## Testing

New `tests/test_watchdog.py`: dead parent → exactly one in-process `raise_signal(SIGTERM)` and **zero** `os.kill` calls; alive parent → loops without signaling until the parent disappears.

Full suite: **182 passed**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)