### PR TITLE
feat(settings): make Reset app data available in server mode

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -331,18 +331,22 @@ _ACTIVE_JOB_STATUSES = ("queued", "downloading", "analyzing", "separating", "pro
 
 @app.post("/api/reset", tags=["settings"])
 def reset_app_data() -> dict[str, object]:
-    """Desktop-only factory reset (Settings -> General -> "Reset app data"):
-    delete every job directory and the registry, so no old work session can
-    resurface across package reinstalls -- the runtime state that actually
+    """Factory reset (Settings -> General -> "Reset app data"): delete every
+    job directory and the registry, so no old work session can resurface
+    across package reinstalls -- on desktop, the runtime state that actually
     persists (~/Documents/StemDeck, not the extracted package's own bundled
     data/ folder) survives a fresh install otherwise. The browser-side
-    library index is a separate store the frontend clears itself (via the
-    Tauri reset_user_data command) after this call succeeds.
+    library index is a separate store the frontend clears itself (the Tauri
+    reset_user_data command on desktop, localStorage directly in server/
+    mobile mode) after this call succeeds.
 
-    Gated server-side, not just hidden in the UI: wiping JOBS_DIR on a
-    shared server would delete every user's data, not just the caller's."""
-    if os.environ.get("STEMDECK_DESKTOP") != "1":
-        raise HTTPException(status_code=403, detail="reset is only available in the desktop app")
+    Available in server mode too, same trust boundary as every other
+    settings-mutating endpoint: the network_gate middleware already allows
+    the host machine always and a LAN device only while network access is
+    on. On a shared deployment this deletes every user's library, not just
+    the caller's -- same blast radius as changing the compute device or any
+    other setting from a device with network access, not a new class of
+    risk this endpoint introduces on its own."""
     active = [j for j in registry_all_jobs().values() if j.status in _ACTIVE_JOB_STATUSES]
     if active:
         raise HTTPException(status_code=409, detail="cannot reset while a job is in progress")

--- a/static/css/daw.css
+++ b/static/css/daw.css
@@ -848,7 +848,6 @@ input, textarea { font-family: inherit; }
 
 /* Settings → General → danger zone (reset app data) */
 .settings-danger-zone { margin-top: 16px; padding-top: 14px; border-top: 1px solid var(--border); }
-.settings-danger-zone.hidden { display: none; }
 .settings-danger-subhead { color: var(--danger); }
 .settings-reset-btn {
   flex-shrink: 0; min-height: 30px; border-radius: 7px;

--- a/static/js/catalog.js
+++ b/static/js/catalog.js
@@ -2077,7 +2077,7 @@ function openResetConfirm() {
   overlay.innerHTML = `
     <div class="reset-confirm-card" role="dialog" aria-modal="true" aria-label="Reset app data">
       <div class="reset-confirm-title">Reset app data?</div>
-      <p class="reset-confirm-body">This permanently deletes every track, job, and library entry stored on this computer. This cannot be undone.</p>
+      <p class="reset-confirm-body">This permanently deletes every track, job, and library entry. On a shared server this affects everyone who uses it. This cannot be undone.</p>
       <p class="reset-confirm-hint">Type <strong>RESET</strong> to confirm.</p>
       <input class="reset-confirm-input" type="text" autocomplete="off" spellcheck="false" aria-label="Type RESET to confirm" />
       <div class="reset-confirm-msg" role="alert" aria-live="polite"></div>
@@ -2208,12 +2208,12 @@ function openLibraryEditor() {
           <span class="library-editor-status" aria-live="polite"></span>
           <button class="library-editor-sync" type="button">Resync out of sync tracks</button>
         </div>
-        <div class="settings-section settings-danger-zone hidden">
+        <div class="settings-section settings-danger-zone">
           <div class="settings-subhead settings-danger-subhead">Danger zone</div>
           <div class="settings-row">
             <div class="settings-row-text">
               <div class="settings-row-title">Reset app data</div>
-              <div class="settings-row-desc">Permanently deletes every track, job, and library entry stored on this computer. Cannot be undone.</div>
+              <div class="settings-row-desc">Permanently deletes every track, job, and library entry. On a shared server this affects everyone who uses it. Cannot be undone.</div>
             </div>
             <button class="settings-reset-btn" type="button">Reset app data…</button>
           </div>
@@ -2312,18 +2312,17 @@ function openLibraryEditor() {
     note.className = "settings-server-note";
     note.textContent = "These settings are read-only in server mode. To change them, update your server configuration (e.g. docker-compose.yml) and restart.";
     overlay.querySelector("[data-pane='network']")?.prepend(note);
-  } else {
-    // Reset app data (#309 follow-up): a desktop-only troubleshooting tool
-    // for the "old session keeps coming back" report -- the real persisted
-    // state lives in ~/Documents/StemDeck, not the extracted package's own
-    // bundled data/ folder, so deleting that folder never clears it. Hidden
-    // in server mode: wiping JOBS_DIR there would delete every user's data,
-    // not just the caller's (also enforced server-side, not just here).
-    overlay.querySelector(".settings-danger-zone")?.classList.remove("hidden");
-    overlay.querySelector(".settings-reset-btn")?.addEventListener("click", () => {
-      openResetConfirm();
-    });
   }
+  // Reset app data (#312): originally a "session keeps coming back across
+  // desktop reinstalls" fix (the real persisted state lives in
+  // ~/Documents/StemDeck, not the extracted package's own bundled data/
+  // folder), available in server mode too -- same network_gate trust
+  // boundary as every other settings-mutating endpoint, enforced
+  // server-side (not just hidden here). On a shared server this deletes
+  // every user's library, which the confirm dialog says explicitly.
+  overlay.querySelector(".settings-reset-btn")?.addEventListener("click", () => {
+    openResetConfirm();
+  });
 }
 
 // Poll a job until it reaches a terminal state, so auto-restores run one at a

--- a/tests/test_reset.py
+++ b/tests/test_reset.py
@@ -61,17 +61,25 @@ def test_reset_all_on_missing_dir_is_a_noop(tmp_path):
 # ─── POST /api/reset ────────────────────────────────────────────────────────
 
 
-def test_reset_endpoint_requires_desktop_mode(client, monkeypatch, tmp_path):
+def test_reset_endpoint_works_without_desktop_mode(client, monkeypatch, tmp_path):
+    """Available in server mode too -- gated by the same network_gate
+    middleware every other settings-mutating endpoint already relies on, not
+    a desktop-only restriction."""
     monkeypatch.delenv("STEMDECK_DESKTOP", raising=False)
     monkeypatch.setattr("app.main.JOBS_DIR", tmp_path)
+    job = Job(id="abcdefabcded", status="done")
+    _jobs[job.id] = job
+    (tmp_path / job.id).mkdir()
 
     r = client.post("/api/reset")
 
-    assert r.status_code == 403
+    assert r.status_code == 200
+    assert r.json() == {"ok": True}
+    assert _jobs == {}
+    assert not (tmp_path / job.id).exists()
 
 
 def test_reset_endpoint_rejects_active_job(client, monkeypatch, tmp_path):
-    monkeypatch.setenv("STEMDECK_DESKTOP", "1")
     monkeypatch.setattr("app.main.JOBS_DIR", tmp_path)
     job = Job(id="abcdefabcdee", status="separating")
     _jobs[job.id] = job
@@ -82,8 +90,7 @@ def test_reset_endpoint_rejects_active_job(client, monkeypatch, tmp_path):
     assert job.id in _jobs  # nothing was touched
 
 
-def test_reset_endpoint_succeeds_in_desktop_mode(client, monkeypatch, tmp_path):
-    monkeypatch.setenv("STEMDECK_DESKTOP", "1")
+def test_reset_endpoint_succeeds(client, monkeypatch, tmp_path):
     monkeypatch.setattr("app.main.JOBS_DIR", tmp_path)
     job = Job(id="abcdefabcdea", status="done")
     _jobs[job.id] = job
@@ -100,7 +107,6 @@ def test_reset_endpoint_succeeds_in_desktop_mode(client, monkeypatch, tmp_path):
 def test_reset_endpoint_allows_only_terminal_jobs(client, monkeypatch, tmp_path):
     """done/error/cancelled jobs never block a reset -- only genuinely active
     ones (queued through processing) do."""
-    monkeypatch.setenv("STEMDECK_DESKTOP", "1")
     monkeypatch.setattr("app.main.JOBS_DIR", tmp_path)
     for i, status in enumerate(("done", "error", "cancelled")):
         _jobs[f"abcdefabcd{i:02x}"] = Job(id=f"abcdefabcd{i:02x}", status=status)


### PR DESCRIPTION
## Summary
Follow-up to #313, per feedback: server/Docker deployments should have the reset option too, not just desktop.

- Removed the `STEMDECK_DESKTOP=1` gate on `POST /api/reset`. It's covered by the same `network_gate` middleware every other settings-mutating endpoint (compute device, port, export sample rate, ...) already relies on -- host machine always allowed, a LAN device only while network access is currently on. Not a new class of risk this endpoint introduces on its own; same trust model, same blast radius as any other setting change from a device with network access.
- Settings -> General -> "Danger zone" now always renders (desktop and server/mobile UI both).
- The frontend's Tauri-specific `reset_user_data` call stays conditional on `window.__TAURI__` existing -- desktop only, no equivalent needed in server mode, since the browser-side library index there already lives in `localStorage` (the Tauri store's own fallback when running outside Tauri), which the existing `localStorage.clear()` call already covers.
- Confirm dialog and the row description now say explicitly that a reset on a shared server affects everyone who uses it.

## Test plan
- [x] `tests/test_reset.py` updated: server-mode-works test replaces the old desktop-required-403 test; the other endpoint tests no longer set `STEMDECK_DESKTOP` (irrelevant now).
- [x] **Live verification**: spun up a throwaway server instance with `STEMDECK_DESKTOP` unset, confirmed `POST /api/reset` now returns 200 (was 403 before this change) and actually clears the registry + deletes the job dir on disk.
- [x] Full suite: `229 passed`. `ruff check` / `ruff format --check` clean. `node --check` on the JS.