### PR TITLE
windows-check.yml: use powershell, not bash

### DIFF
--- a/.github/workflows/windows-check.yml
+++ b/.github/workflows/windows-check.yml
@@ -25,7 +25,12 @@ jobs:
     timeout-minutes: 30
     defaults:
       run:
-        shell: bash
+        # bash on this self-hosted runner mangles the auto-generated temp
+        # script's Windows-style path (backslashes stripped -- "No such file
+        # or directory" on a path that plainly exists), the way
+        # windows-release.yml's own steps already discovered. powershell is
+        # the proven shell for this runner.
+        shell: powershell
         working-directory: desktop/src-tauri
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -44,13 +49,13 @@ jobs:
         # findings from this workflow's first-ever run -- nothing has
         # type-checked this target before, so they predate this workflow
         # rather than being caused by it.
-        run: |
-          cargo clippy --tests -- -D warnings \
-            -A clippy::derivable_impls \
-            -A clippy::single_match \
-            -A clippy::trim_split_whitespace \
-            -A unused_variables \
-            -A clippy::needless_return
+        run: >
+          cargo clippy --tests -- -D warnings
+          -A clippy::derivable_impls
+          -A clippy::single_match
+          -A clippy::trim_split_whitespace
+          -A unused_variables
+          -A clippy::needless_return
 
       - name: cargo test
         run: cargo test


### PR DESCRIPTION
## Summary

\`windows-check.yml\`'s first real run failed immediately on \`cargo fmt --check\` with \`bash: ...sh: No such file or directory\` - not a real formatting issue, an infrastructure one. \`shell: bash\` on this self-hosted Windows runner mangles the auto-generated temp script's Windows-style path (backslashes stripped). \`windows-release.yml\`'s own steps already use \`shell: powershell\` for exactly this reason; this workflow copied \`macos-check.yml\`'s bash default without adjusting for the platform.

## Test plan

Purely CI config. Will dispatch \`windows-check.yml\` against \`main\` after merging to confirm it actually runs clean this time.