### PR TITLE
chore(unraid): pin template to 0.8.0-alpha.17

### DIFF
--- a/templates/stemdeck.xml
+++ b/templates/stemdeck.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>StemDeck</Name>
-  <Repository>ghcr.io/stemdeckapp/stemdeck:0.8.0-alpha.16</Repository>
+  <Repository>ghcr.io/stemdeckapp/stemdeck:0.8.0-alpha.17</Repository>
   <Registry>https://github.com/stemdeckapp/stemdeck/pkgs/container/stemdeck</Registry>
   <Network>bridge</Network>
   <Shell>sh</Shell>


### PR DESCRIPTION
Points the Unraid Community Applications template at the alpha 17 image, ahead of cutting that release.

Merged before tagging deliberately, so the commit `v0.8.0-alpha.17` points at already carries the correct pin. Pinning after the tag would leave the tagged tree referencing the previous image.

Note the ordering consequence: between this merging and the alpha 17 image being published, `main` names a tag that does not exist yet. A fresh Unraid install pulling in that window would fail until the build finishes. The window is short and no existing install is affected, since Unraid only pulls on install or update.

Nothing else in the template changes.