### PR TITLE
feat(settings): add "Reset app data" (desktop)

### DIFF
--- a/app/core/registry.py
+++ b/app/core/registry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import shutil
 import subprocess
 import threading
 import uuid
@@ -203,6 +204,27 @@ def set_proc(job_id: str, proc: subprocess.Popen | None) -> None:
             _procs.pop(job_id, None)
         else:
             _procs[job_id] = proc
+
+
+def reset_all(jobs_dir: Path) -> None:
+    """Delete every job directory and the registry file, clearing the
+    in-memory registry too. Desktop-only factory reset (Settings -> General
+    -> "Reset app data") -- the caller is responsible for checking no job is
+    actively running first (deleting a running job's directory out from
+    under it would corrupt that job, not just reset the library)."""
+    with _lock:
+        _jobs.clear()
+        _procs.clear()
+    if not jobs_dir.is_dir():
+        return
+    for entry in jobs_dir.iterdir():
+        try:
+            if entry.is_dir():
+                shutil.rmtree(entry)
+            else:
+                entry.unlink()
+        except OSError:
+            logger.warning("reset: could not remove %s", entry, exc_info=True)
 
 
 def get_proc(job_id: str) -> subprocess.Popen | None:

--- a/app/main.py
+++ b/app/main.py
@@ -28,7 +28,9 @@ from app.core.config import (
     ensure_runtime_dirs,
 )
 from app.core.logging_setup import configure_logging
+from app.core.registry import all_jobs as registry_all_jobs
 from app.core.registry import registry_path
+from app.core.registry import reset_all as reset_registry
 from app.core.registry import restore as restore_registry
 from app.core.settings import (
     get_allow_network,
@@ -322,6 +324,30 @@ async def update_settings(request: Request) -> dict[str, object]:
         except ValueError as e:
             raise HTTPException(status_code=422, detail=str(e)) from None
     return _settings_payload()
+
+
+_ACTIVE_JOB_STATUSES = ("queued", "downloading", "analyzing", "separating", "processing")
+
+
+@app.post("/api/reset", tags=["settings"])
+def reset_app_data() -> dict[str, object]:
+    """Desktop-only factory reset (Settings -> General -> "Reset app data"):
+    delete every job directory and the registry, so no old work session can
+    resurface across package reinstalls -- the runtime state that actually
+    persists (~/Documents/StemDeck, not the extracted package's own bundled
+    data/ folder) survives a fresh install otherwise. The browser-side
+    library index is a separate store the frontend clears itself (via the
+    Tauri reset_user_data command) after this call succeeds.
+
+    Gated server-side, not just hidden in the UI: wiping JOBS_DIR on a
+    shared server would delete every user's data, not just the caller's."""
+    if os.environ.get("STEMDECK_DESKTOP") != "1":
+        raise HTTPException(status_code=403, detail="reset is only available in the desktop app")
+    active = [j for j in registry_all_jobs().values() if j.status in _ACTIVE_JOB_STATUSES]
+    if active:
+        raise HTTPException(status_code=409, detail="cannot reset while a job is in progress")
+    reset_registry(JOBS_DIR)
+    return {"ok": True}
 
 
 @app.get("/api/registry", tags=["settings"])

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -225,6 +225,7 @@ fn main() {
             save_audio_file,
             store_get,
             store_set,
+            reset_user_data,
             mark_store_migration_done,
         ])
         .build(tauri::generate_context!())
@@ -286,6 +287,19 @@ fn store_set(app: tauri::AppHandle, key: String, value: serde_json::Value) -> Re
     let path = documents_store_path(&app)?;
     let store = app.store(path).map_err(|e| e.to_string())?;
     store.set(key, value);
+    store.save().map_err(|e| e.to_string())
+}
+
+/// Clear the persistent user-data store entirely (Settings -> General ->
+/// "Reset app data"). Complements the backend's own job-data wipe (POST
+/// /api/reset) -- together they fully clear a user's local StemDeck state,
+/// including the per-job mixer-state keys (stemdeck:mix:<job_id>) that have
+/// no fixed enumeration to clear individually.
+#[tauri::command]
+fn reset_user_data(app: tauri::AppHandle) -> Result<(), String> {
+    let path = documents_store_path(&app)?;
+    let store = app.store(path).map_err(|e| e.to_string())?;
+    store.clear();
     store.save().map_err(|e| e.to_string())
 }
 

--- a/static/css/daw.css
+++ b/static/css/daw.css
@@ -846,6 +846,49 @@ input, textarea { font-family: inherit; }
 }
 .settings-registry-view:focus { outline: none; }
 
+/* Settings → General → danger zone (reset app data) */
+.settings-danger-zone { margin-top: 16px; padding-top: 14px; border-top: 1px solid var(--border); }
+.settings-danger-zone.hidden { display: none; }
+.settings-danger-subhead { color: var(--danger); }
+.settings-reset-btn {
+  flex-shrink: 0; min-height: 30px; border-radius: 7px;
+  border: 1px solid rgba(214,90,74,0.35); background: rgba(214,90,74,0.12);
+  color: var(--danger); font-family: var(--font-mono); font-size: 11px; font-weight: 600;
+  padding: 0 12px; cursor: pointer;
+}
+.settings-reset-btn:hover { background: rgba(214,90,74,0.2); }
+
+/* Reset app data — confirm dialog (nested above the Settings dialog) */
+.reset-confirm-backdrop {
+  position: fixed; inset: 0; z-index: 150;
+  display: grid; place-items: center;
+  background: rgba(3,8,13,0.55); backdrop-filter: blur(2px);
+}
+.reset-confirm-card {
+  width: min(340px, calc(100vw - 32px));
+  border: 1px solid rgba(214,90,74,0.4);
+  border-radius: 10px;
+  background: linear-gradient(180deg, rgba(28,39,48,0.98), rgba(13,21,29,0.98));
+  box-shadow: var(--shadow-panel);
+  padding: 16px; color: var(--fg); font-family: var(--font-mono);
+}
+.reset-confirm-title { font-size: 13px; font-weight: 700; color: var(--danger); margin-bottom: 8px; }
+.reset-confirm-body { font-size: 11.5px; color: var(--fg-2); line-height: 1.5; margin: 0 0 10px; }
+.reset-confirm-hint { font-size: 10.5px; color: var(--muted); margin: 0 0 7px; }
+.reset-confirm-hint strong { color: var(--fg); letter-spacing: 0.04em; }
+.reset-confirm-input {
+  width: 100%; min-height: 34px; border: 1px solid var(--border-strong); border-radius: 7px;
+  background: rgba(10,17,24,0.78); color: var(--fg); font: inherit; font-size: 12px;
+  padding: 0 10px; outline: none; box-sizing: border-box;
+}
+.reset-confirm-input:focus { border-color: rgba(214,90,74,0.5); box-shadow: 0 0 0 2px rgba(214,90,74,0.14); }
+.reset-confirm-msg { color: var(--danger); font-size: 11px; margin-top: 8px; min-height: 1em; }
+.reset-confirm-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 14px; }
+.reset-confirm-actions button { min-height: 30px; border-radius: 7px; font-family: var(--font-mono); font-size: 11px; cursor: pointer; padding: 0 12px; }
+.reset-confirm-cancel { border: 1px solid var(--border); background: rgba(21,31,39,0.52); color: var(--muted); }
+.reset-confirm-go { border: 1px solid rgba(214,90,74,0.4); background: rgba(214,90,74,0.18); color: var(--danger); font-weight: 600; }
+.reset-confirm-go:disabled { opacity: 0.4; cursor: not-allowed; }
+
 .library-editor-foot { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-top: 11px; }
 .library-editor-status { font-size: 10.5px; color: var(--muted); }
 .library-editor-status.out-of-sync { color: var(--danger); font-weight: 600; }

--- a/static/js/catalog.js
+++ b/static/js/catalog.js
@@ -1765,6 +1765,7 @@ function closeLibraryEditor() {
     document.removeEventListener("keydown", libraryEditorOnKey);
     libraryEditorOnKey = null;
   }
+  closeResetConfirm();
   libraryEditor?.remove();
   libraryEditor = null;
 }
@@ -2062,6 +2063,84 @@ async function loadRegistryView(overlay) {
   }
 }
 
+let resetConfirmOverlay = null;
+
+function closeResetConfirm() {
+  resetConfirmOverlay?.remove();
+  resetConfirmOverlay = null;
+}
+
+function openResetConfirm() {
+  closeResetConfirm();
+  const overlay = document.createElement("div");
+  overlay.className = "reset-confirm-backdrop";
+  overlay.innerHTML = `
+    <div class="reset-confirm-card" role="dialog" aria-modal="true" aria-label="Reset app data">
+      <div class="reset-confirm-title">Reset app data?</div>
+      <p class="reset-confirm-body">This permanently deletes every track, job, and library entry stored on this computer. This cannot be undone.</p>
+      <p class="reset-confirm-hint">Type <strong>RESET</strong> to confirm.</p>
+      <input class="reset-confirm-input" type="text" autocomplete="off" spellcheck="false" aria-label="Type RESET to confirm" />
+      <div class="reset-confirm-msg" role="alert" aria-live="polite"></div>
+      <div class="reset-confirm-actions">
+        <button class="reset-confirm-cancel" type="button">Cancel</button>
+        <button class="reset-confirm-go" type="button" disabled>Reset app data</button>
+      </div>
+    </div>
+  `;
+
+  const input = overlay.querySelector(".reset-confirm-input");
+  const goBtn = overlay.querySelector(".reset-confirm-go");
+  const msg = overlay.querySelector(".reset-confirm-msg");
+
+  input.addEventListener("input", () => {
+    goBtn.disabled = input.value.trim() !== "RESET";
+  });
+  overlay.querySelector(".reset-confirm-cancel").addEventListener("click", closeResetConfirm);
+  overlay.addEventListener("mousedown", (e) => { if (e.target === overlay) closeResetConfirm(); });
+  const onKey = (e) => { if (e.code === "Escape") closeResetConfirm(); };
+  document.addEventListener("keydown", onKey, { once: true });
+
+  goBtn.addEventListener("click", async () => {
+    goBtn.disabled = true;
+    input.disabled = true;
+    msg.textContent = "Resetting…";
+    try {
+      const r = await fetch("/api/reset", { method: "POST" });
+      if (!r.ok) {
+        let detail = "Reset failed.";
+        try { detail = (await r.json()).detail || detail; } catch (err) { console.warn("reset error body parse failed:", err); }
+        msg.textContent = detail;
+        goBtn.disabled = false;
+        input.disabled = false;
+        return;
+      }
+      // Backend job/registry data is gone. The browser-side library index
+      // (folders, tracks, per-job mixer state, trash) is a separate store
+      // the API call above doesn't touch -- clear it too, then reload so
+      // every in-memory JS structure re-initializes from the now-empty state
+      // instead of trying to reconcile itself piecemeal.
+      if (window.__TAURI__?.core?.invoke) {
+        try {
+          await window.__TAURI__.core.invoke("reset_user_data");
+        } catch (err) {
+          console.warn("reset_user_data failed:", err);
+        }
+      }
+      try { localStorage.clear(); } catch (err) { console.warn("localStorage.clear failed:", err); }
+      window.location.reload();
+    } catch (err) {
+      console.warn("reset failed:", err);
+      msg.textContent = "Reset failed — check your connection.";
+      goBtn.disabled = false;
+      input.disabled = false;
+    }
+  });
+
+  document.body.appendChild(overlay);
+  resetConfirmOverlay = overlay;
+  input.focus();
+}
+
 function openLibraryEditor() {
   closeFolderEditor();
   closeLibraryEditor();
@@ -2128,6 +2207,16 @@ function openLibraryEditor() {
         <div class="library-editor-foot">
           <span class="library-editor-status" aria-live="polite"></span>
           <button class="library-editor-sync" type="button">Resync out of sync tracks</button>
+        </div>
+        <div class="settings-section settings-danger-zone hidden">
+          <div class="settings-subhead settings-danger-subhead">Danger zone</div>
+          <div class="settings-row">
+            <div class="settings-row-text">
+              <div class="settings-row-title">Reset app data</div>
+              <div class="settings-row-desc">Permanently deletes every track, job, and library entry stored on this computer. Cannot be undone.</div>
+            </div>
+            <button class="settings-reset-btn" type="button">Reset app data…</button>
+          </div>
         </div>
       </div>
       <div class="settings-pane hidden" data-pane="network">
@@ -2223,6 +2312,17 @@ function openLibraryEditor() {
     note.className = "settings-server-note";
     note.textContent = "These settings are read-only in server mode. To change them, update your server configuration (e.g. docker-compose.yml) and restart.";
     overlay.querySelector("[data-pane='network']")?.prepend(note);
+  } else {
+    // Reset app data (#309 follow-up): a desktop-only troubleshooting tool
+    // for the "old session keeps coming back" report -- the real persisted
+    // state lives in ~/Documents/StemDeck, not the extracted package's own
+    // bundled data/ folder, so deleting that folder never clears it. Hidden
+    // in server mode: wiping JOBS_DIR there would delete every user's data,
+    // not just the caller's (also enforced server-side, not just here).
+    overlay.querySelector(".settings-danger-zone")?.classList.remove("hidden");
+    overlay.querySelector(".settings-reset-btn")?.addEventListener("click", () => {
+      openResetConfirm();
+    });
   }
 }
 

--- a/tests/test_reset.py
+++ b/tests/test_reset.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.models import Job
+from app.core.registry import _jobs, _procs
+from app.core.registry import reset_all as reset_registry
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry():
+    _jobs.clear()
+    _procs.clear()
+    yield
+    _jobs.clear()
+    _procs.clear()
+
+
+@pytest.fixture
+def client():
+    from app.main import app
+
+    return TestClient(app)
+
+
+# ─── registry.reset_all() ──────────────────────────────────────────────────
+
+
+def test_reset_all_clears_registry_and_deletes_job_dirs(tmp_path):
+    job = Job(id="abcdefabcdef", status="done", title="Old song")
+    _jobs[job.id] = job
+    job_dir = tmp_path / job.id
+    (job_dir / "stems").mkdir(parents=True)
+    (job_dir / "stems" / "vocals.wav").write_bytes(b"RIFF")
+    (tmp_path / "registry.json").write_text(json.dumps({"version": 1, "jobs": [job.to_record()]}))
+    (tmp_path / "failed").mkdir()
+    (tmp_path / "failed" / "somejob").mkdir()
+
+    reset_registry(tmp_path)
+
+    assert _jobs == {}
+    assert list(tmp_path.iterdir()) == []  # every entry under jobs_dir is gone
+
+
+def test_reset_all_clears_active_procs(tmp_path):
+    from unittest.mock import MagicMock
+
+    _procs["abcdefabcdef"] = MagicMock()
+    reset_registry(tmp_path)
+    assert _procs == {}
+
+
+def test_reset_all_on_missing_dir_is_a_noop(tmp_path):
+    missing = tmp_path / "does-not-exist"
+    reset_registry(missing)  # must not raise
+
+
+# ─── POST /api/reset ────────────────────────────────────────────────────────
+
+
+def test_reset_endpoint_requires_desktop_mode(client, monkeypatch, tmp_path):
+    monkeypatch.delenv("STEMDECK_DESKTOP", raising=False)
+    monkeypatch.setattr("app.main.JOBS_DIR", tmp_path)
+
+    r = client.post("/api/reset")
+
+    assert r.status_code == 403
+
+
+def test_reset_endpoint_rejects_active_job(client, monkeypatch, tmp_path):
+    monkeypatch.setenv("STEMDECK_DESKTOP", "1")
+    monkeypatch.setattr("app.main.JOBS_DIR", tmp_path)
+    job = Job(id="abcdefabcdee", status="separating")
+    _jobs[job.id] = job
+
+    r = client.post("/api/reset")
+
+    assert r.status_code == 409
+    assert job.id in _jobs  # nothing was touched
+
+
+def test_reset_endpoint_succeeds_in_desktop_mode(client, monkeypatch, tmp_path):
+    monkeypatch.setenv("STEMDECK_DESKTOP", "1")
+    monkeypatch.setattr("app.main.JOBS_DIR", tmp_path)
+    job = Job(id="abcdefabcdea", status="done")
+    _jobs[job.id] = job
+    (tmp_path / job.id).mkdir()
+
+    r = client.post("/api/reset")
+
+    assert r.status_code == 200
+    assert r.json() == {"ok": True}
+    assert _jobs == {}
+    assert not (tmp_path / job.id).exists()
+
+
+def test_reset_endpoint_allows_only_terminal_jobs(client, monkeypatch, tmp_path):
+    """done/error/cancelled jobs never block a reset -- only genuinely active
+    ones (queued through processing) do."""
+    monkeypatch.setenv("STEMDECK_DESKTOP", "1")
+    monkeypatch.setattr("app.main.JOBS_DIR", tmp_path)
+    for i, status in enumerate(("done", "error", "cancelled")):
+        _jobs[f"abcdefabcd{i:02x}"] = Job(id=f"abcdefabcd{i:02x}", status=status)
+
+    r = client.post("/api/reset")
+
+    assert r.status_code == 200


### PR DESCRIPTION
## Summary
Closes #312.

- **`app/core/registry.py`**: `reset_all(jobs_dir)` clears the in-memory registry and deletes every entry under `jobs_dir` (job dirs, the `failed/` quarantine, `registry.json` itself).
- **`app/main.py`**: `POST /api/reset`, gated server-side by `STEMDECK_DESKTOP=1` -- not just hidden in the UI, since wiping `JOBS_DIR` on a shared server would delete every user's data, not just the caller's. Returns 409 (not silently corrupting a job mid-separation) if a job is actively running.
- **`desktop/src-tauri/src/main.rs`**: new `reset_user_data` Tauri command clears the persistent library-index store (`~/Documents/StemDeck/user-data.json`) -- a separate store from the job data, holding folders/tracks/per-job mixer state/trash, with no fixed key list to enumerate individually.
- **`static/js/catalog.js` + `daw.css`**: Settings -> General -> a desktop-only "Danger zone" section with a "Reset app data" button, gated behind a type-to-confirm dialog (must type `RESET` to enable the confirm button). On confirm: `POST /api/reset`, then `reset_user_data`, then `localStorage.clear()`, then reload -- every in-memory JS structure re-initializes from a genuinely empty state instead of trying to reconcile itself piecemeal.

## Root cause this addresses
A user reported that old work sessions kept reappearing across fresh CPU/CUDA package installs even after deleting "the data folder". The real persisted state lives in `~/Documents/StemDeck/` (job data + registry, and separately `user-data.json` for the library index) -- not the extracted package's own bundled `data/` folder -- so deleting or replacing the executable never touched it.

## Test plan
- [x] `tests/test_reset.py`: `registry.reset_all` clears the registry and deletes every entry under `jobs_dir` (including `registry.json` and the `failed/` quarantine); clears active proc handles; no-ops on a missing dir. Endpoint tests: 403 outside desktop mode, 409 with an active job (nothing touched), 200 + empty registry + deleted dir in desktop mode, terminal-status jobs (done/error/cancelled) never block a reset.
- [x] **Live end-to-end verification** against a real running server (not just unit tests): registered a recovered job in a throwaway jobs dir, confirmed it via `GET /api/jobs`, called `POST /api/reset`, confirmed `GET /api/jobs` returned `[]` and the directory on disk was completely empty. Also confirmed 403 with `STEMDECK_DESKTOP` unset.
- [x] Rust: `cargo clippy --all-targets` (WSL, since CI doesn't build the desktop app) -- clean, only 3 pre-existing warnings unrelated to this change. `cargo test` -- 12/12 passed.
- [x] `node --check static/js/catalog.js` -- valid syntax.
- [x] Full suite: `229 passed`. `ruff check` / `ruff format --check` clean.
- [ ] **Not verified**: the actual dialog UI inside a running Tauri window -- no browser-automation tool available in this environment, and the "Danger zone" section only renders when `window.__TAURI__` exists (desktop-only by design), so it can't be exercised via a browser hitting the dev server either. Worth a manual pass in the real desktop app before the next release.