### PR TITLE
feat(desktop): release-notes modal with per-arch download link

### DIFF
--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -155,6 +155,19 @@ struct BackendStarted {
     url: String,
 }
 
+/// Identifies which published release asset matches the running build, so the
+/// frontend's "new release" dialog can offer the correct download link.
+/// `gpu` only distinguishes Windows/Linux assets (NVIDIA vs CPU variant);
+/// macOS ships one build per arch, so it reports "universal" and the frontend
+/// keys the macOS asset name on `arch` alone.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct BuildTarget {
+    os: String,
+    arch: String,
+    gpu: String,
+}
+
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct AssetStatus {
@@ -221,6 +234,7 @@ fn main() {
             ensure_torch_device,
             start_backend,
             local_ip,
+            build_target,
             open_url,
             save_audio_file,
             store_get,
@@ -682,6 +696,33 @@ fn start_backend(
         }
         Err(e) => Err(e),
     }
+}
+
+/// Reports the running build's OS/arch/GPU variant so the frontend can pick the
+/// matching release asset for the "new release" download link. GPU variant is
+/// derived from the shipped `cpu-only` marker (present only in CPU packages);
+/// on macOS there is no variant, so it reports "universal".
+#[tauri::command]
+fn build_target() -> BuildTarget {
+    let os = match std::env::consts::OS {
+        "macos" => "macos",
+        "windows" => "windows",
+        _ => "linux",
+    }
+    .to_string();
+    let arch = match std::env::consts::ARCH {
+        "aarch64" => "arm64",
+        _ => "x64",
+    }
+    .to_string();
+    let gpu = if os == "macos" {
+        "universal".to_string()
+    } else if app_root().map(|r| is_cpu_only_package(&r)).unwrap_or(true) {
+        "cpu".to_string()
+    } else {
+        "nvidia".to_string()
+    };
+    BuildTarget { os, arch, gpu }
 }
 
 /// Best-effort primary LAN IPv4, shown in Settings so the user knows the address

--- a/static/css/daw.css
+++ b/static/css/daw.css
@@ -2320,6 +2320,34 @@ input, textarea { font-family: inherit; }
   letter-spacing: 0.06em;
   margin: 0 0 6px !important;
 }
+/* Server/Docker mode: image-pull guidance in place of a desktop download. */
+.release-docker {
+  width: 100%;
+  text-align: left;
+  margin: 0 0 16px;
+}
+.release-docker-label {
+  margin: 0 0 6px;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--accent);
+}
+.release-docker-text { margin: 0 0 8px; font-size: 12px; color: var(--fg-2); }
+.release-docker-cmd {
+  margin: 0 0 8px;
+  padding: 8px 10px;
+  overflow-x: auto;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg);
+}
+.release-docker-note { margin: 0; font-size: 11px; color: var(--muted); }
+
 /* The "New release available" card opens the dialog on click. */
 .daw-notif-release { cursor: pointer; }
 

--- a/static/css/daw.css
+++ b/static/css/daw.css
@@ -2252,6 +2252,77 @@ input, textarea { font-family: inherit; }
 }
 .about-social-btn:hover { background: var(--accent); border-color: var(--accent); color: #000; }
 
+/* ── Release notes dialog ── */
+.release-card {
+  width: min(520px, calc(100vw - 32px));
+  max-height: calc(100vh - 64px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.release-notes {
+  width: 100%;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  text-align: left;
+  margin: 0 0 16px;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel);
+  color: var(--fg-2);
+  font-size: 12px;
+  line-height: 1.5;
+}
+.release-notes h4 {
+  margin: 12px 0 4px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--fg);
+}
+.release-notes h4:first-child { margin-top: 0; }
+.release-notes p { margin: 0 0 8px; }
+.release-notes ul { margin: 0 0 8px; padding-left: 18px; }
+.release-notes li { margin: 2px 0; }
+.release-notes a { color: var(--accent); text-decoration: none; overflow-wrap: anywhere; }
+.release-notes a:hover { text-decoration: underline; }
+.release-notes code {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0 4px;
+}
+.release-notes pre {
+  margin: 0 0 8px;
+  padding: 8px 10px;
+  overflow-x: auto;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+.release-notes pre code { border: 0; background: none; padding: 0; }
+.release-notes blockquote {
+  margin: 0 0 8px;
+  padding: 8px 12px;
+  border-left: 3px solid var(--accent);
+  border-radius: 0 6px 6px 0;
+  background: rgba(139, 92, 246, 0.08);
+}
+.release-notes blockquote > :last-child { margin-bottom: 0; }
+.release-callout {
+  font-weight: 700;
+  color: var(--accent);
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  margin: 0 0 6px !important;
+}
+/* The "New release available" card opens the dialog on click. */
+.daw-notif-release { cursor: pointer; }
+
 /* ── Library sections (Recent · Stem Collections · Tags) ── */
 .lib-section {
   display: flex;

--- a/static/index.html
+++ b/static/index.html
@@ -744,6 +744,13 @@
         <h2 id="releaseTitle">New release available</h2>
         <span class="about-version-badge" id="releaseVersion">…</span>
         <div class="release-notes" id="releaseNotes"></div>
+        <!-- Server/Docker mode: updating means pulling a new image, not a file download. -->
+        <div class="release-docker hidden" id="releaseDocker">
+          <p class="release-docker-label">Update your server</p>
+          <p class="release-docker-text">Pull the new image and restart the container:</p>
+          <pre class="release-docker-cmd"><code id="releaseDockerCmd"></code></pre>
+          <p class="release-docker-note">On Unraid, update via the Community Applications template instead.</p>
+        </div>
         <div class="about-primary-links">
           <a class="about-link about-link-primary" id="releaseDownload" href="#" target="_blank" rel="noopener noreferrer">Download</a>
           <a class="about-link about-link-secondary" id="releaseAllLink" href="https://github.com/stemdeckapp/stemdeck/releases" target="_blank" rel="noopener noreferrer">All releases</a>

--- a/static/index.html
+++ b/static/index.html
@@ -732,6 +732,25 @@
       </div>
     </div>
 
+    <!-- Release notes dialog (opened from the "New release available" card) -->
+    <div class="about-backdrop hidden" id="releaseDialog" role="dialog" aria-modal="true" aria-labelledby="releaseTitle">
+      <div class="about-card release-card">
+        <button class="about-close" id="releaseClose" type="button" aria-label="Close release dialog">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M18 6 6 18M6 6l12 12"/></svg>
+        </button>
+        <div class="about-logo" aria-hidden="true">
+          <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M12 2l2.4 7.4H22l-6.2 4.5 2.4 7.4L12 17l-6.2 4.3 2.4-7.4L2 9.4h7.6z"/></svg>
+        </div>
+        <h2 id="releaseTitle">New release available</h2>
+        <span class="about-version-badge" id="releaseVersion">…</span>
+        <div class="release-notes" id="releaseNotes"></div>
+        <div class="about-primary-links">
+          <a class="about-link about-link-primary" id="releaseDownload" href="#" target="_blank" rel="noopener noreferrer">Download</a>
+          <a class="about-link about-link-secondary" id="releaseAllLink" href="https://github.com/stemdeckapp/stemdeck/releases" target="_blank" rel="noopener noreferrer">All releases</a>
+        </div>
+      </div>
+    </div>
+
     <script type="module" src="/js/main.js"></script>
     <script type="module" src="/js/ui-chrome.js"></script>
   </body>

--- a/static/js/catalog.js
+++ b/static/js/catalog.js
@@ -1724,6 +1724,8 @@ async function openReleaseDialog() {
   const version = document.getElementById("releaseVersion");
   const notes = document.getElementById("releaseNotes");
   const download = document.getElementById("releaseDownload");
+  const docker = document.getElementById("releaseDocker");
+  const dockerCmd = document.getElementById("releaseDockerCmd");
 
   if (version) version.textContent = `v${normalizeVersion(latestRelease.tag_name)}`;
   if (notes) {
@@ -1733,20 +1735,29 @@ async function openReleaseDialog() {
       : `<p>No release notes provided. See the full release on GitHub.</p>`;
   }
 
-  if (download) {
+  // Server/Docker mode has no Tauri: updating is an image pull, not a file
+  // download, and the client browser's OS/arch is irrelevant to the container.
+  // Show the docker pull command instead of a (meaningless) desktop download.
+  const serverMode = !window.__TAURI__?.core?.invoke;
+  if (serverMode) {
+    const tag = normalizeVersion(latestRelease.tag_name);
+    if (dockerCmd) dockerCmd.textContent = `docker pull ghcr.io/stemdeckapp/stemdeck:${tag}`;
+    docker?.classList.remove("hidden");
+    download?.classList.add("hidden");
+  } else if (download) {
+    docker?.classList.add("hidden");
     const target = await getBuildTarget();
     const picked = pickReleaseAsset(latestRelease, target);
     if (picked) {
       download.href = picked.url;
       download.textContent = "Download";
-      download.classList.remove("hidden");
     } else {
-      // No matching asset (e.g. web/server mode, or an arch we don't build):
-      // fall back to the release page so the user can pick manually.
+      // No matching asset (e.g. an arch we don't build): fall back to the
+      // release page so the user can pick manually.
       download.href = latestRelease.html_url || RELEASES_URL;
       download.textContent = "View download";
-      download.classList.remove("hidden");
     }
+    download.classList.remove("hidden");
   }
 
   dialog.classList.remove("hidden");

--- a/static/js/catalog.js
+++ b/static/js/catalog.js
@@ -1531,6 +1531,11 @@ const RELEASES_URL = "https://github.com/stemdeckapp/stemdeck/releases";
 const RELEASES_API = "https://api.github.com/repos/stemdeckapp/stemdeck/releases/latest";
 const DISMISSED_UPDATE_KEY = "stemdeck.dismissed_update";
 
+// The full GitHub release object from the last successful update check, used to
+// populate the release dialog (notes + per-arch download link) on card click.
+let latestRelease = null;
+let cachedBuildTarget = null;
+
 function normalizeVersion(value) {
   return String(value || "").trim().replace(/^v/i, "") || FALLBACK_VERSION;
 }
@@ -1566,6 +1571,201 @@ async function loadCurrentVersion() {
   } catch (e) { console.warn("[catalog] version fetch failed:", e); }
 }
 
+function escapeHtml(value) {
+  return String(value == null ? "" : value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+// Inline markdown, applied AFTER escapeHtml so the markers (`* [ ] ( )`) are
+// still literal characters and never HTML. Links are restricted to http(s) to
+// block javascript:/data: URIs; label and URL are already entity-escaped.
+function renderInlineMd(text) {
+  return text
+    .replace(/`([^`]+)`/g, (_, code) => `<code>${code}</code>`)
+    .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+    .replace(
+      /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,
+      (_, label, url) => `<a href="${url}" target="_blank" rel="noopener noreferrer">${label}</a>`,
+    );
+}
+
+// Minimal, XSS-safe markdown subset for GitHub release bodies: headings, bullet
+// lists, fenced code blocks, paragraphs, and the inline set above. Everything is
+// HTML-escaped first; only a fixed whitelist of tags is ever emitted.
+function renderReleaseNotes(markdown) {
+  const lines = escapeHtml(markdown).split(/\r?\n/);
+  const out = [];
+  let inList = false;
+  let inCode = false;
+  let inQuote = false;
+  const code = [];
+  const closeList = () => {
+    if (inList) {
+      out.push("</ul>");
+      inList = false;
+    }
+  };
+  const closeQuote = () => {
+    if (inQuote) {
+      out.push("</blockquote>");
+      inQuote = false;
+    }
+  };
+  for (const raw of lines) {
+    let line = raw.replace(/\s+$/, "");
+    // Blockquote prefix — GitHub admonitions (macOS block) use `> [!IMPORTANT]`
+    // and `> ...` lines, and can wrap a fenced code block. escapeHtml already
+    // ran, so the marker is `&gt;`. Strip it unconditionally (so a blockquoted
+    // closing fence is still recognised), but only open/close the <blockquote>
+    // wrapper when not mid-fence, to avoid toggling it inside a code block.
+    const quoted = /^&gt;\s?/.test(line);
+    if (quoted) line = line.replace(/^&gt;\s?/, "");
+    if (!inCode) {
+      if (quoted && !inQuote) {
+        closeList();
+        out.push("<blockquote>");
+        inQuote = true;
+      } else if (!quoted && inQuote) {
+        closeList();
+        closeQuote();
+      }
+    }
+
+    if (/^```/.test(line)) {
+      if (inCode) {
+        out.push(`<pre><code>${code.join("\n")}</code></pre>`);
+        code.length = 0;
+        inCode = false;
+      } else {
+        closeList();
+        inCode = true;
+      }
+      continue;
+    }
+    if (inCode) {
+      code.push(line);
+      continue;
+    }
+    let m;
+    if ((m = /^\[!(\w+)\]/.exec(line))) {
+      // GitHub admonition label ([!IMPORTANT] -> "Important").
+      const label = m[1].charAt(0) + m[1].slice(1).toLowerCase();
+      out.push(`<p class="release-callout">${label}</p>`);
+    } else if ((m = /^#{1,6}\s+(.*)$/.exec(line))) {
+      closeList();
+      out.push(`<h4>${renderInlineMd(m[1])}</h4>`);
+    } else if ((m = /^\s*[-*]\s+(.*)$/.exec(line))) {
+      if (!inList) {
+        out.push("<ul>");
+        inList = true;
+      }
+      out.push(`<li>${renderInlineMd(m[1])}</li>`);
+    } else if (line.trim() === "") {
+      closeList();
+    } else {
+      closeList();
+      out.push(`<p>${renderInlineMd(line)}</p>`);
+    }
+  }
+  if (inCode) out.push(`<pre><code>${code.join("\n")}</code></pre>`);
+  closeList();
+  closeQuote();
+  return out.join("\n");
+}
+
+// Resolve the running build's OS/arch/GPU variant. On desktop this is exact
+// (Rust build_target); on web/server there is no reliable signal, so guess the
+// OS from the user agent and leave the variant as CPU.
+async function getBuildTarget() {
+  if (cachedBuildTarget) return cachedBuildTarget;
+  const invoke = window.__TAURI__?.core?.invoke;
+  if (invoke) {
+    try {
+      cachedBuildTarget = await invoke("build_target");
+      return cachedBuildTarget;
+    } catch (e) {
+      console.warn("[catalog] build_target failed:", e);
+    }
+  }
+  const ua = navigator.userAgent || "";
+  let os = "linux";
+  if (/Mac/i.test(ua)) os = "macos";
+  else if (/Win/i.test(ua)) os = "windows";
+  const arch = /arm64|aarch64/i.test(ua) ? "arm64" : "x64";
+  cachedBuildTarget = { os, arch, gpu: "cpu" };
+  return cachedBuildTarget;
+}
+
+// Expected release-asset filename for a build target. Names are deterministic
+// from the release workflows: macOS keys on arch; Windows/Linux add a .NVIDIA
+// infix for the CUDA variant.
+function assetNameFor(target) {
+  if (target.os === "macos") {
+    return `StemDeck-macOS-${target.arch === "arm64" ? "arm64" : "x64"}.dmg`;
+  }
+  const variant = target.gpu === "nvidia" ? ".NVIDIA" : "";
+  if (target.os === "windows") return `StemDeck-Windows-x64${variant}.zip`;
+  return `StemDeck-Linux-x64${variant}.tar.gz`;
+}
+
+function pickReleaseAsset(release, target) {
+  const name = assetNameFor(target);
+  const asset = (release.assets || []).find((a) => a.name === name);
+  return asset ? { url: asset.browser_download_url, name } : null;
+}
+
+async function openReleaseDialog() {
+  const dialog = document.getElementById("releaseDialog");
+  if (!dialog || !latestRelease) return;
+  const version = document.getElementById("releaseVersion");
+  const notes = document.getElementById("releaseNotes");
+  const download = document.getElementById("releaseDownload");
+
+  if (version) version.textContent = `v${normalizeVersion(latestRelease.tag_name)}`;
+  if (notes) {
+    const body = (latestRelease.body || "").trim();
+    notes.innerHTML = body
+      ? renderReleaseNotes(body)
+      : `<p>No release notes provided. See the full release on GitHub.</p>`;
+  }
+
+  if (download) {
+    const target = await getBuildTarget();
+    const picked = pickReleaseAsset(latestRelease, target);
+    if (picked) {
+      download.href = picked.url;
+      download.textContent = "Download";
+      download.classList.remove("hidden");
+    } else {
+      // No matching asset (e.g. web/server mode, or an arch we don't build):
+      // fall back to the release page so the user can pick manually.
+      download.href = latestRelease.html_url || RELEASES_URL;
+      download.textContent = "View download";
+      download.classList.remove("hidden");
+    }
+  }
+
+  dialog.classList.remove("hidden");
+}
+
+function wireReleaseDialog() {
+  const dialog = document.getElementById("releaseDialog");
+  const close = document.getElementById("releaseClose");
+  if (!dialog) return;
+  const hide = () => dialog.classList.add("hidden");
+  close?.addEventListener("click", hide);
+  dialog.addEventListener("mousedown", (e) => {
+    if (e.target === dialog) hide();
+  });
+  dialog.addEventListener("keydown", (e) => {
+    if (e.code === "Escape") hide();
+  });
+}
+
 async function checkForUpdate() {
   try {
     const res = await fetch(RELEASES_API, { headers: { Accept: "application/vnd.github+json" } });
@@ -1583,6 +1783,9 @@ async function checkForUpdate() {
     try { dismissed = localStorage.getItem(DISMISSED_UPDATE_KEY); } catch (e) { console.warn(e); }
     if (dismissed === latest) return;
 
+    // Keep the full release so the dialog can render notes + pick the download.
+    latestRelease = data;
+
     const card = document.getElementById("notifReleaseCard");
     const desc = document.getElementById("notifReleaseDesc");
     const badge = document.getElementById("notifBadge");
@@ -1594,7 +1797,14 @@ async function checkForUpdate() {
     badge?.classList.remove("hidden");
     empty?.classList.add("hidden");
 
-    dismissBtn?.addEventListener("click", () => {
+    // Clicking the card (anywhere but the dismiss button) opens the release dialog.
+    card?.addEventListener("click", (e) => {
+      if (e.target.closest("#notifReleaseDismiss")) return;
+      openReleaseDialog();
+    });
+
+    dismissBtn?.addEventListener("click", (e) => {
+      e.stopPropagation();
       try { localStorage.setItem(DISMISSED_UPDATE_KEY, latest); } catch (e) { console.warn(e); }
       card?.classList.add("hidden");
       badge?.classList.add("hidden");
@@ -2427,6 +2637,7 @@ export async function initCatalog() {
   wireLibraryDeleteKeys();
   wireAboutDialog();
   wireSupportersDialog();
+  wireReleaseDialog();
   wireSettingsMenu();
   setDisplayedVersion(currentVersion);
   render();

--- a/templates/stemdeck.xml
+++ b/templates/stemdeck.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>StemDeck</Name>
-  <Repository>ghcr.io/stemdeckapp/stemdeck:0.8.0-alpha.12</Repository>
+  <Repository>ghcr.io/stemdeckapp/stemdeck:0.8.0-alpha.13</Repository>
   <Registry>https://github.com/stemdeckapp/stemdeck/pkgs/container/stemdeck</Registry>
   <Network>bridge</Network>
   <Shell>sh</Shell>


### PR DESCRIPTION
## What

Clicking the "New release available" notification card opens a settings-style modal showing the GitHub release notes and, depending on how StemDeck is running, either a per-arch desktop download or Docker image-pull guidance. No self-update / in-place swapping.

## Behavior

- On launch, `checkForUpdate` shows the bell badge + notification card when a newer release exists (unchanged).
- Clicking the card opens the modal. Badge + card on launch, modal only on click.

## Desktop mode

Offers the download asset matching the **running build** (not live hardware) via the new `build_target` Tauri command, which returns `{ os, arch, gpu }`:

| Build | Asset |
|---|---|
| macOS arm64 / x64 | `StemDeck-macOS-{arch}.dmg` |
| Windows NVIDIA / CPU | `StemDeck-Windows-x64[.NVIDIA].zip` |
| Linux NVIDIA / CPU | `StemDeck-Linux-x64[.NVIDIA].tar.gz` |

GPU variant comes from the shipped `cpu-only` marker (present only in CPU packages), so a CPU-build user is offered the CPU update and an NVIDIA-build user the NVIDIA update. No match falls back to the release page.

## Server / Docker mode

No Tauri, so a desktop download is meaningless (the client browser's OS/arch is unrelated to the container). The modal instead shows:

- `docker pull ghcr.io/stemdeckapp/stemdeck:<tag>` (tag derived from the release, matching the published image tag) + "restart the container".
- A note that Unraid users update via the Community Applications template.

## Release notes rendering

`renderReleaseNotes` is a minimal XSS-safe markdown subset: headings, bold, `http(s)` links, bullet lists, fenced code blocks, and GitHub blockquote admonitions (the macOS `IMPORTANT` block). Escapes first, emits only whitelisted tags.

## Verification

Previewed live against the real `v0.8.0-alpha.12` release via headless Chrome in both modes:
- Desktop: modal renders notes correctly; Download resolves to a real per-arch asset URL.
- Server: Download hidden (confirmed via computed style), `docker pull` command resolves to the correct tag.
- `node --check` passes; `cargo check`/`clippy`/`fmt` clean for the added code.

## Also

Pins the Unraid template to `0.8.0-alpha.13` (separate commit). Note: that image must be published before Unraid users can pull it.