### PR TITLE
polish: compact DAW summary bar, distinct mute color, We Recommend updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,15 +53,16 @@ StemDeck is free and **does not accept any money, sponsorship, or funding** - no
 
 | Name | What they do | Link |
 |---|---|---|
-| Analog4Lyfe | Analog music gear | [@analog4lyfe](https://www.instagram.com/analog4lyfe) |
-| Dlima Guitars | Custom guitars and basses | [@dlimaguitars](https://www.instagram.com/dlimaguitars) |
-| Empress Effects | Effects pedals | [empresseffects.com](https://empresseffects.com) |
-| Joao Gaspar | Producer/Film Scorer, Touring/Session Musician | [@jay_glaspar](https://www.instagram.com/jay_glaspar) |
-| Kris Luthier | Luthier and Musical Instrument Repair, Lisboa | [@krisluthier](https://www.instagram.com/krisluthier) |
-| Lisbon Guitar Works | Guitar building | [dlimaguitars.com](https://dlimaguitars.com) |
+| Analog4Lyfe | All-analog music gear, no digital shortcuts | [@analog4lyfe](https://www.instagram.com/analog4lyfe) |
+| Beltr | Turns the songs you already own into karaoke gold, right on your own machine, no subscription, no cloud, just you and the mic | [beltr.app](https://beltr.app/) |
+| Dlima Guitars | Custom guitars and basses, built one at a time | [@dlimaguitars](https://www.instagram.com/dlimaguitars) |
+| Empress Effects | Boutique effects pedals for tone chasers who don't settle | [empresseffects.com](https://empresseffects.com) |
+| Joao Gaspar | Producer and film scorer, also plays as a touring/session musician | [@jay_glaspar](https://www.instagram.com/jay_glaspar) |
+| Kris Luthier | Hand-repairs and restores instruments in Lisbon, one careful fix at a time | [@krisluthier](https://www.instagram.com/krisluthier) |
+| Lisbon Guitar Works | Guitars built by hand in Lisbon | [dlimaguitars.com](https://dlimaguitars.com) |
 | More Notes Less Talk | Instruments and gear with personality, recorded raw to tape. No hype, no gatekeeping. | [@morenoteslesstalk](https://www.youtube.com/@morenoteslesstalk) |
 | Seratone | Turns any TV into a studio-grade karaoke stage | [seratone.audio](https://seratone.audio/) |
-| Thomann | Online Music Store | [@thomann.music](https://www.instagram.com/thomann.music) |
+| Thomann | One of Europe's largest music gear retailers, practically everything a musician could need | [@thomann.music](https://www.instagram.com/thomann.music) |
 
 
 ---

--- a/static/css/daw.css
+++ b/static/css/daw.css
@@ -1164,7 +1164,7 @@ input, textarea { font-family: inherit; }
   display: flex;
   gap: 14px;
   align-items: flex-start;
-  padding: 14px 16px;
+  padding: 4px 16px;
   flex-shrink: 0;
   width: 340px;
   border-right: 1px solid var(--border);
@@ -1173,10 +1173,11 @@ input, textarea { font-family: inherit; }
 /* Metadata cards */
 .daw-meta-card {
   flex: 1;
-  padding: 14px 16px;
+  padding: 4px 16px;
   border-right: 1px solid var(--border);
   display: flex;
   flex-direction: column;
+  justify-content: center;
   gap: 5px;
   min-width: 0;
 }
@@ -1816,9 +1817,14 @@ input, textarea { font-family: inherit; }
 .lane-icon-toggle.mx-btn:hover,
 .ms-btn.mx-btn:hover { color: var(--fg); border-color: #3a4550; }
 
-/* Mute button: "active" = NOT muted (lit up) */
+/* Mute button: "active" = NOT muted (normal). Engaged (muted) lights up blue,
+   mirroring the solo button's own lit-up treatment below. */
 .lane-icon-toggle.mx-btn.mute.active { color: var(--fg-2); border-color: var(--border-strong); }
-.lane-icon-toggle.mx-btn.mute:not(.active) { opacity: 0.35; }
+.lane-icon-toggle.mx-btn.mute:not(.active) {
+  background: rgba(59,130,246,0.18);
+  color: #60a5fa;
+  border-color: rgba(59,130,246,0.4);
+}
 
 /* Solo button: "active" = soloed */
 .ms-btn.mx-btn.active { background: rgba(244,183,64,0.18); color: var(--accent); border-color: rgba(244,183,64,0.4); }
@@ -2196,7 +2202,7 @@ input, textarea { font-family: inherit; }
   font-variant-numeric: tabular-nums;
 }
 .footer-wave-bar {
-  height: 52px; flex-shrink: 0;
+  height: 31px; flex-shrink: 0;
   position: relative; overflow: hidden;
 }
 #footer-waveform {

--- a/static/js/catalog.js
+++ b/static/js/catalog.js
@@ -32,36 +32,52 @@ const DELETED_JOBS_KEY = "stemdeck.deleted_jobs";
 const FRIENDS = [
   {
     name: "Analog4Lyfe",
-    role: "Analog music gear",
+    role: "All-analog music gear, no digital shortcuts",
     url: "https://www.instagram.com/analog4lyfe",
     logo: "/img/friends/analog4lyfe.jpg",
     avatar: true,
   },
-  { name: "Dlima Guitars", url: "https://www.instagram.com/dlimaguitars", logo: "/img/friends/dlima-guitars-ig.jpg", avatar: true },
+  {
+    name: "Beltr",
+    role: "Turns the songs you already own into karaoke gold, right on your own machine, no subscription, no cloud, just you and the mic",
+    url: "https://beltr.app/",
+  },
+  {
+    name: "Dlima Guitars",
+    role: "Custom guitars and basses, built one at a time",
+    url: "https://www.instagram.com/dlimaguitars",
+    logo: "/img/friends/dlima-guitars-ig.jpg",
+    avatar: true,
+  },
   {
     name: "Empress Effects",
-    role: "Effects pedals",
+    role: "Boutique effects pedals for tone chasers who don't settle",
     url: "https://empresseffects.com",
     logo: "/img/friends/empress-effects.png",
   },
   {
     name: "Joao Gaspar",
-    role: "Producer/Film Scorer, Touring/Session Musician",
+    role: "Producer and film scorer, also plays as a touring/session musician",
     url: "https://www.instagram.com/jay_glaspar",
     logo: "/img/friends/joao-gaspar.jpg",
     avatar: true,
   },
   {
     name: "Kris Luthier",
-    role: "Luthier and Musical Instrument Repair, Lisboa",
+    role: "Hand-repairs and restores instruments in Lisbon, one careful fix at a time",
     url: "https://www.instagram.com/krisluthier",
     logo: "/img/friends/kris-luthier.jpg",
     avatar: true,
   },
-  { name: "Lisbon Guitar Works", url: "https://dlimaguitars.com", logo: "/img/friends/lisbon-guitar-works.webp" },
+  {
+    name: "Lisbon Guitar Works",
+    role: "Guitars built by hand in Lisbon",
+    url: "https://dlimaguitars.com",
+    logo: "/img/friends/lisbon-guitar-works.webp",
+  },
   {
     name: "More Notes Less Talk",
-    role: "YouTube channel",
+    role: "Instruments and gear with personality, recorded raw to tape. No hype, no gatekeeping.",
     url: "https://www.youtube.com/@morenoteslesstalk",
   },
   {
@@ -71,7 +87,7 @@ const FRIENDS = [
   },
   {
     name: "Thomann",
-    role: "Online Music Store",
+    role: "One of Europe's largest music gear retailers, practically everything a musician could need",
     url: "https://www.instagram.com/thomann.music",
     logo: "/img/friends/thomann.jpg",
     avatar: true,


### PR DESCRIPTION
## Summary
- Footer overview waveform bar (the one under the timeline ruler): shrunk from 52px to 31px. Both it and the beat-grid editor overlay already resize off the container's `clientHeight` via `ResizeObserver`, so no JS changes were needed.
- Track/meta summary cards (Key, BPM, LUFS, Duration, Scale, Dynamic Range, Tempo Stability, and the stem-presence row): vertical padding cut from 14px down to 4px, and content is now vertically centered (`justify-content: center`) so cards without a sub-label line (BPM, Vocal Presence, etc.) don't sit top-anchored next to taller cards that have one (Key, LUFS).
- Mute button: now lights up blue when engaged, mirroring the solo button's existing lit-up gold treatment. Previously it just faded to `opacity: 0.35` with no distinct "pressed" color, so it didn't read as an active toggle the way solo did.
- We Recommend list: added Beltr (AI karaoke app), and rewrote several flat one-line descriptions (Analog4Lyfe, Dlima Guitars, Empress Effects, Joao Gaspar, Kris Luthier, Lisbon Guitar Works, Thomann) to be more specific and readable. Also fixed `catalog.js`'s in-app list, which had drifted from `README.md` (a stale "YouTube channel" role for More Notes Less Talk, and two entries missing a role line entirely).

## Test plan
- [x] `node --check static/js/catalog.js` passes
- [x] Manually verified all four visual changes in the running dev server
- [ ] CI green