### PR TITLE
chore(unraid): pin template to 0.8.0-alpha.12

### DIFF
--- a/templates/stemdeck.xml
+++ b/templates/stemdeck.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>StemDeck</Name>
-  <Repository>ghcr.io/stemdeckapp/stemdeck:0.8.0-alpha.11</Repository>
+  <Repository>ghcr.io/stemdeckapp/stemdeck:0.8.0-alpha.12</Repository>
   <Registry>https://github.com/stemdeckapp/stemdeck/pkgs/container/stemdeck</Registry>
   <Network>bridge</Network>
   <Shell>sh</Shell>


### PR DESCRIPTION
Bumps the Unraid Community Applications template to the `0.8.0-alpha.12` image tag.

⚠️ **Merge only after the [v0.8.0-alpha.12 release](https://github.com/stemdeckapp/stemdeck/releases) is published.** The versioned `0.8.0-alpha.12` image tag is created by the release build (Docker Publish tags the version on `release: published`). Merging before publish would point the template at a tag that does not exist yet.

Mirrors #315 (the alpha.11 pin).