### PR TITLE
build(windows): don't bundle CUDA torch in the NVIDIA package (revert #318)

### DIFF
--- a/scripts/windows/make-portable.ps1
+++ b/scripts/windows/make-portable.ps1
@@ -202,25 +202,20 @@ if ($PackageVersion) {
 & $PythonExe -m pip install "$Root"
 
 if ($CpuOnly) {
-  # Force the CPU wheel explicitly. On Windows the default PyPI torch wheel is
+  # Force the slim CPU-only wheel. On Windows the default PyPI torch wheel is
   # already CPU-only, but this also downgrades a build host that resolved a CUDA
-  # wheel (e.g. via a cu124 index in the runner's pip config), so the CPU package
+  # wheel (e.g. via a cuXXX index in the runner's pip config), so the CPU package
   # is deterministic regardless of the host.
   & $PythonExe -m pip install torch==2.6.0+cpu torchaudio==2.6.0+cpu `
       --index-url https://download.pytorch.org/whl/cpu `
       --force-reinstall --no-deps
-} else {
-  # Force the CUDA wheel explicitly. Unlike Linux (whose default PyPI torch wheel
-  # bundles CUDA), the Windows PyPI torch wheel is CPU-only, so `pip install`
-  # above yields a CPU torch. Without this step the "NVIDIA" package's GPU support
-  # would depend on the build host happening to resolve a CUDA wheel -- silently
-  # regressing to CPU if that host's pip config ever changes. The Windows CUDA
-  # wheel is self-contained (bundles the CUDA DLLs; no separate nvidia-* deps like
-  # Linux), so --no-deps is correct here. (#316)
-  & $PythonExe -m pip install torch==2.6.0+cu124 torchaudio==2.6.0+cu124 `
-      --index-url https://download.pytorch.org/whl/cu124 `
-      --force-reinstall --no-deps
 }
+# Do NOT bundle CUDA torch into the NVIDIA (non-CpuOnly) package. It ships base
+# torch and the desktop app installs the CUDA build on first run via
+# ensure_torch_device, which picks the cuXXX index matching the detected GPU's
+# compute capability / driver. Bundling the CUDA wheel here (~2.5 GB installed)
+# pushes the zip past GitHub's 2 GiB release-asset cap and loses that adaptive
+# versioning. (Reverts #318; the real GPU-detection fix is #317.)
 
 & $PythonExe -c "import fastapi, uvicorn, yt_dlp, demucs, torch, torchaudio, librosa, pyloudnorm, soundfile"
 


### PR DESCRIPTION
Reverts #318, which broke the Windows NVIDIA asset upload on the v0.8.0-alpha.12 release.

## What happened

#318 force-installed the CUDA torch wheel into the NVIDIA package. That pushed `StemDeck-Windows-x64.NVIDIA.zip` to **2456 MB**, over GitHub's hard **2 GiB release-asset cap** (2147483648 bytes):

```
Validation Failed: {"resource":"ReleaseAsset","code":"custom","field":"size","message":"size must be less than 2147483648"}
```

So the release got the macOS + Windows-CPU assets but **not** the Windows NVIDIA zip.

## Why bundling was wrong

The desktop app already installs the CUDA build **on first run** via `ensure_torch_device` ([main.rs](desktop/src-tauri/src/main.rs#L753-L782)): it detects the GPU, picks the `cuXXX` index matching the card's compute capability / driver, and pip-installs CUDA torch. The NVIDIA package is meant to ship **base torch small** (~419 MB zip) and pull CUDA on first launch — that's what the setup UI's "Installing NVIDIA acceleration… CUDA Torch packages are large" step is.

Bundling CUDA torch (~2.5 GB installed) both blew the size cap **and** discarded the adaptive per-GPU CUDA-version selection. The genuine GPU-detection fix is #317 (re-probe after a CPU→NVIDIA build swap), which makes the first-run install trigger again — that's what actually fixed the reporter's machine.

## Change

Restore the non-`CpuOnly` path to base torch (drop the CUDA force-install) and add a comment documenting why not to bundle, so this isn't reintroduced.

## Verified

- Script parses cleanly (`Parser::ParseFile`, no errors).
- Restores the exact pre-#318 behavior that shipped fine on alpha.11 and earlier (NVIDIA zip well under 2 GiB).

## Release recovery

The v0.8.0-alpha.12 tag has #318 baked in, so its Windows build will keep failing. After this merges, the release needs re-cutting (see follow-up note) — the Docker image and Unraid pin (#319) are unaffected.