### PR TITLE
chore: pin Unraid template to 0.12.1

### DIFF
--- a/templates/stemdeck.xml
+++ b/templates/stemdeck.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>StemDeck</Name>
-  <Repository>ghcr.io/stemdeckapp/stemdeck:0.12.0</Repository>
+  <Repository>ghcr.io/stemdeckapp/stemdeck:0.12.1</Repository>
   <Registry>https://github.com/stemdeckapp/stemdeck/pkgs/container/stemdeck</Registry>
   <Network>bridge</Network>
   <Shell>sh</Shell>


### PR DESCRIPTION
Pins the Unraid Community Applications template to 0.12.1, which fixes #407 (vocal split failing at runtime due to librosa/audioread). Docker/GHCR builds from `pyproject.toml` the same way desktop packaging does, so Unraid users hit the same bug on 0.12.0.