### PR TITLE
Add an on-demand Windows Rust check on the self-hosted runner

### DIFF
--- a/.github/workflows/windows-check.yml
+++ b/.github/workflows/windows-check.yml
@@ -1,0 +1,56 @@
+name: Windows Rust Check
+
+# Manual only -- not on every PR/push, to keep the self-hosted runner's load
+# and cost unchanged from today. Companion to macos-check.yml: ci.yml (which
+# does run on every PR) is 100% ubuntu-latest, so nothing behind
+# #[cfg(windows)] -- or, as it turned out, code that lost a #[cfg(unix)] gate
+# and started compiling on Windows by accident -- has ever had a real
+# compiler pass before merging. That exact gap shipped a broken Windows
+# build in v0.11.1's first release attempt.
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    # Runner must have rustup and the MSVC toolchain (same requirements as
+    # windows-release.yml, which this intentionally does not replace -- this
+    # only builds/checks, never packages or uploads anything).
+    runs-on: [self-hosted, windows, x64]
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
+        working-directory: desktop/src-tauri
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: cargo fmt --check
+        run: cargo fmt --check
+
+      - name: cargo build
+        run: cargo build --tests
+
+      - name: cargo clippy
+        # -A flags suppress pre-existing lints unrelated to this workflow's
+        # purpose (tracked separately, not introduced by whatever change this
+        # check is run against) so a real regression isn't lost in known noise.
+        # unused_variables (pip_pid) and needless_return are Windows-build-only
+        # findings from this workflow's first-ever run -- nothing has
+        # type-checked this target before, so they predate this workflow
+        # rather than being caused by it.
+        run: |
+          cargo clippy --tests -- -D warnings \
+            -A clippy::derivable_impls \
+            -A clippy::single_match \
+            -A clippy::trim_split_whitespace \
+            -A unused_variables \
+            -A clippy::needless_return
+
+      - name: cargo test
+        run: cargo test


### PR DESCRIPTION
## Summary

Companion to \`macos-check.yml\`, and this time justified by a real incident rather than a hypothetical: \`v0.11.1\`'s first release attempt shipped a broken Windows build. \`download_file\` silently lost its \`#[cfg(unix)]\` gate while being refactored (a new helper inserted directly above it took over the attribute, since a Rust \`#[cfg]\` only applies to the single following item) and started compiling - and failing to compile, since it called a still-\`#[cfg(unix)]\`-gated helper - on Windows too. \`ci.yml\` is 100% \`ubuntu-latest\` and \`macos-check.yml\` also satisfies \`cfg(unix)\`, so neither could have caught it. Only an actual Windows compile could, and none existed until now.

Fixed directly on \`main\` as an emergency hotfix (bypassed branch protection given the release was live and broken; verified natively on Windows, macOS CI, and WSL before pushing) and the release was re-fired successfully - this PR is the follow-up so it doesn't happen again silently.

## Test plan

Purely additive CI config, inert until manually triggered. No app code touched.