### PR TITLE
chore(release): prepare 0.9.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -51,7 +51,7 @@ body:
     attributes:
       label: StemDeck version
       description: Shown in the About dialog (Help icon).
-      placeholder: e.g. v0.7.0-alpha.12
+      placeholder: e.g. v0.9.0
     validations:
       required: true
   - type: dropdown

--- a/templates/stemdeck.xml
+++ b/templates/stemdeck.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>StemDeck</Name>
-  <Repository>ghcr.io/stemdeckapp/stemdeck:0.8.0-alpha.17</Repository>
+  <Repository>ghcr.io/stemdeckapp/stemdeck:0.9.0</Repository>
   <Registry>https://github.com/stemdeckapp/stemdeck/pkgs/container/stemdeck</Registry>
   <Network>bridge</Network>
   <Shell>sh</Shell>


### PR DESCRIPTION
Prepares the 0.9.0 release. Two one-line changes, plus the release notes drafted below.

## Changes

- `templates/stemdeck.xml` — Unraid pin `0.8.0-alpha.17` -> `0.9.0`
- `.github/ISSUE_TEMPLATE/bug_report.yml` — placeholder `e.g. v0.7.0-alpha.12` -> `e.g. v0.9.0`, since that version format will no longer exist

Nothing else is required. hatch-vcs derives the version from the git tag, and `Cargo.toml` and `tauri.conf.json` carry `0.0.0` placeholders filled at build time. I checked the three things that parse versions: `canonicalVersion` in the update check, the installer's `version_cmp`, and the Docker `:latest` gate. None need changing for a suffix-free version.

The "alpha" wording stays in SECURITY.md and the platform READMEs, because the software is still alpha. Only the version string changed.

## Merge timing

**Merge this at or just after tagging**, not before. The Unraid template pins a published image tag, so between merging and publishing `0.9.0` the template would point at an image that does not exist yet.

## Release checklist

1. Merge this PR
2. Tag `v0.9.0`
3. Publish the release: **not** marked prerelease, and **set as latest** — the in-app update banner reads `/releases/latest`, which excludes prereleases, and Docker `:latest` is gated on the same flag
4. Paste the notes below

---

# Release notes draft

> [!IMPORTANT]
> **macOS first launch (no code signing yet).** After dragging StemDeck to Applications, clear the Gatekeeper quarantine flag or macOS will say the app is damaged:
> ```
> xattr -dr com.apple.quarantine /Applications/StemDeck.app
> ```
>
> **Optional: start from a clean slate.** To reproduce a true first-run experience, open each path in Finder via the **Go** menu, then **Go to Folder** (Shift+Cmd+G), and move the folders to Trash:
> - `~/Library/Application Support/StemDeck`
> - `~/Library/WebKit/app.stemdeck.desktop`
> - `~/Library/Caches/stemdeck`
> - `~/Library/Caches/app.stemdeck.desktop`
>
> You can also delete `~/Library/Preferences/app.stemdeck.desktop.plist` the same way. This is optional; the app will work without it.

## What's new in 0.9.0

StemDeck is still alpha. The version number just stopped saying so twice: releases are now plain `0.9.0` instead of `0.9.0-alpha.1`, because a leading `0.` already means "no stability promise". Nothing about the software's maturity changed with this release.

This is the largest release so far.

### Import a whole queue and keep working

- **Imports now run in the background.** Add a track while another is separating and it joins a queue instead of taking over the screen. The song you are working on keeps playing. (#344, #345)
- **Import a YouTube playlist.** Paste a playlist URL, confirm the track count, and every track lands in a folder named after the playlist. (#348)
- **Drop several files at once** instead of one at a time. (#349)
- **A Queue view in the sidebar** shows what is waiting, what is running, and how far along it is. Cancel anything that has not started, and **drag rows to reorder** what runs next. (#346, #351)
- **The queue survives a restart.** Close the app mid-queue and the remaining jobs resume in order when you reopen it. A job whose stems had already finished is recognised as done instead of being re-run.

### Choose where your stems are stored

- **Settings -> General -> StemData location.** Pick any folder and StemDeck moves your existing library there. (#354)
- The default is still `~/Documents/StemDeck`, which on many machines is synced to iCloud or OneDrive. If you did not intend to spend cloud storage on tens of gigabytes of stems, this is the setting you want.
- Desktop only. Docker and Unraid keep their fixed, configured path.

### Linux: an optional installer

- The Linux tarball now carries an `install.sh` that adds a desktop icon and an applications-menu entry, with `--uninstall` to remove it again. (#342)
- **StemDeck stays portable.** Extract and run `./StemDeck` exactly as before; the installer is opt-in and changes nothing about how the app works.
- Upgrades replace the old copy only once the new one is verified, so a failed or interrupted upgrade leaves your working version alone.
- Built on the design, and the working prototype, contributed by [@MetalMan1245](https://github.com/MetalMan1245).

### Playback and export fixes

- **Some tracks loaded with waveforms but no playback**, showing the right duration in the header and `0:00 / 0:00` in the transport. StemDeck read only the first kilobyte of each stem looking for the audio, which is not enough when the encoder writes extra metadata in front of it. It now reads as far as it needs to. Reported by [@MetalMan1245](https://github.com/MetalMan1245) (#343, #358)
- **A track that cannot be played now says why**, instead of failing silently with nothing on screen. (#359)
- **24-bit and 32-bit audio files** are now handed to the browser's own decoder rather than being loaded and then played as silence.
- **The export button no longer says "Exporting..." while the save dialog is open.** Nothing is being exported until you have chosen where to put it. (#338)

### Disk space

- **Old runtime downloads are cleaned up.** Updating used to leave every previously downloaded runtime archive on disk, roughly 165 MB each. They are removed once the runtime they contain is installed. (#356)

### Under the hood

- Browser-driven tests now run in CI for the export menu, in both the desktop and browser code paths (#339). The Linux installer has its own test suite. Neither changes anything you can see; both exist so the bugs above stay fixed.

### Notes on the beat detection model

Unchanged, repeated here for anyone upgrading from an older release:

- The first time you use the click track, StemDeck downloads a **77 MB beat-detection model** (MIT licensed, code and weights). It is cached alongside the Demucs models, so this happens once.
- If that download is unavailable, for example on a machine with no internet, detection falls back to the classic librosa tracker automatically. The click still works; it is just more likely to pick half or double tempo on fast material, which `/2` and `x2` correct.
- **Known limitation:** tracks whose time signature changes bar to bar, such as odd-time progressive material, get a usable steady pulse but the bar accents will not follow the written meter. No current beat tracker handles that automatically. The grid editor is the way to fix it by hand.
- Tracks with no drums fall back to detecting on the full mix and are less reliable.
