### PR TITLE
build(windows): install CUDA torch explicitly for the NVIDIA package (#316)

### DIFF
--- a/scripts/windows/make-portable.ps1
+++ b/scripts/windows/make-portable.ps1
@@ -202,11 +202,23 @@ if ($PackageVersion) {
 & $PythonExe -m pip install "$Root"
 
 if ($CpuOnly) {
-  # pip strips local version identifiers when resolving requirements, so it installs
-  # the CUDA wheel from PyPI even when we pre-install the CPU wheel. Force-reinstall
-  # after the fact: uninstalls CUDA torch and replaces it with the CPU-only variant.
+  # Force the CPU wheel explicitly. On Windows the default PyPI torch wheel is
+  # already CPU-only, but this also downgrades a build host that resolved a CUDA
+  # wheel (e.g. via a cu124 index in the runner's pip config), so the CPU package
+  # is deterministic regardless of the host.
   & $PythonExe -m pip install torch==2.6.0+cpu torchaudio==2.6.0+cpu `
       --index-url https://download.pytorch.org/whl/cpu `
+      --force-reinstall --no-deps
+} else {
+  # Force the CUDA wheel explicitly. Unlike Linux (whose default PyPI torch wheel
+  # bundles CUDA), the Windows PyPI torch wheel is CPU-only, so `pip install`
+  # above yields a CPU torch. Without this step the "NVIDIA" package's GPU support
+  # would depend on the build host happening to resolve a CUDA wheel -- silently
+  # regressing to CPU if that host's pip config ever changes. The Windows CUDA
+  # wheel is self-contained (bundles the CUDA DLLs; no separate nvidia-* deps like
+  # Linux), so --no-deps is correct here. (#316)
+  & $PythonExe -m pip install torch==2.6.0+cu124 torchaudio==2.6.0+cu124 `
+      --index-url https://download.pytorch.org/whl/cu124 `
       --force-reinstall --no-deps
 }
 


### PR DESCRIPTION
Follow-up hardening for #316.

## Problem

The Windows NVIDIA build's GPU support was never guaranteed by the packaging script. The non-`-CpuOnly` path does only `pip install "$Root"` and trusts PyPI to serve a CUDA torch wheel — true on Linux (default wheel bundles CUDA) but **false on Windows**, where the PyPI torch wheel is CPU-only. So the "NVIDIA" package being GPU-capable was an implicit property of the build host's pip resolution (e.g. a cu124 index configured in the runner). If that host config ever changes, releases silently regress to CPU torch — exactly the CPU-only artifact a plain-PyPI build produces locally.

## Fix

Mirror the existing `-CpuOnly` force-reinstall in reverse: the NVIDIA path now force-installs `torch==2.6.0+cu124 torchaudio==2.6.0+cu124` from `https://download.pytorch.org/whl/cu124`, making the GPU build deterministic regardless of build host. The Windows CUDA wheel is self-contained (bundles the CUDA DLLs; no separate `nvidia-*` deps like Linux), so `--no-deps` is correct. The CPU path comment is updated to note it also downgrades a host that resolved a CUDA wheel.

## Verification

- Script parses cleanly (`Parser::ParseFile`, no syntax errors).
- Change is a direct mirror of the already-proven `-CpuOnly` reinstall pattern.
- Full build not run here (pulls the ~2.5 GB CUDA wheel); the release CI exercises both variants. After merge, the NVIDIA zip should ship `torch.version.cuda != None` / `__version__ == "2.6.0+cu124"` and grow to the expected ~1.6 GB.

## Scope

Windows portable packaging only. macOS (MPS) and Docker (Linux CUDA baked into the image) are unaffected.