### PR TITLE
fix: pin librosa <1 and add audioread explicitly (#407)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,11 @@ dependencies = [
     # backend to handle uri ... drums.wav".
     "soundfile>=0.12",
     # BPM + key analysis on the downloaded source. Pulls numpy/scipy/numba.
-    "librosa>=0.10",
+    # librosa 1.0.0 dropped its audioread dependency; audio-separator (below)
+    # still imports audioread directly, so an unpinned upper bound lets a
+    # librosa upgrade silently break the vocal-split feature (#407). Pin
+    # <1 to match what audio-separator expects and what uv.lock resolves.
+    "librosa>=0.10,<1",
     # Beat/downbeat tracker for the click track. MIT for both code and the
     # published weights. librosa's tracker resolves fast music to half tempo
     # (180 BPM punk -> 90) because of its 120 BPM lognormal prior, which is not
@@ -74,6 +78,10 @@ dependencies = [
     # blocker, since the main separation already gets full GPU accel via torch.
     "audio-separator>=0.24; sys_platform != 'darwin' or platform_machine != 'x86_64'",
     "onnxruntime>=1.19; sys_platform != 'darwin' or platform_machine != 'x86_64'",
+    # audio-separator imports this directly; librosa<1 pulls it in transitively
+    # today, but pin it explicitly so this survives an eventual librosa 1.x move
+    # (#407) -- same platform gate as audio-separator itself.
+    "audioread>=3.0; sys_platform != 'darwin' or platform_machine != 'x86_64'",
 ]
 
 [project.optional-dependencies]

--- a/scripts/linux/make-portable.sh
+++ b/scripts/linux/make-portable.sh
@@ -135,7 +135,10 @@ echo "    removing:$orphans"
 "$BUNDLED_PYTHON" -m pip uninstall -y $orphans 2>/dev/null || true
 
 echo "==> Verifying imports"
-"$BUNDLED_PYTHON" -c "import fastapi, uvicorn, yt_dlp, demucs, torch, torchaudio, librosa, pyloudnorm, soundfile; print('torch', torch.__version__, 'cuda', torch.version.cuda)"
+# audio_separator/onnxruntime: vocal split (#275). Missing here would have
+# caught #407 (librosa 1.0.0 dropping audioread, which audio-separator still
+# needs) before release instead of after.
+"$BUNDLED_PYTHON" -c "import fastapi, uvicorn, yt_dlp, demucs, torch, torchaudio, librosa, pyloudnorm, soundfile, audio_separator, onnxruntime; print('torch', torch.__version__, 'cuda', torch.version.cuda)"
 
 echo "==> Staging backend"
 cp -R "$REPO_ROOT/app" "$BACKEND_DIR/app"

--- a/scripts/macos/make-runtime-pack.sh
+++ b/scripts/macos/make-runtime-pack.sh
@@ -129,7 +129,7 @@ SETUPTOOLS_SCM_PRETEND_VERSION="${VERSION#v}" \
   uv pip install --system --python "$PYTHON_DIR/bin/python" "$REPO_ROOT"
 
 echo "==> Verifying stdlib and imports"
-PYTHON_DIR="$PYTHON_DIR" PYTHONHOME="$PYTHON_DIR" "$PYTHON_DIR/bin/python" - <<'PY'
+PYTHON_DIR="$PYTHON_DIR" PYTHONHOME="$PYTHON_DIR" ARCH="$ARCH" "$PYTHON_DIR/bin/python" - <<'PY'
 import importlib, os, pathlib, sys
 
 ver = f"python{sys.version_info.major}.{sys.version_info.minor}"
@@ -143,6 +143,11 @@ packages = [
     "fastapi", "uvicorn", "yt_dlp", "demucs", "torch", "torchaudio",
     "librosa", "pyloudnorm", "soundfile",
 ]
+# audio_separator/onnxruntime (vocal split, #275) are excluded on Intel macOS
+# (x64) -- the feature gates itself off there, matching pyproject.toml's
+# platform marker. Missing here would have caught #407 before release.
+if os.environ.get("ARCH") != "x64":
+    packages += ["audio_separator", "onnxruntime"]
 for package in packages:
     importlib.import_module(package)
     print(f"  OK {package}")

--- a/scripts/windows/make-portable.ps1
+++ b/scripts/windows/make-portable.ps1
@@ -221,7 +221,10 @@ if ($CpuOnly) {
 # pushes the zip past GitHub's 2 GiB release-asset cap and loses that adaptive
 # versioning. (Reverts #318; the real GPU-detection fix is #317.)
 
-& $PythonExe -c "import fastapi, uvicorn, yt_dlp, demucs, torch, torchaudio, librosa, pyloudnorm, soundfile"
+# audio_separator/onnxruntime: vocal split (#275). Missing here would have
+# caught #407 (librosa 1.0.0 dropping audioread, which audio-separator still
+# needs) before release instead of after.
+& $PythonExe -c "import fastapi, uvicorn, yt_dlp, demucs, torch, torchaudio, librosa, pyloudnorm, soundfile, audio_separator, onnxruntime"
 
 Bundle-PythonRuntime $PythonDir $PythonExe
 & $PythonExe -c "import sys, fastapi, uvicorn; print('Portable Python:', sys.executable)"

--- a/uv.lock
+++ b/uv.lock
@@ -2251,6 +2251,7 @@ name = "stemdeck"
 source = { editable = "." }
 dependencies = [
     { name = "audio-separator", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "audioread", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
     { name = "beat-this" },
     { name = "demucs" },
     { name = "fastapi" },
@@ -2283,11 +2284,12 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "audio-separator", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'", specifier = ">=0.24" },
+    { name = "audioread", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'", specifier = ">=3.0" },
     { name = "beat-this", specifier = ">=1.1" },
     { name = "demucs", specifier = ">=4.0.1,<4.1" },
     { name = "fastapi", specifier = ">=0.115,!=0.136.3" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
-    { name = "librosa", specifier = ">=0.10" },
+    { name = "librosa", specifier = ">=0.10,<1" },
     { name = "numba", marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'", specifier = ">=0.61,<0.62" },
     { name = "numpy", marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'", specifier = "<2" },
     { name = "onnxruntime", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'", specifier = ">=1.19" },


### PR DESCRIPTION
## Summary
- Fixes #407: `librosa 1.0.0` dropped its `audioread` dependency, but `audio-separator` (vocal split, #275) still imports `audioread` directly. `uv.lock` already resolved `librosa 0.11.0` so dev/CI never hit this, but the packaging scripts install from `pyproject.toml` rather than the lockfile, so the unbounded upper bound let shipped macOS/Windows/Linux runtime packs silently pick up `librosa 1.0.0` and lose `audioread`, breaking the vocal-split subprocess only in the packaged artifact.
- Pin `librosa>=0.10,<1` and add `audioread>=3.0` as an explicit dependency (same platform marker as `audio-separator`).
- Add `audio_separator`/`onnxruntime` to all three packaging scripts' import verification (platform-guarded on Intel macOS, where the feature is deliberately excluded), so a broken vocal-split dependency chain fails the build instead of shipping.

## Test plan
- [x] `uv lock` resolves cleanly (`librosa 0.11.0`, `audioread 3.1.0`)
- [x] `ruff check` / `ruff format --check` pass
- [x] `pytest tests/` - no regressions vs. main (pre-existing Windows-only failures unrelated to this change: beatgrid numeric edge cases, watchdog signal semantics, Linux installer test)
- [ ] CI green