### PR TITLE
chore: pin Unraid template to 0.12.2

### DIFF
--- a/templates/stemdeck.xml
+++ b/templates/stemdeck.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>StemDeck</Name>
-  <Repository>ghcr.io/stemdeckapp/stemdeck:0.12.1</Repository>
+  <Repository>ghcr.io/stemdeckapp/stemdeck:0.12.2</Repository>
   <Registry>https://github.com/stemdeckapp/stemdeck/pkgs/container/stemdeck</Registry>
   <Network>bridge</Network>
   <Shell>sh</Shell>


### PR DESCRIPTION
Pins the Unraid Community Applications template to 0.12.2, which includes the desktop-only jobs-folder fixes (#403 follow-ups) and DAW UI polish since 0.12.1. Docker/GHCR builds are otherwise unaffected by those two desktop fixes, but keeping the template current with the latest published tag.