### PR TITLE
chore: pin Unraid template to 0.12.0

### DIFF
--- a/templates/stemdeck.xml
+++ b/templates/stemdeck.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>StemDeck</Name>
-  <Repository>ghcr.io/stemdeckapp/stemdeck:0.11.1</Repository>
+  <Repository>ghcr.io/stemdeckapp/stemdeck:0.12.0</Repository>
   <Registry>https://github.com/stemdeckapp/stemdeck/pkgs/container/stemdeck</Registry>
   <Network>bridge</Network>
   <Shell>sh</Shell>


### PR DESCRIPTION
Bumps `templates/stemdeck.xml` from `0.11.1` to `0.12.0`.

## Do not merge before the image exists

Unraid pulls this exact tag. `ghcr.io/stemdeckapp/stemdeck:0.12.0` is only pushed by `docker-publish.yml` when the 0.12.0 release is published, so merging this first leaves `main` pointing at a tag that 404s for anyone installing in the gap.

**Merge order:** publish release 0.12.0 -> wait for `docker-publish.yml` to push the image -> merge this.

Split out of #394 for that reason; #394 has no such ordering constraint.