### PR TITLE
chore(unraid): pin template to 0.8.0-alpha.11

### DIFF
--- a/templates/stemdeck.xml
+++ b/templates/stemdeck.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>StemDeck</Name>
-  <Repository>ghcr.io/stemdeckapp/stemdeck:0.8.0-alpha.8</Repository>
+  <Repository>ghcr.io/stemdeckapp/stemdeck:0.8.0-alpha.11</Repository>
   <Registry>https://github.com/stemdeckapp/stemdeck/pkgs/container/stemdeck</Registry>
   <Network>bridge</Network>
   <Shell>sh</Shell>


### PR DESCRIPTION
## Summary
Pins the Unraid Community Applications template to the newly published `v0.8.0-alpha.11` image (confirmed pushed to `ghcr.io/stemdeckapp/stemdeck:0.8.0-alpha.11` via the release's docker-publish run).

Was still pinned at `0.8.0-alpha.8` -- three releases behind.