### PR TITLE
fix(export): re-enable Export All Stems after an export

### DIFF
--- a/static/js/catalog.js
+++ b/static/js/catalog.js
@@ -2368,7 +2368,7 @@ async function exportLogs(btn) {
     URL.revokeObjectURL(url);
   } catch (e) {
     console.warn("[settings] log export failed:", e);
-    showError("Could not export the logs.");
+    showError("Could not export the logs.", null, { retry: false });
   } finally {
     if (btn) { btn.disabled = false; btn.textContent = "Export logs"; }
   }

--- a/static/js/job.js
+++ b/static/js/job.js
@@ -66,7 +66,11 @@ function stopJobPolling() {
   }
 }
 
-export function showError(message, detail) {
+// `retry` controls the button: "Try again" sends the user back to the URL field
+// to start a fresh import, which is right for an import failure and wrong for
+// anything else. Export failures pass retry:false and get a plain Dismiss, since
+// the error box has no other way to be cleared.
+export function showError(message, detail, { retry = true } = {}) {
   errorEl.textContent = "";
   const msg = document.createElement("div");
   msg.className = "error-msg";
@@ -79,16 +83,18 @@ export function showError(message, detail) {
     detailEl.textContent = detail;
     msg.appendChild(detailEl);
   }
-  const retry = document.createElement("button");
-  retry.className = "retry-btn";
-  retry.type = "button";
-  retry.textContent = "Try again";
-  retry.addEventListener("click", () => {
+  const btn = document.createElement("button");
+  btn.className = "retry-btn";
+  btn.type = "button";
+  btn.textContent = retry ? "Try again" : "Dismiss";
+  btn.addEventListener("click", () => {
     errorEl.classList.add("hidden");
-    urlInput.focus();
-    urlInput.select();
+    if (retry) {
+      urlInput.focus();
+      urlInput.select();
+    }
   });
-  errorEl.append(msg, retry);
+  errorEl.append(msg, btn);
   errorEl.classList.remove("hidden");
 }
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -194,8 +194,14 @@ function wireFooterControls() {
     busy = false;
     exportBtn?.classList.remove("is-busy");
     if (exportLabel) exportLabel.textContent = "Export Mix";
-    itemMix?.removeAttribute("aria-disabled");
-    applyFormatState(); // restores stems/region per the active format
+    // Clear every row, not just the ones flashBusy could see: it disables via
+    // actionItems(), which filters on visibility, so a row hidden at reset time
+    // would keep the attribute forever. Under Tauri the panel is still open when
+    // flashBusy runs (invoke() returns without the synthetic <a> click that
+    // closes it in a browser), so all three get disabled and only a symmetric
+    // clear brings them back.
+    for (const it of [itemMix, itemStems, itemRegion]) it?.removeAttribute("aria-disabled");
+    applyFormatState(); // re-derives the region row's genuine disabled state
   }
 
   // Single-file (mix/region) downloads give no JS-observable byte progress, so

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -233,7 +233,7 @@ function wireFooterControls() {
     pending
       .catch((err) => {
         // A cancelled save dialog resolves, so anything here is a real failure.
-        showError(typeof err === "string" && err ? err : "Export failed.");
+        showError(typeof err === "string" && err ? err : "Export failed.", null, { retry: false });
       })
       .finally(() => {
         window.clearTimeout(backstop);
@@ -252,7 +252,7 @@ function wireFooterControls() {
     e.stopPropagation();
     if (busy) return;
     const ok = format === "mp4" ? downloadCurrentVideo() : downloadCurrentMix(format);
-    if (!ok) { showError("All stems are muted - nothing to export."); return; }
+    if (!ok) { showError("All stems are muted - nothing to export.", null, { retry: false }); return; }
     flashBusy(ok);
   });
 
@@ -260,7 +260,7 @@ function wireFooterControls() {
     e.stopPropagation();
     if (busy || itemRegion.getAttribute("aria-disabled") === "true") return;
     const ok = downloadRegionMix(format);
-    if (!ok) { showError("All stems are muted - nothing to export."); return; }
+    if (!ok) { showError("All stems are muted - nothing to export.", null, { retry: false }); return; }
     flashBusy(ok);
   });
 
@@ -270,7 +270,7 @@ function wireFooterControls() {
     e.stopPropagation();
     if (busy || itemStems.getAttribute("aria-disabled") === "true") return;
     const ok = downloadAllStemsZip(format);
-    if (!ok) { showError("No stems to export."); return; }
+    if (!ok) { showError("No stems to export.", null, { retry: false }); return; }
     flashBusy(ok);
   });
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -243,7 +243,7 @@ function wireFooterControls() {
   itemStems?.addEventListener("click", (e) => {
     e.stopPropagation();
     if (busy || itemStems.getAttribute("aria-disabled") === "true") return;
-    downloadAllStemsZip(format);
+    if (!downloadAllStemsZip(format)) { showError("No stems to export."); return; }
     flashBusy();
   });
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -204,15 +204,41 @@ function wireFooterControls() {
     applyFormatState(); // re-derives the region row's genuine disabled state
   }
 
-  // Single-file (mix/region) downloads give no JS-observable byte progress, so
-  // show a brief indeterminate "Exporting…" state, then reset.
-  function flashBusy() {
+  // How long to hold the indeterminate state when the host reports nothing back.
+  const EXPORT_FLASH_MS = 1200;
+  // Safety net for the promise path: a pending invoke that somehow never settles
+  // must not leave the menu disabled for the rest of the session (#335).
+  const EXPORT_BUSY_MAX_MS = 15 * 60 * 1000;
+  // Guards against a stale timer from a finished export resetting a later one.
+  let busyToken = 0;
+
+  // `pending` is whatever the download helper returned: a promise on desktop,
+  // where save_audio_file resolves once the file is written, or `true` in a
+  // browser, where an <a download> is fire-and-forget and there is nothing to
+  // wait on. Only the guess needs a fixed duration.
+  function flashBusy(pending) {
     busy = true;
+    const token = ++busyToken;
+    const finish = () => { if (token === busyToken) resetBusy(); };
     exportBtn?.classList.add("is-busy");
     if (exportLabel) exportLabel.textContent = "Exporting…";
     actionItems().forEach((it) => it?.setAttribute("aria-disabled", "true"));
     closePanel();
-    window.setTimeout(resetBusy, 1200);
+
+    if (!pending || typeof pending.then !== "function") {
+      window.setTimeout(finish, EXPORT_FLASH_MS);
+      return;
+    }
+    const backstop = window.setTimeout(finish, EXPORT_BUSY_MAX_MS);
+    pending
+      .catch((err) => {
+        // A cancelled save dialog resolves, so anything here is a real failure.
+        showError(typeof err === "string" && err ? err : "Export failed.");
+      })
+      .finally(() => {
+        window.clearTimeout(backstop);
+        finish();
+      });
   }
 
   exportBtn?.addEventListener("click", (e) => {
@@ -227,7 +253,7 @@ function wireFooterControls() {
     if (busy) return;
     const ok = format === "mp4" ? downloadCurrentVideo() : downloadCurrentMix(format);
     if (!ok) { showError("All stems are muted - nothing to export."); return; }
-    flashBusy();
+    flashBusy(ok);
   });
 
   itemRegion?.addEventListener("click", (e) => {
@@ -235,7 +261,7 @@ function wireFooterControls() {
     if (busy || itemRegion.getAttribute("aria-disabled") === "true") return;
     const ok = downloadRegionMix(format);
     if (!ok) { showError("All stems are muted - nothing to export."); return; }
-    flashBusy();
+    flashBusy(ok);
   });
 
   // All Stems = a single backend-built ZIP, named after the song. Audio-only,
@@ -243,8 +269,9 @@ function wireFooterControls() {
   itemStems?.addEventListener("click", (e) => {
     e.stopPropagation();
     if (busy || itemStems.getAttribute("aria-disabled") === "true") return;
-    if (!downloadAllStemsZip(format)) { showError("No stems to export."); return; }
-    flashBusy();
+    const ok = downloadAllStemsZip(format);
+    if (!ok) { showError("No stems to export."); return; }
+    flashBusy(ok);
   });
 
   // Keyboard: ↓ opens/moves into the menu, ↑/↓ cycle rows, Esc closes + restores focus.

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -1526,18 +1526,25 @@ export function updateFooterTrack({ title, thumbnail, key, bpm, stemCount } = {}
   }
 }
 
+// Returns a promise that settles when the file is actually on disk, or `true`
+// when the host gives no completion signal. Callers use the difference to show
+// a real "Exporting…" state instead of a fixed-length guess.
 function _triggerDownload(url, filename) {
   const fullUrl = url.startsWith("http") ? url : `${location.origin}${url}`;
   if (window.__TAURI__?.core?.invoke) {
-    window.__TAURI__.core.invoke("save_audio_file", { url: fullUrl, filename });
-    return;
+    // save_audio_file streams to a temp file and renames, resolving only once
+    // the whole body is written -- so this covers the save dialog and the copy.
+    return window.__TAURI__.core.invoke("save_audio_file", { url: fullUrl, filename });
   }
+  // A browser <a download> is fire-and-forget: the fetch is owned by the
+  // download manager and reports nothing back to the page.
   const a = document.createElement("a");
   a.href = fullUrl;
   a.download = filename;
   document.body.appendChild(a);
   a.click();
   a.remove();
+  return true;
 }
 
 // Per-lane effective gain mirroring mixer.js applyMix (volume + mute + solo),
@@ -1614,8 +1621,7 @@ function _exportFilename(ext) {
 export function downloadCurrentMix(ext = "wav") {
   const url = _mixdownUrl(ext, false);
   if (!url) return false;
-  _triggerDownload(url, _exportFilename(ext));
-  return true;
+  return _triggerDownload(url, _exportFilename(ext));
 }
 
 // MP4 export: the preserved source video muxed with the current audio mix.
@@ -1636,8 +1642,7 @@ export function downloadCurrentVideo() {
     .slice(0, 80)
     .replace(/^_+|_+$/g, "");
   const name = safe ? `${safe}_video.mp4` : "video.mp4";
-  _triggerDownload(`/api/jobs/${currentJobId}/video.mp4?${q}`, name);
-  return true;
+  return _triggerDownload(`/api/jobs/${currentJobId}/video.mp4?${q}`, name);
 }
 
 export function downloadCurrentStems(format = "wav", onProgress) {
@@ -1676,8 +1681,7 @@ export function downloadAllStemsZip(format = "wav") {
     .replace(/^_+|_+$/g, "");
   const name = safe ? `${safe}_stems.zip` : "stems.zip";
   const q = new URLSearchParams({ format, stems: names.join(",") });
-  _triggerDownload(`/api/jobs/${currentJobId}/stems/all.zip?${q}`, name);
-  return true;
+  return _triggerDownload(`/api/jobs/${currentJobId}/stems/all.zip?${q}`, name);
 }
 
 function _regionFilename(ext) {
@@ -1693,6 +1697,5 @@ export function downloadRegionMix(ext = "wav") {
   if (!loopEnabled || loopStart >= loopEnd) return false;
   const url = _mixdownUrl(ext, true);
   if (!url) return false;
-  _triggerDownload(url, _regionFilename(ext));
-  return true;
+  return _triggerDownload(url, _regionFilename(ext));
 }

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -1661,11 +1661,14 @@ export function downloadCurrentStems(format = "wav", onProgress) {
   });
 }
 
+// Returns false when there is nothing to zip, matching downloadCurrentMix and
+// downloadCurrentVideo, so the caller can skip the "Exporting…" state instead of
+// showing it for a download that never starts.
 export function downloadAllStemsZip(format = "wav") {
-  if (!currentJobId) return;
+  if (!currentJobId) return false;
   // Only the active (selected) stems loaded in the DAW — not all 6.
   const names = _currentStems.filter((s) => s.name !== "original").map((s) => s.name);
-  if (!names.length) return;
+  if (!names.length) return false;
   const safe = _currentTitle
     .replace(/[^a-zA-Z0-9]+/g, "_")
     .replace(/_{2,}/g, "_")
@@ -1674,6 +1677,7 @@ export function downloadAllStemsZip(format = "wav") {
   const name = safe ? `${safe}_stems.zip` : "stems.zip";
   const q = new URLSearchParams({ format, stems: names.join(",") });
   _triggerDownload(`/api/jobs/${currentJobId}/stems/all.zip?${q}`, name);
+  return true;
 }
 
 function _regionFilename(ext) {


### PR DESCRIPTION
Fixes #335, plus three adjacent defects in the same export state machine found while tracing it.

## 1. Export All Stems stuck disabled (#335)

### Symptom

After exporting once, "Export All Stems" is greyed out and unclickable for every song until the app is restarted.

Wider than the report: **any** export triggers it, not just the stems zip. Exporting a mix once kills the stems row for the rest of the session.

### Cause

`resetBusy()` cleared `aria-disabled` from the mix row and re-derived the region row via `applyFormatState()`, but never cleared the stems row. `flashBusy()` sets the attribute on all three. `.export-item[aria-disabled="true"]` is `opacity: 0.4; pointer-events: none`, and the DOM node is global, so it survives track switches and only a page reload clears it.

`itemStems` had four references in the codebase: set at one, read at one, never cleared.

### Why it never showed up in a browser

`_triggerDownload()` branches on the host:

- **Browser**: appends an `<a>` and clicks it. That synthetic click bubbles to the document handler and closes the chip panel *before* `flashBusy()` runs. `actionItems()` filters on `offsetParent !== null`, so with the panel closed it returns `[]` and nothing is disabled.
- **Tauri**: `invoke("save_audio_file")` returns without that click, the panel is still open, all three rows get disabled.

Desktop-only, which matches the Linux tar.gz report.

### Fix

Clear all three rows unconditionally instead of through the visibility-filtered `actionItems()`, keeping the set and clear paths symmetric. `applyFormatState()` still runs last so the region row's genuine "no loop selected" state is re-derived, not clobbered.

## 2. "Exporting..." shown when there is nothing to zip

`downloadAllStemsZip()` returns early when there is no current job or no stems loaded, but the click handler called `flashBusy()` regardless, so the button announced a 1200 ms export that never started. The mix and region rows both check their return value; this one did not.

Returns `false` on both early exits now, matching the contract `downloadCurrentMix` and `downloadCurrentVideo` already use.

## 3. Busy state was a fixed timer, not real completion

`flashBusy()` reset after 1200 ms no matter how long the export took, so a large stems zip reported done while ffmpeg was still working, and a failed save looked identical to a successful one.

`_triggerDownload()` now returns what the host can actually tell us:

- **Desktop**: the `invoke()` promise. `save_audio_file` is `async` and resolves only after the response is streamed to a temp file, `sync_all`'d and renamed, so it covers the save dialog and the copy.
- **Browser**: `true`. An `<a download>` hands the fetch to the download manager, which reports nothing back to the page, so the timed guess is kept there and only there.

`flashBusy()` waits on the promise when there is one. A rejection now surfaces the backend's message instead of passing for success.

Because this makes the busy state open-ended, two guards keep it from becoming a new instance of bug 1: a 15-minute backstop, and a generation token so a stale timer from a finished export cannot reset a later one.

## 4. Export errors offered "Try again", which went to the import field

`showError()` always rendered a "Try again" button that hid the error and moved focus to the URL import input. Correct for an import failure, wrong for an export failure, which has nothing to do with importing a track.

This was invisible until bug 3 was fixed: export failures never reached the error box, because the timer could not tell success from failure. `showError()` now takes `{ retry }`, defaulting to today's behaviour; the export call sites pass `retry: false` and get a plain Dismiss that clears the box without stealing focus.

## Verification

Playwright against a local server with real jobs, driving the actual export menu, with `window.__TAURI__` stubbed to reach the desktop branch.

Bug 1, before:

```
song A, before any export : {"stems":"null","stemsPointer":"auto","stemsOpacity":"1"}
song A, after Export Mix  : {"stems":"true","stemsPointer":"none","stemsOpacity":"0.4"}
song B (different track)  : {"stems":"true","stemsPointer":"none","stemsOpacity":"0.4"}
```

Bug 1, after:

```
song A, before any export : {"stems":"null","stemsPointer":"auto","stemsOpacity":"1"}
song A, after Export Mix  : {"stems":"null","stemsPointer":"auto","stemsOpacity":"1"}
song B (different track)  : {"stems":"null","stemsPointer":"auto","stemsOpacity":"1"}
```

Bug 3, stubbing `invoke` to resolve after 4 s, to reject, and removing `__TAURI__` entirely:

```
slow     -> cleared after 4094ms
reject   -> cleared after 545ms, error: "disk is full"
browser  -> cleared after 1277ms
```

The slow case held the busy state for the real 4 s rather than the old 1200 ms; the browser case still uses the flash, since there is nothing to wait on.

Bug 4, both paths:

```
export failure  : {"text":"disk is full","btn":"Dismiss","visible":true}
after Dismiss   : {"hidden":true,"focused":"BODY"}
import failure  : {"label":"Try again","focused":"url","hidden":true}
```

Also checked:

- The error box is genuinely visible in the player view, not just present in the DOM (`display: block`, in viewport, 65 px tall).
- Full recovery after a failed export: `{"busy":false,"stems":"null","mix":"null"}`.
- MP4 mode: both rows are `display: none` there, so the unconditional clear cannot surface a wrongly-enabled control, and leaving MP4 restores the region row's real state (`region: "true"` with no loop selected).
- No page errors or unhandled promise rejections across every path exercised.
- No other consumers of the four download helpers whose return type changed; `main.js` is the only caller.
- Browser path unchanged end to end, second consecutive zip export still downloads.
- `node --check` passes on every file in `static/js/`.

Settings had the same wart at the log-export call site, fixed here too.

## Behaviour changes worth knowing

Consequences of tracking real completion, not defects:

- The export menu is now locked for the real duration of an export rather than ~1.2 s, so a second export cannot be started until the first finishes, including after switching songs. Left as-is deliberately: one export at a time is arguably correct, and nobody has asked for the old behaviour.
- "Exporting..." appears while the native save dialog is open, before any bytes move, because `save_audio_file` shows the picker before fetching. Splitting those phases needs a Rust change, filed as #338.

## Follow-ups filed

- #338 - separate the save dialog from the transfer so the busy label is accurate
- #339 - no automated tests for frontend behaviour, which is why #335 shipped and why all four defects here were found by throwaway scripts

## Scope

Frontend only: `static/js/main.js`, `static/js/player.js`, `static/js/job.js`, `static/js/catalog.js`. No backend or Rust changes; the desktop command already resolved at the right moment, nothing was listening for it.