### PR TITLE
Relock yt-dlp to 2026.8.19 to fix YouTube 403 on download

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2320,9 +2320,9 @@ wheels = [
 
 [[package]]
 name = "yt-dlp"
-version = "2026.7.4"
+version = "2026.8.19"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/c5/9972af4b472b0d55badf841ebafd2f98944cb0ae0f46e11d01f363ea5b91/yt_dlp-2026.7.4.tar.gz", hash = "sha256:b094813404f87a9dd2186f00815231df32e5fd8a5403be0f807b3bb2d21a4432", size = 3049326, upload-time = "2026-07-04T22:42:14.837Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/e0/832fa4ca334b766a06933a196066edc3dba37cdb6f14cd98d59bcc69a4b4/yt_dlp-2026.8.19.tar.gz", hash = "sha256:9e213e48cea35c66b378e4447903f118f6392a5fa380a2b6d7070ec86f4e0af1", size = 3052025, upload-time = "2026-08-19T23:48:59.291Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/8a/cd4c9b02c10c563adfe78118310129641900e1cd6de888cfae2452072696/yt_dlp-2026.7.4-py3-none-any.whl", hash = "sha256:f11f2b11d5a8ac4059f9bdf29fa4407dc7c6bb00c5097e95ca22a7a9db518266", size = 3184705, upload-time = "2026-07-04T22:42:12.989Z" },
+    { url = "https://files.pythonhosted.org/packages/69/b2/8cd1613f56eed7ceb64fbd4df3f1c01246bfb098e6f398228bafda22b80b/yt_dlp-2026.8.19-py3-none-any.whl", hash = "sha256:1d57897e94c6665a0a6f9bc54b34e584284e32c034ffab3a7df25d8f7b24eedf", size = 3185533, upload-time = "2026-08-19T23:48:56.925Z" },
 ]


### PR DESCRIPTION
## Summary
- YouTube changed how it serves media streams; the pinned `yt-dlp` 2026.7.4 build 403's fetching the actual audio stream while the latest release succeeds. Reproduced locally: old pin 403's on `https://www.youtube.com/watch?v=XXXXo`, new pin downloads it cleanly.
- `pyproject.toml`'s floor (`>=2026.7.4`) already permits this; only `uv.lock` needed relocking (`uv lock --upgrade-package yt-dlp`).
- Already shipped in the [v0.11.2 patch release](https://github.com/stemdeckapp/stemdeck/releases/tag/v0.11.2), cut off `v0.11.1` to sidestep the pending SignPath work on `main`. This PR brings the same fix to `main` so it isn't lost once SignPath lands and 0.12.0 ships.

## Test plan
- [x] `uv run pytest tests/` — download/playlist/pipeline-runner tests pass
- [x] Reproduced the 403 with the old pin and a clean download with the new pin against the reported video