### PR TITLE
chore: pin Unraid template to 0.11.2

### DIFF
--- a/templates/stemdeck.xml
+++ b/templates/stemdeck.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>StemDeck</Name>
-  <Repository>ghcr.io/stemdeckapp/stemdeck:0.11.1</Repository>
+  <Repository>ghcr.io/stemdeckapp/stemdeck:0.11.2</Repository>
   <Registry>https://github.com/stemdeckapp/stemdeck/pkgs/container/stemdeck</Registry>
   <Network>bridge</Network>
   <Shell>sh</Shell>


### PR DESCRIPTION
The template pins an exact published image tag, so this must not merge before \`ghcr.io/stemdeckapp/stemdeck:0.11.2\` exists (the v0.11.2 Docker Publish run was in progress at PR-open time — check it's green before merging).

Kept separate from the code-signing work, same as the parked \`chore/unraid-pin-0.12.0\` branch for the next release.