### PR TITLE
feat(export): name every export after its song

### DIFF
--- a/app/api/stems.py
+++ b/app/api/stems.py
@@ -412,6 +412,18 @@ async def get_beat_grid(job_id: str) -> Response:
     )
 
 
+def _stem_download_name(job_id: str, name: str, ext: str, suffix: str = "") -> str:
+    """Filename offered for a single stem, prefixed with the song (#336).
+
+    Content-Disposition wins over an <a download> attribute for same-origin
+    requests, so the server has to carry the name for the browser to honour it.
+    """
+    job = registry_get(job_id)
+    slug = _title_slug(job.title if job else None)
+    stem = f"{name}{suffix}"
+    return f"{slug}_{stem}.{ext}" if slug else f"{stem}.{ext}"
+
+
 @router.api_route("/jobs/{job_id}/stems/{name}.wav", methods=["GET", "HEAD"], response_model=None)
 async def get_stem(
     job_id: str,
@@ -427,7 +439,9 @@ async def get_stem(
     path = _validate_stem_path(job_id, name)
 
     if start is None and end is None:
-        return FileResponse(path, media_type="audio/wav", filename=f"{name}.wav")
+        return FileResponse(
+            path, media_type="audio/wav", filename=_stem_download_name(job_id, name, "wav")
+        )
 
     if start is None or end is None or start >= end:
         raise HTTPException(
@@ -455,7 +469,11 @@ async def get_stem(
     return StreamingResponse(
         _stream_ffmpeg(cmd, context=f"stem-region job={job_id} stem={name}"),
         media_type="audio/wav",
-        headers={"Content-Disposition": f'attachment; filename="{name}_region.wav"'},
+        headers={
+            "Content-Disposition": (
+                f'attachment; filename="{_stem_download_name(job_id, name, "wav", "_region")}"'
+            )
+        },
     )
 
 
@@ -484,7 +502,9 @@ async def get_stem_mp3(
             cached,
             media_type="audio/mpeg",
             headers={
-                "Content-Disposition": f'attachment; filename="{name}.mp3"',
+                "Content-Disposition": (
+                    f'attachment; filename="{_stem_download_name(job_id, name, "mp3")}"'
+                ),
                 # Stems are immutable once a job is done — let the phone cache
                 # them so a re-load is instant and offline-friendly.
                 "Cache-Control": "public, max-age=31536000, immutable",
@@ -613,11 +633,21 @@ async def get_mixdown(
     )
 
 
-def _safe_title(title: str | None) -> str:
-    """Sanitize a song title into a filename-safe slug (matches the frontend)."""
+def _title_slug(title: str | None) -> str:
+    """Sanitize a song title into a filename-safe slug (matches the frontend).
+
+    Returns "" for a title that survives sanitizing as empty, so callers can
+    decide whether to substitute a fallback or drop the prefix entirely. The
+    output is restricted to [A-Za-z0-9_], which also makes it safe to use as a
+    ZIP member name -- no separators, no traversal.
+    """
     safe = re.sub(r"[^a-zA-Z0-9]+", "_", title or "")
-    safe = re.sub(r"_{2,}", "_", safe).strip("_")[:80].strip("_")
-    return safe or "stems"
+    return re.sub(r"_{2,}", "_", safe).strip("_")[:80].strip("_")
+
+
+def _safe_title(title: str | None) -> str:
+    """Slug for a whole-archive filename, where an empty title still needs a name."""
+    return _title_slug(title) or "stems"
 
 
 @router.get("/jobs/{job_id}/video.mp4", response_model=None)
@@ -704,14 +734,23 @@ async def get_video_mixdown(
     )
 
 
-def _build_stems_zip(sources: list[tuple[str, Path]], fmt: str, dest: Path) -> None:
+def _arcname(prefix: str, name: str, ext: str) -> str:
+    """ZIP member name for one stem. Prefixed with the song slug so the files stay
+    identifiable once extracted into a project folder alongside other songs'
+    stems (#336); unprefixed when the song has no usable title."""
+    return f"{prefix}_{name}.{ext}" if prefix else f"{name}.{ext}"
+
+
+def _build_stems_zip(
+    sources: list[tuple[str, Path]], fmt: str, dest: Path, prefix: str = ""
+) -> None:
     """Blocking: write the stems into a ZIP. WAV files are stored as-is; MP3,
     FLAC, and OGG are transcoded per stem via ffmpeg. ZIP_STORED throughout - audio doesn't
     meaningfully compress, and STORED keeps the build fast. Runs in a thread."""
     if fmt == "wav":
         with zipfile.ZipFile(dest, "w", zipfile.ZIP_STORED) as zf:
             for name, p in sources:
-                zf.write(p, arcname=f"{name}.wav")
+                zf.write(p, arcname=_arcname(prefix, name, "wav"))
         return
     encode = _ENCODE_ARGS[fmt]
     with tempfile.TemporaryDirectory() as td, zipfile.ZipFile(dest, "w", zipfile.ZIP_STORED) as zf:
@@ -739,7 +778,7 @@ def _build_stems_zip(sources: list[tuple[str, Path]], fmt: str, dest: Path) -> N
             if proc.returncode != 0:
                 tail = proc.stderr[-2000:].decode("utf-8", "replace")
                 raise RuntimeError(f"ffmpeg failed for {name}: {tail}")
-            zf.write(out, arcname=f"{name}.{fmt}")
+            zf.write(out, arcname=_arcname(prefix, name, fmt))
 
 
 @router.get("/jobs/{job_id}/stems/all.zip")
@@ -786,7 +825,7 @@ async def get_all_stems_zip(
     os.close(fd)
     tmp_path = Path(tmp)
     try:
-        await asyncio.to_thread(_build_stems_zip, sources, fmt, tmp_path)
+        await asyncio.to_thread(_build_stems_zip, sources, fmt, tmp_path, _title_slug(job.title))
     except Exception:
         tmp_path.unlink(missing_ok=True)
         logger.exception("failed to build stems zip for job %s", job_id)

--- a/app/api/stems.py
+++ b/app/api/stems.py
@@ -529,7 +529,8 @@ async def get_stem_mp3(
         "mp3",
         "pipe:1",
     ]
-    filename = f"{name}_region.mp3" if start is not None else f"{name}.mp3"
+    # Only the trimmed branch reaches here; the untrimmed one returned above.
+    filename = _stem_download_name(job_id, name, "mp3", "_region")
     return StreamingResponse(
         _stream_ffmpeg(cmd, context=f"stem-mp3 job={job_id} stem={name}"),
         media_type="audio/mpeg",

--- a/app/api/stems.py
+++ b/app/api/stems.py
@@ -538,6 +538,16 @@ async def get_stem_mp3(
     )
 
 
+def _mixdown_download_name(job_id: str, ext: str, is_region: bool) -> str:
+    """Filename offered for a mixdown, prefixed with the song like the stems
+    (#336). Mirrors the names the frontend builds, because Content-Disposition
+    overrides an <a download> attribute and the two must not disagree."""
+    job = registry_get(job_id)
+    slug = _title_slug(job.title if job else None)
+    kind = "region" if is_region else "exported_mix"
+    return f"{slug}_{kind}.{ext}" if slug else f"{kind}.{ext}"
+
+
 @router.get("/jobs/{job_id}/mixdown.{ext}", response_model=None)
 async def get_mixdown(
     job_id: str,
@@ -584,7 +594,11 @@ async def get_mixdown(
         return FileResponse(
             cache_path,
             media_type=media_type,
-            headers={"Content-Disposition": f'attachment; filename="mixdown.{ext}"'},
+            headers={
+                "Content-Disposition": (
+                    f'attachment; filename="{_mixdown_download_name(job_id, ext, start is not None)}"'
+                )
+            },
         )
 
     pre_seek = ["-ss", str(start)] if start is not None else []
@@ -630,7 +644,11 @@ async def get_mixdown(
             cmd, context=f"mixdown job={job_id} ext={ext} stems={stems}", cache_path=cache_path
         ),
         media_type=media_type,
-        headers={"Content-Disposition": f'attachment; filename="mixdown.{ext}"'},
+        headers={
+            "Content-Disposition": (
+                f'attachment; filename="{_mixdown_download_name(job_id, ext, start is not None)}"'
+            )
+        },
     )
 
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -455,10 +455,19 @@ document.addEventListener("keydown", (e) => {
 document.addEventListener("click", (e) => {
   const dl = e.target.closest("a.lane-dl");
   if (dl?.href) {
-    const openUrl = window.__TAURI__?.core?.invoke;
-    if (openUrl) {
+    const invoke = window.__TAURI__?.core?.invoke;
+    // A download attribute is meaningless to the OS handler, so open_url used to
+    // hand the stem to a browser or media player instead of saving it. Save it
+    // like every other export, which also honours the song-prefixed name (#336).
+    // Placeholder rows for absent stems keep href="#" and carry no name.
+    if (invoke && dl.download && !dl.getAttribute("href").endsWith("#")) {
       e.preventDefault();
-      openUrl("open_url", { url: dl.href });
+      invoke("save_audio_file", { url: dl.href, filename: dl.download });
+      return;
+    }
+    if (invoke) {
+      e.preventDefault();
+      invoke("open_url", { url: dl.href });
     }
     return;
   }

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -1008,7 +1008,7 @@ export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, ti
     const dl = row.querySelector(".lane-dl");
     if (dl) {
       dl.href = stem.url;
-      dl.download = `${stem.name}.wav`;
+      dl.download = _stemFilename(stem.name);
     }
   }
 
@@ -1604,6 +1604,18 @@ function _mixdownUrl(ext, region) {
   }
   _clickParams(q);
   return `/api/jobs/${currentJobId}/mixdown.${ext}?${q}`;
+}
+
+// One stem, named after the song so it stays identifiable once dragged into a
+// project folder next to other songs' stems (#336). Falls back to the bare stem
+// name when the song has no usable title.
+function _stemFilename(name, ext = "wav") {
+  const safe = _currentTitle
+    .replace(/[^a-zA-Z0-9]+/g, "_")
+    .replace(/_{2,}/g, "_")
+    .slice(0, 80)
+    .replace(/^_+|_+$/g, "");
+  return safe ? `${safe}_${name}.${ext}` : `${name}.${ext}`;
 }
 
 function _exportFilename(ext) {

--- a/tests/test_stems_api.py
+++ b/tests/test_stems_api.py
@@ -72,6 +72,37 @@ def test_serves_done_job_stem(client, tmp_path):
     assert r.headers["content-type"] == "audio/wav"
 
 
+def test_single_stem_download_is_named_after_the_song(client, tmp_path):
+    """Content-Disposition beats an <a download> attribute for same-origin
+    requests, so the prefix (#336) has to come from the server to be honoured."""
+    job = Job(id="abcdef000339")
+    job.status = "done"
+    job.title = "Come As You Are"
+    _jobs[job.id] = job
+    _make_stem_file(tmp_path, job.id, "bass", b"RIFF1234")
+    r = client.get(f"/api/jobs/{job.id}/stems/bass.wav")
+    assert 'filename="Come_As_You_Are_bass.wav"' in r.headers["content-disposition"]
+
+
+def test_single_stem_region_download_keeps_both_song_and_region(client, tmp_path):
+    _skip_without_ffmpeg()
+    job = _done_job_with_stems(tmp_path, "abcdef00033a", ["vocals"])
+    job.title = "Come As You Are"
+    r = client.get(f"/api/jobs/{job.id}/stems/vocals.wav?start=0&end=0.05")
+    assert r.status_code == 200
+    assert 'filename="Come_As_You_Are_vocals_region.wav"' in r.headers["content-disposition"]
+
+
+def test_single_stem_download_falls_back_to_the_bare_name(client, tmp_path):
+    """An untitled job must not produce a leading-underscore filename."""
+    job = Job(id="abcdef00033b")
+    job.status = "done"
+    _jobs[job.id] = job
+    _make_stem_file(tmp_path, job.id, "bass", b"RIFF1234")
+    r = client.get(f"/api/jobs/{job.id}/stems/bass.wav")
+    assert 'filename="bass.wav"' in r.headers["content-disposition"]
+
+
 # --- peaks endpoint ---
 
 
@@ -142,8 +173,12 @@ def test_all_stems_zip_all_when_no_subset(client, tmp_path):
     assert "My_Song_Live_stems.zip" in r.headers["content-disposition"]
 
     zf = zipfile.ZipFile(io.BytesIO(r.content))
-    assert sorted(zf.namelist()) == ["bass.wav", "drums.wav", "vocals.wav"]
-    assert zf.read("vocals.wav") == b"RIFFvocals"
+    assert sorted(zf.namelist()) == [
+        "My_Song_Live_bass.wav",
+        "My_Song_Live_drums.wav",
+        "My_Song_Live_vocals.wav",
+    ]
+    assert zf.read("My_Song_Live_vocals.wav") == b"RIFFvocals"
 
 
 def test_all_stems_zip_only_active_subset(client, tmp_path):
@@ -161,6 +196,59 @@ def test_all_stems_zip_only_active_subset(client, tmp_path):
     assert r.status_code == 200
     zf = zipfile.ZipFile(io.BytesIO(r.content))
     assert sorted(zf.namelist()) == ["bass.wav", "vocals.wav"]
+
+
+def test_all_stems_zip_prefixes_members_with_the_song(client, tmp_path):
+    """Extracted stems land in whatever folder the user is working in, next to
+    other songs' stems, so a bare "bass.wav" is ambiguous and collides (#336)."""
+    import io
+    import zipfile
+
+    job = Job(id="abcdef000336")
+    job.status = "done"
+    job.title = "Come As You Are"
+    _jobs[job.id] = job
+    _make_stem_file(tmp_path, job.id, "bass", b"RIFFbass")
+    _make_stem_file(tmp_path, job.id, "vocals", b"RIFFvocals")
+
+    zf = zipfile.ZipFile(io.BytesIO(client.get(f"/api/jobs/{job.id}/stems/all.zip").content))
+    assert sorted(zf.namelist()) == ["Come_As_You_Are_bass.wav", "Come_As_You_Are_vocals.wav"]
+    # The prefix must not disturb the payload.
+    assert zf.read("Come_As_You_Are_bass.wav") == b"RIFFbass"
+
+
+def test_all_stems_zip_omits_the_prefix_when_the_title_is_unusable(client, tmp_path):
+    """A title of pure punctuation sanitizes to nothing; prefixing anyway would
+    produce a leading underscore on every member."""
+    import io
+    import zipfile
+
+    job = Job(id="abcdef000337")
+    job.status = "done"
+    job.title = "!!! ???"
+    _jobs[job.id] = job
+    _make_stem_file(tmp_path, job.id, "vocals")
+
+    zf = zipfile.ZipFile(io.BytesIO(client.get(f"/api/jobs/{job.id}/stems/all.zip").content))
+    assert zf.namelist() == ["vocals.wav"]
+
+
+def test_all_stems_zip_member_names_cannot_escape_on_extraction(client, tmp_path):
+    """The member name is derived from a user-controlled title, and an archive
+    member is a path at extraction time. Separators must not survive."""
+    import io
+    import zipfile
+
+    job = Job(id="abcdef000338")
+    job.status = "done"
+    job.title = "../../etc/passwd"
+    _jobs[job.id] = job
+    _make_stem_file(tmp_path, job.id, "vocals")
+
+    zf = zipfile.ZipFile(io.BytesIO(client.get(f"/api/jobs/{job.id}/stems/all.zip").content))
+    assert zf.namelist() == ["etc_passwd_vocals.wav"]
+    for member in zf.namelist():
+        assert "/" not in member and "\\" not in member and ".." not in member
 
 
 def test_all_stems_zip_rejects_unknown_stem(client, tmp_path):
@@ -232,8 +320,8 @@ def test_all_stems_zip_mp3(client, tmp_path):
     r = client.get(f"/api/jobs/{job.id}/stems/all.zip?format=mp3")
     assert r.status_code == 200
     zf = zipfile.ZipFile(io.BytesIO(r.content))
-    assert zf.namelist() == ["vocals.mp3"]
-    assert len(zf.read("vocals.mp3")) > 0
+    assert zf.namelist() == ["Track_vocals.mp3"]
+    assert len(zf.read("Track_vocals.mp3")) > 0
 
 
 def test_all_stems_zip_ogg(client, tmp_path):
@@ -266,8 +354,8 @@ def test_all_stems_zip_ogg(client, tmp_path):
     r = client.get(f"/api/jobs/{job.id}/stems/all.zip?format=ogg")
     assert r.status_code == 200
     zf = zipfile.ZipFile(io.BytesIO(r.content))
-    assert zf.namelist() == ["vocals.ogg"]
-    ogg_bytes = zf.read("vocals.ogg")
+    assert zf.namelist() == ["Track_vocals.ogg"]
+    ogg_bytes = zf.read("Track_vocals.ogg")
     assert ogg_bytes.startswith(b"OggS")
 
 
@@ -575,8 +663,8 @@ def test_all_stems_zip_flac(client, tmp_path):
     r = client.get(f"/api/jobs/{job.id}/stems/all.zip?format=flac")
     assert r.status_code == 200
     zf = zipfile.ZipFile(io.BytesIO(r.content))
-    assert zf.namelist() == ["vocals.flac"]
-    assert zf.read("vocals.flac")[:4] == b"fLaC"
+    assert zf.namelist() == ["Track_vocals.flac"]
+    assert zf.read("Track_vocals.flac")[:4] == b"fLaC"
 
 
 # --- MP4 video mux endpoint (#219) ---

--- a/tests/test_stems_api.py
+++ b/tests/test_stems_api.py
@@ -102,6 +102,35 @@ def test_single_stem_mp3_region_download_keeps_both_song_and_region(client, tmp_
     assert 'filename="Come_As_You_Are_vocals_region.mp3"' in r.headers["content-disposition"]
 
 
+def test_mixdown_download_is_named_after_the_song(client, tmp_path):
+    """The mix had the same hardcoded name every stem did: "mixdown.wav" for
+    every song, so exporting several into one folder collided (#336)."""
+    _skip_without_ffmpeg()
+    job = _done_job_with_stems(tmp_path, "abcdef00033d", ["vocals"])
+    job.title = "Come As You Are"
+    r = client.get(f"/api/jobs/{job.id}/mixdown.wav?stems=vocals&gains=1.0")
+    assert r.status_code == 200
+    assert 'filename="Come_As_You_Are_exported_mix.wav"' in r.headers["content-disposition"]
+
+
+def test_mixdown_region_download_is_marked_as_a_region(client, tmp_path):
+    _skip_without_ffmpeg()
+    job = _done_job_with_stems(tmp_path, "abcdef00033e", ["vocals"])
+    job.title = "Come As You Are"
+    r = client.get(f"/api/jobs/{job.id}/mixdown.wav?stems=vocals&gains=1.0&start=0&end=0.05")
+    assert r.status_code == 200
+    assert 'filename="Come_As_You_Are_region.wav"' in r.headers["content-disposition"]
+
+
+def test_mixdown_download_falls_back_without_a_title(client, tmp_path):
+    _skip_without_ffmpeg()
+    job = _done_job_with_stems(tmp_path, "abcdef00033f", ["vocals"])
+    job.title = None  # the helper presets one; an untitled job is the case here
+    r = client.get(f"/api/jobs/{job.id}/mixdown.wav?stems=vocals&gains=1.0")
+    assert r.status_code == 200
+    assert 'filename="exported_mix.wav"' in r.headers["content-disposition"]
+
+
 def test_single_stem_download_falls_back_to_the_bare_name(client, tmp_path):
     """An untitled job must not produce a leading-underscore filename."""
     job = Job(id="abcdef00033b")

--- a/tests/test_stems_api.py
+++ b/tests/test_stems_api.py
@@ -93,6 +93,15 @@ def test_single_stem_region_download_keeps_both_song_and_region(client, tmp_path
     assert 'filename="Come_As_You_Are_vocals_region.wav"' in r.headers["content-disposition"]
 
 
+def test_single_stem_mp3_region_download_keeps_both_song_and_region(client, tmp_path):
+    _skip_without_ffmpeg()
+    job = _done_job_with_stems(tmp_path, "abcdef00033c", ["vocals"])
+    job.title = "Come As You Are"
+    r = client.get(f"/api/jobs/{job.id}/stems/vocals.mp3?start=0&end=0.05")
+    assert r.status_code == 200
+    assert 'filename="Come_As_You_Are_vocals_region.mp3"' in r.headers["content-disposition"]
+
+
 def test_single_stem_download_falls_back_to_the_bare_name(client, tmp_path):
     """An untitled job must not produce a leading-underscore filename."""
     job = Job(id="abcdef00033b")


### PR DESCRIPTION
Closes #336.

## Problem

Stems export as `bass.wav`, `vocals.wav`, `drums.wav`. As the reporter put it, that makes them unusable for file management: drop two songs' stems into one project folder and they are indistinguishable, and identically-named files overwrite each other.

Tracing it turned up the same defect in the mix export, which downloaded as `mixdown.wav` for every song.

## What changed

Every file the user exports is now named after its song:

```
05_Welcome_To_Paradise_Green_Day_Dookie_bass.wav
05_Welcome_To_Paradise_Green_Day_Dookie_vocals.wav
05_Welcome_To_Paradise_Green_Day_Dookie_exported_mix.wav
```

Covering every path that hands a file to the user:

| Path | Before | After |
|---|---|---|
| ZIP members | `bass.wav` | `<Song>_bass.wav` |
| Single stem | `bass.wav` | `<Song>_bass.wav` |
| Single stem, region | `bass_region.wav` | `<Song>_bass_region.wav` |
| Stem MP3 | `bass.mp3` | `<Song>_bass.mp3` |
| Stem MP3, region | `bass_region.mp3` | `<Song>_bass_region.mp3` |
| Mixdown | `mixdown.wav` | `<Song>_exported_mix.wav` |
| Mixdown, region | `mixdown.wav` | `<Song>_region.wav` |
| Video | already correct | unchanged |

## Two things worth reviewing

**The server has to carry the name.** Setting the `<a download>` attribute alone did nothing: `Content-Disposition` wins over it for same-origin requests, and the routes were already sending `filename="bass.wav"` / `filename="mixdown.wav"`. This was caught in testing, when a correct `download` attribute still produced a `bass.wav` download. The attribute is set as well, as the fallback for any response without the header.

This is also why the mix bug survived unnoticed: desktop users never saw it, because `save_audio_file` uses the frontend's filename rather than the header.

**The desktop per-stem download did not download.** Clicking the stem download icon routed through `open_url`, which spawns the OS handler, so the stem opened in a browser or media player and was never saved. No filename applied at all, meaning this feature would have done nothing for per-stem downloads on the reporter's platform. It now goes through `save_audio_file` like every other export, giving a real Save dialog with the prefixed name.

## Naming

`_` and lowercase, matching what the app already produced (`Song_exported_mix.wav`, `Song_region.wav`, `Song_stems.zip`). The reporter asked for `[TrackName]-Bass`; the prefix is the substance of the request and house consistency won on the separator.

`_safe_title` is split in two:

- `_title_slug` returns `""` for a title that sanitizes to nothing
- `_safe_title` keeps the `"stems"` fallback for the whole-archive filename

A per-file prefix must be droppable, otherwise an untitled job produces `_bass.wav` on every member.

## Verification

Nine new tests in `tests/test_stems_api.py`:

- ZIP members carry the prefix and the payload is unchanged
- Untitled and punctuation-only titles fall back to bare names, no leading underscore
- Single-stem, stem-region, stem-MP3-region and untitled `Content-Disposition` names
- Mixdown, mixdown-region and untitled mixdown names
- Member names cannot escape on extraction: a title of `../../etc/passwd` yields `etc_passwd_vocals.wav`, and no member contains a separator or `..`

Manual, against a real job with real audio:

```
$ curl .../stems/all.zip?stems=vocals,bass
   05_Welcome_To_Paradise_Green_Day_Dookie_vocals.wav  39634992 bytes
   05_Welcome_To_Paradise_Green_Day_Dookie_bass.wav    39634992 bytes

$ curl -I .../stems/bass.wav
content-disposition: attachment; filename="05_Welcome_To_Paradise_Green_Day_Dookie_bass.wav"
```

Playwright, driving the real controls in both host modes:

```
per-stem, browser : 05_Welcome_To_Paradise_Green_Day_Dookie_bass.wav
per-stem, tauri   : {"cmd":"save_audio_file",
                     "filename":"05_Welcome_To_Paradise_Green_Day_Dookie_bass.wav"}
Export Mix, browser: 05_Welcome_To_Paradise_Green_Day_Dookie_exported_mix.wav   (was mixdown.wav)
```

`398 passed` on the full suite. One pre-existing failure, `test_all_stems_zip_ogg`, fails identically on `main` because the local ffmpeg has no libvorbis encoder; it passes in CI. `ruff check`, `ruff format --check` and `node --check` all clean.

## Scope

`app/api/stems.py`, `static/js/player.js`, `static/js/main.js`, `tests/test_stems_api.py`. No Rust changes; `save_audio_file` already did the right thing and simply was not being called.