### PR TITLE
fix(desktop): hide mode-specific parts of the release modal

### DIFF
--- a/static/css/daw.css
+++ b/static/css/daw.css
@@ -2348,6 +2348,16 @@ input, textarea { font-family: inherit; }
 }
 .release-docker-note { margin: 0; font-size: 11px; color: var(--muted); }
 
+/* The release dialog lives outside `.daw`, so the scoped `.daw .hidden` rule
+   does not reach its inner elements and base.css's global `.hidden` is not
+   loaded on this page. Hide the mode-specific parts explicitly (same approach
+   as `.about-backdrop.hidden`) so desktop hides the docker block and server
+   hides the download button. */
+.release-docker.hidden,
+.release-card .about-link.hidden {
+  display: none !important;
+}
+
 /* The "New release available" card opens the dialog on click. */
 .daw-notif-release { cursor: pointer; }
 


### PR DESCRIPTION
## Bug

The release-notes modal (#321) toggles two mode-specific elements:
- the `docker pull` block (shown in server/Docker mode)
- the Download button (shown in desktop mode)

It hides the inactive one with the bare `.hidden` class. But this page only loads `variables.css`, `waves.css`, and `daw.css`. The only `.hidden` rule that sets `display:none` is the **scoped** `.daw .hidden`, and the dialog lives **outside** `.daw`; `base.css`'s global `.hidden` is not loaded on this page. So neither inner element was ever actually hidden.

Result:
- **Desktop app:** showed an empty "UPDATE YOUR SERVER" block below the Download button (the docker command is only populated in server mode, so the box was blank).
- **Server/Docker:** showed a meaningless desktop Download button next to the docker command.

The About dialog avoids this because it has its own explicit `.about-backdrop.hidden` rule rather than relying on the bare class.

## Fix

Add explicit rules (same approach as `.about-backdrop.hidden`):

```css
.release-docker.hidden,
.release-card .about-link.hidden { display: none !important; }
```

## Verification

Confirmed via `getComputedStyle` in a stubbed Tauri (desktop) vs plain browser (server), driving the real modal:

| Mode | docker block | Download button |
|---|---|---|
| Desktop (Tauri present) | `display:none` (hidden) | shown |
| Server (no Tauri) | shown | `display:none` (hidden) |

CSS-only change; `node --check` unaffected.

## Note

This bug shipped in `v0.8.0-alpha.13`. The desktop builds for that tag contain it; a follow-up release is needed to ship the fix to desktop users.