### PR TITLE
build(linux): stage desktop-entry assets into the portable tarball

### DIFF
--- a/packaging/linux/stemdeck.desktop.in
+++ b/packaging/linux/stemdeck.desktop.in
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Type=Application
+Version=1.0
+Name=StemDeck
+GenericName=Stem Separation
+Comment=Free, local stem separation for music production and practice
+Exec="@EXEC@"
+Icon=@ICON@
+Terminal=false
+StartupNotify=true
+StartupWMClass=StemDeck
+Categories=AudioVideo;Audio;Music;
+Keywords=stems;separation;audio;vocals;drums;bass;karaoke;demucs;

--- a/scripts/linux/make-portable.sh
+++ b/scripts/linux/make-portable.sh
@@ -148,6 +148,15 @@ printf '{ "version": "%s" }\n' "$RESOLVED_VERSION" > "$BACKEND_DIR/static/versio
 cp "$REPO_ROOT/packaging/linux/README-LINUX.txt" "$STAGE/README-LINUX.txt"
 cp "$REPO_ROOT/packaging/linux/THIRD_PARTY_NOTICES.txt" "$STAGE/THIRD_PARTY_NOTICES.txt"
 
+# Desktop-entry assets for the optional installer (#360). Carried inside the
+# package so the installer needs no second download and no asset URL that could
+# drift from the release it is installing. The Tauri icon is already square, so
+# it doubles as the desktop icon with no separate artwork to keep in sync.
+echo "==> Staging desktop-entry assets"
+mkdir -p "$STAGE/packaging"
+cp "$REPO_ROOT/desktop/src-tauri/icons/icon.png" "$STAGE/packaging/stemdeck.png"
+cp "$REPO_ROOT/packaging/linux/stemdeck.desktop.in" "$STAGE/packaging/stemdeck.desktop.in"
+
 # CPU-only marker: read by is_cpu_only_package so the shell skips GPU detection.
 # Omitted for the NVIDIA variant so the shell detects the GPU and uses CUDA.
 if [[ "$CPU_ONLY" == "1" ]]; then

--- a/tests/test_packaging_linux.py
+++ b/tests/test_packaging_linux.py
@@ -1,0 +1,71 @@
+"""The Linux desktop-entry assets staged into the portable tarball (#360).
+
+These are plain data files with no code path to exercise them until the
+installer lands (#361), so the things worth pinning are the ones that fail
+silently at the user's end: a launcher that will not start, or an icon the
+packaging script cannot find.
+"""
+
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE = ROOT / "packaging" / "linux" / "stemdeck.desktop.in"
+ICON = ROOT / "desktop" / "src-tauri" / "icons" / "icon.png"
+MAKE_PORTABLE = ROOT / "scripts" / "linux" / "make-portable.sh"
+
+
+def _entries() -> dict[str, str]:
+    lines = TEMPLATE.read_text(encoding="utf-8").splitlines()
+    assert lines[0] == "[Desktop Entry]", "the group header must come first"
+    return dict(line.split("=", 1) for line in lines[1:] if line and not line.startswith("#"))
+
+
+def test_exec_is_quoted_so_a_path_with_spaces_still_launches():
+    """The freedesktop spec splits Exec on whitespace.
+
+    The reference installer in #342 emitted an unquoted Exec, so installing to
+    a directory such as ~/My Apps produced an entry that tried to run a binary
+    called ".../My". Quoting is the whole fix, and it is invisible until
+    someone picks a custom path.
+    """
+    exec_line = _entries()["Exec"].replace("@EXEC@", "/home/u/My Apps/StemDeck-Linux-x64/StemDeck")
+    assert shlex.split(exec_line) == ["/home/u/My Apps/StemDeck-Linux-x64/StemDeck"]
+
+
+def test_placeholders_are_present_for_the_installer_to_substitute():
+    entries = _entries()
+    assert "@EXEC@" in entries["Exec"]
+    assert entries["Icon"] == "@ICON@"
+
+
+@pytest.mark.parametrize("key", ["Type", "Name", "Exec", "Icon", "Categories"])
+def test_required_keys_are_present(key):
+    assert key in _entries()
+
+
+def test_type_and_categories_are_registered_values():
+    entries = _entries()
+    assert entries["Type"] == "Application"
+    cats = [c for c in entries["Categories"].split(";") if c]
+    # A registered main category is required; Audio and Music are additional
+    # ones that only carry meaning alongside it.
+    assert "AudioVideo" in cats
+    assert "Multimedia" not in cats, "Multimedia is not a registered category"
+    assert entries["Categories"].endswith(";"), "the list must be semicolon-terminated"
+
+
+def test_the_icon_the_packaging_script_copies_exists():
+    """make-portable.sh copies this by path. A move would break the Linux build
+    at package time, long after the change that caused it."""
+    assert ICON.is_file()
+
+
+def test_make_portable_stages_both_assets():
+    script = MAKE_PORTABLE.read_text(encoding="utf-8")
+    assert "packaging/stemdeck.png" in script
+    assert "packaging/stemdeck.desktop.in" in script


### PR DESCRIPTION
Closes #360. Prep for #342.

Adds two data files to the Linux tarball and nothing else. No runtime behaviour changes, and the package still runs in place when extracted.

```
StemDeck-Linux-x64/
  packaging/
    stemdeck.png            # desktop/src-tauri/icons/icon.png, already square
    stemdeck.desktop.in     # Exec= and Icon= substituted at install time
```

## Why in the tarball

It is what lets the installer be self-contained: no second download, no checksum step, and no raw asset URL pointing at a branch that can drift from the release being installed. The version and variant it needs are already in the package too, in `backend/static/version.json` and the `cpu-only` marker.

## The one substantive detail

`Exec=` is quoted. The freedesktop spec splits `Exec` on whitespace, so the unquoted form used by the reference installer in #342 generates an entry that tries to run `/home/u/My` when installed to `~/My Apps`:

```
parsed into: ['/home/u/My', 'Apps/StemDeck-Linux-x64/StemDeck']
```

That is invisible until someone picks a custom directory, so `tests/test_packaging_linux.py` pins it. Removing the quotes fails that test, verified.

## Verification

- Replayed the staging block against a temp stage: both files land at the right paths, icon is 1024x1024 RGBA.
- Substituted a path containing a space and confirmed `shlex.split` yields a single argument.
- `bash -n scripts/linux/make-portable.sh` clean.
- 10 new tests; full suite 536 passed.
- `tests/test_stems_api.py::test_all_stems_zip_ogg` fails identically on clean `main` (local ffmpeg has no `libvorbis`, and the test's skip guard only checks that ffmpeg exists). Unrelated, not fixed here.

## Not included

`install.sh` and the `README-LINUX.txt` section documenting it, both of which land with #361 along with the line that stages the script. Splitting it this way means this ships without referencing a file that does not exist yet, and gives whoever writes the installer the ground to stand on. #361 is offered to @MetalMan1245, whose fork prompted all of this.
