### PR TITLE
fix(desktop): re-detect GPU after CPU→NVIDIA build swap (#316)

### DIFF
--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -351,7 +351,10 @@ fn probe_runtime() -> Result<RuntimeProbe, String> {
     }
     let ffmpeg = resolve_existing_ffmpeg(&data_dir);
     let torch_device = read_config_str(&data_dir, "torchDevice");
-    let torch_device_reason = read_config_str(&data_dir, "torchDeviceReason");
+    let torch_device_reason = effective_device_reason(
+        read_config_str(&data_dir, "torchDeviceReason"),
+        is_cpu_only_package(&root),
+    );
     Ok(RuntimeProbe {
         app_root: root.display().to_string(),
         data_dir: data_dir.display().to_string(),
@@ -799,6 +802,22 @@ fn ensure_torch_device(state: tauri::State<BackendState>) -> Result<GpuSetup, St
 /// installed CPU build permanently force the NVIDIA build onto CPU (#247).
 fn is_cpu_only_package(root: &Path) -> bool {
     root.join("cpu-only").is_file()
+}
+
+/// A persisted "cpu-only-package" device decision is only trustworthy while the
+/// *current* install is still the CPU-only build. When a user replaces the CPU
+/// package with the NVIDIA (CUDA) build in the same data dir, the leftover
+/// reason would otherwise make the setup gate treat the device as "settled" on
+/// CPU and skip GPU detection entirely -- pinning a GPU machine to CPU until the
+/// data dir is cleared by hand. Dropping the stale reason marks the device
+/// unsettled so setup re-runs `ensure_torch_device` (which clears the stale
+/// marker and re-probes the GPU). Other reasons pass through unchanged; the
+/// existing #247 "unknown reason = unsettled" path handles the rest. (#316)
+fn effective_device_reason(persisted: Option<String>, cpu_only_package: bool) -> Option<String> {
+    match persisted.as_deref() {
+        Some("cpu-only-package") if !cpu_only_package => None,
+        _ => persisted,
+    }
 }
 
 /// Deletes a stale `cpu-only` marker left in the shared data dir by an older
@@ -2763,6 +2782,44 @@ mod tests {
                                   // but migration_flag is absent so no cleanup fires. Correct behavior.
         let last = fs::read_to_string(&version_file).unwrap_or_default();
         assert_eq!(last.trim(), "0.4.0");
+    }
+
+    // --- cpu-only-package re-probe on package swap (#316) ---
+
+    #[test]
+    fn stale_cpu_only_reason_dropped_when_package_is_not_cpu_only() {
+        // CPU build -> NVIDIA build swap in the same data dir: the leftover
+        // "cpu-only-package" reason must be invalidated so the setup gate treats
+        // the device as unsettled and re-runs GPU detection.
+        let got =
+            super::effective_device_reason(Some("cpu-only-package".to_string()), /* cpu_only */ false);
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn cpu_only_reason_kept_when_package_is_still_cpu_only() {
+        // Genuine CPU-only build: the reason is accurate and must stay so setup
+        // doesn't waste a probe on a machine that can never use CUDA.
+        let got =
+            super::effective_device_reason(Some("cpu-only-package".to_string()), /* cpu_only */ true);
+        assert_eq!(got.as_deref(), Some("cpu-only-package"));
+    }
+
+    #[test]
+    fn other_device_reasons_pass_through_unchanged() {
+        for reason in ["verified", "no-gpu-detected", "cuda-verify-failed", "mps"] {
+            assert_eq!(
+                super::effective_device_reason(Some(reason.to_string()), false).as_deref(),
+                Some(reason),
+            );
+            assert_eq!(
+                super::effective_device_reason(Some(reason.to_string()), true).as_deref(),
+                Some(reason),
+            );
+        }
+        // Absent reason stays absent (already unsettled) in both package kinds.
+        assert_eq!(super::effective_device_reason(None, false), None);
+        assert_eq!(super::effective_device_reason(None, true), None);
     }
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
Fixes #316.

## Problem

A Windows user with an NVIDIA GPU who switches from the CPU portable build to the NVIDIA build — reusing the same `%LOCALAPPDATA%\StemDeck` data dir — stays pinned to CPU. The only recovery was manually deleting the data dir and relaunching.

## Cause

The setup gate treats a persisted `cpu-only-package` device reason as permanently settled, so setup early-returns and **skips `ensure_torch_device`** — the very function whose `clear_stale_cpu_marker` + GPU re-probe (#247) heals this case. The `cpu-only-package` reason is only valid while the *current* install is still the CPU-only build; after an in-place swap to the NVIDIA build it is stale but never re-checked.

## Fix

`probe_runtime` now runs the persisted reason through a new pure helper `effective_device_reason(persisted, cpu_only_package)`: a `cpu-only-package` reason is dropped to `None` when the current install is **not** the cpu-only package. That marks the device unsettled, so the gate falls through and setup re-runs `ensure_torch_device`, which clears the stale marker, detects the GPU, and persists `cuda`/`verified`. Single heal — subsequent launches match. All other reasons pass through unchanged (reuses the existing #247 "unknown/unsettled reason self-heals" path).

## Scope

- **Windows desktop:** fixed.
- **macOS / Docker / self-hosted:** unaffected (macOS `mps` reasons are already non-terminal; Docker has no persisted-device machinery and upgrades are clean image replacements).

## Tests

Three unit tests for `effective_device_reason` (stale reason dropped on non-cpu-only package; kept on genuine cpu-only package; all other reasons + `None` pass through). Validated via WSL `cargo test` (3 passed) and `cargo clippy --all-targets` (no new warnings).

## Follow-up (separate PR)

Make the Windows NVIDIA build install cu124 torch explicitly in `make-portable.ps1` so GPU support is reproducible rather than an implicit property of the CI runner's PyPI resolution.