### PR TITLE
Add an on-demand macOS Rust check on the self-hosted runner

### DIFF
--- a/.github/workflows/macos-check.yml
+++ b/.github/workflows/macos-check.yml
@@ -1,0 +1,49 @@
+name: macOS Rust Check
+
+# Manual only -- not on every PR/push, to keep the self-hosted runner's load
+# and cost unchanged from today. Exists because ci.yml (which does run on
+# every PR) is 100% ubuntu-latest, and a Linux runner cannot type-check code
+# behind #[cfg(target_os = "macos")] at all -- that code is stripped before
+# semantic analysis even starts, not just skipped at test time. This is the
+# only way to get a real compiler pass over it before merging.
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    # Runner must be darwin/arm64 with Xcode CLT and rustup (same requirements
+    # as macos-release.yml, which this intentionally does not replace -- this
+    # only builds/checks, never signs, packages, or uploads anything).
+    runs-on: [self-hosted, macOS, ARM64]
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
+        working-directory: desktop/src-tauri
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: cargo fmt --check
+        run: cargo fmt --check
+
+      - name: cargo build
+        run: cargo build
+
+      - name: cargo clippy
+        # -A flags suppress 3 pre-existing lints unrelated to this workflow's
+        # purpose (tracked separately, not introduced by whatever change this
+        # check is run against) so a real regression isn't lost in known noise.
+        run: |
+          cargo clippy -- -D warnings \
+            -A clippy::derivable_impls \
+            -A clippy::single_match \
+            -A clippy::trim_split_whitespace
+
+      - name: cargo test
+        run: cargo test


### PR DESCRIPTION
## Summary

Bootstrapping commit split out of #390 - GitHub only allows dispatching a `workflow_dispatch` workflow that already exists on the default branch, so this needs to land on `main` before it can be used to actually verify #390's macOS-specific changes.

`ci.yml` (PR-triggered) is 100% `ubuntu-latest`, so code behind `#[cfg(target_os = "macos")]` has never had a real compiler pass before merging - that cfg-gated code is stripped before semantic analysis even starts on a non-matching target, not just skipped at test time. `macos-release.yml` already has a real macOS runner, but only fires on `release: published` and does the full signed/packaged build.

This is deliberately narrow: build/clippy/test only, `workflow_dispatch` only (not on every PR/push, so the runner's load and cost don't change from today), never touches signing, packaging, or uploads.

## Test plan

Purely additive CI config, inert until manually triggered. No app code touched.