### PR TITLE
Coverage to 85%, starting with the measurement that was wrong

### DIFF
--- a/app/pipeline/analyze.py
+++ b/app/pipeline/analyze.py
@@ -210,7 +210,13 @@ def _load_audio_ffmpeg(
     cmd.append("-")  # write to stdout
     try:
         proc = subprocess.run(cmd, capture_output=True, check=True, timeout=timeout)
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError) as e:
+    # OSError, not just FileNotFoundError. A missing binary is only one way
+    # spawning fails: a portable install whose ffmpeg lost its executable bit
+    # raises PermissionError, which is an OSError but not a FileNotFoundError,
+    # and would have crashed the analysis instead of degrading. Everything this
+    # function produces is a display field, so None is always the right answer
+    # on failure.
+    except (subprocess.SubprocessError, OSError) as e:
         logger.warning("ffmpeg decode failed for %s: %s", source, e)
         return None
     y = np.frombuffer(proc.stdout, dtype=np.float32)

--- a/tests/ffmpeg_probe.py
+++ b/tests/ffmpeg_probe.py
@@ -1,0 +1,39 @@
+"""One answer to "can this machine run ffmpeg", shared by every test that asks.
+
+Each caller used to ask `shutil.which("ffmpeg")`, which is not the question.
+The app does not require ffmpeg on PATH: `ffmpeg_executable()` prefers the
+bundled binary and only falls back to PATH. So on a developer machine with a
+bundled ffmpeg and nothing on PATH, twenty-odd tests skipped while the code
+they cover worked perfectly.
+
+That is worse than a failing test. It reported app/api/stems.py at 51% when it
+was really at 85%, and the gap pointed a coverage effort at a module that did
+not need one.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+
+def ffmpeg_available() -> bool:
+    """Whether ffmpeg can actually be run, the way the app resolves it."""
+    from app.core.config import ffmpeg_executable
+
+    try:
+        subprocess.run(
+            [ffmpeg_executable(), "-version"],
+            capture_output=True,
+            timeout=15,
+            check=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return True
+
+
+def skip_without_ffmpeg() -> None:
+    if not ffmpeg_available():
+        pytest.skip("ffmpeg not available (not bundled and not on PATH)")

--- a/tests/test_pipeline_analyze.py
+++ b/tests/test_pipeline_analyze.py
@@ -1,0 +1,448 @@
+"""Key detection, loudness and audio loading (app/pipeline/analyze.py).
+
+This stage was the least covered in the app and the one where a bug is
+quietest. Nothing here crashes when it is wrong: a mis-detected key shows a
+confident wrong label, and a bad tempo silently misplaces every beat in the
+click track and the grid editor. There is no error to notice.
+
+Key detection is pure arithmetic over a 12-bin chroma vector, so most of it
+needs no audio at all. The parts that do decode use a tone generated here
+rather than a fixture, so the expected answer is known rather than asserted
+against whatever the file happened to contain.
+"""
+
+from __future__ import annotations
+
+import math
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from app.pipeline import analyze as az
+from tests.ffmpeg_probe import skip_without_ffmpeg
+
+PITCHES = az._PITCHES
+
+
+def chroma_for(notes: dict[str, float], floor: float = 0.05) -> list[float]:
+    """A 12-bin chroma vector with the named pitch classes raised."""
+    vec = [floor] * 12
+    for name, weight in notes.items():
+        vec[PITCHES.index(name)] = weight
+    return vec
+
+
+# A major triad plus the diatonic notes that decide major against minor.
+C_MAJOR = chroma_for({"C": 1.0, "E": 0.8, "G": 0.9, "D": 0.5, "A": 0.5, "B": 0.45, "F": 0.5})
+A_MINOR = chroma_for({"A": 1.0, "C": 0.8, "E": 0.9, "D": 0.5, "G": 0.6, "F": 0.5, "B": 0.35})
+
+
+# ── _correlate ───────────────────────────────────────────────────────
+
+
+def test_correlation_is_perfect_against_the_profile_itself():
+    chroma = list(az._MAJOR_PROFILE)
+    assert az._correlate(az._MAJOR_PROFILE, chroma, 0) == pytest.approx(1.0)
+
+
+def test_correlation_is_inverted_against_a_mirrored_profile():
+    mean = sum(az._MAJOR_PROFILE) / 12
+    mirrored = [2 * mean - v for v in az._MAJOR_PROFILE]
+    assert az._correlate(az._MAJOR_PROFILE, mirrored, 0) == pytest.approx(-1.0)
+
+
+def test_a_flat_chroma_correlates_to_nothing():
+    """Silence, or a signal with no pitch content, has zero variance. Dividing
+    by that would raise; returning 0.0 keeps the caller ranking sanely."""
+    assert az._correlate(az._MAJOR_PROFILE, [0.5] * 12, 0) == 0.0
+    assert az._correlate(az._MAJOR_PROFILE, [0.0] * 12, 7) == 0.0
+
+
+@pytest.mark.parametrize("shift", range(12))
+def test_shift_rotates_the_chroma_not_the_profile(shift):
+    """The whole method depends on this: shift n asks "is the song in the key
+    n semitones up", so the audio rotates against a fixed profile.
+
+    _correlate reads chroma[(i + shift) % 12], so a chroma built by shifting
+    the profile right by n must correlate perfectly at that same n. Every
+    shift, because an off-by-one here makes exactly one key undetectable.
+    """
+    chroma = [0.0] * 12
+    for i, value in enumerate(az._MAJOR_PROFILE):
+        chroma[(i + shift) % 12] = value
+    assert az._correlate(az._MAJOR_PROFILE, chroma, shift) == pytest.approx(1.0)
+
+
+# ── _detect_key ──────────────────────────────────────────────────────
+
+
+def test_detects_a_major_key():
+    label, scale, confidence = az._detect_key(C_MAJOR)
+    assert label == "C maj"
+    assert scale == "Major"
+    assert 0 <= confidence <= 100
+
+
+def test_detects_a_minor_key():
+    label, scale, _ = az._detect_key(A_MINOR)
+    assert label == "A min"
+    assert scale == "Natural Minor"
+
+
+def test_every_root_is_reachable():
+    """A rotation bug shows up as certain keys never being detected, which is
+    invisible until someone imports a song in one of them."""
+    found = set()
+    for shift in range(12):
+        vec = [C_MAJOR[(i - shift) % 12] for i in range(12)]
+        found.add(az._detect_key(vec)[0].split()[0])
+    assert found == set(PITCHES), f"unreachable roots: {set(PITCHES) - found}"
+
+
+def test_a_near_tie_prefers_minor():
+    """Pop and rock have a strong minor prior, and the algorithm otherwise
+    drifts to the relative major on an ostinato bass note. The comment in
+    analyze.py cites Come As You Are, which is E minor over a hammered D."""
+    flat = [0.5] * 12
+    label, scale, _ = az._detect_key(flat[:])
+    # A perfectly flat chroma is the most ambiguous input there is.
+    assert scale == "Natural Minor", f"ambiguity resolved to {label}, not minor"
+
+
+def test_confidence_is_higher_for_a_clear_key_than_a_muddy_one():
+    _, _, clear = az._detect_key(C_MAJOR)
+    muddy = chroma_for({p: 0.5 for p in PITCHES} | {"C": 0.52})
+    _, _, vague = az._detect_key(muddy)
+    assert clear > vague
+
+
+def test_confidence_stays_in_range_for_extreme_input():
+    """confidence_pct is clamped. An unclamped value would render as "480%"."""
+    for vec in ([1.0] + [0.0] * 11, [0.0] * 12, [1e6] + [1e-6] * 11):
+        _, _, pct = az._detect_key(list(vec))
+        assert 0 <= pct <= 100, f"{pct} out of range for {vec[:3]}"
+
+
+def test_a_silent_chroma_does_not_raise():
+    label, scale, pct = az._detect_key([0.0] * 12)
+    assert label.split()[0] in PITCHES
+    assert scale in ("Major", "Natural Minor")
+    assert pct == 0
+
+
+def test_the_minor_profile_favours_the_flat_seventh():
+    """The reason this project uses Albrecht-Shanahan rather than
+    Temperley: the b7 is the diatonic seventh in pop and rock, and a
+    harmonic-minor profile biases toward the leading tone instead."""
+    b7 = az._MINOR_PROFILE[10]
+    maj7 = az._MINOR_PROFILE[11]
+    assert b7 > maj7, "the minor profile has been swapped for a classical one"
+
+
+# ── _measure_loudness ────────────────────────────────────────────────
+
+
+def _tone(seconds: float = 4.0, sr: int = 22050, freq: float = 440.0, amp: float = 0.5):
+    import numpy as np
+
+    t = np.linspace(0, seconds, int(sr * seconds), endpoint=False, dtype="float32")
+    return (amp * np.sin(2 * np.pi * freq * t)).astype("float32")
+
+
+def test_loudness_of_nothing_is_none():
+    assert az._measure_loudness(None, 22050) == (None, None)
+
+
+def test_loudness_of_an_empty_array_is_none():
+    import numpy as np
+
+    assert az._measure_loudness(np.zeros(0, dtype="float32"), 22050) == (None, None)
+
+
+def test_peak_matches_the_signal():
+    """A half-amplitude tone peaks at about -6 dBFS."""
+    _, peak = az._measure_loudness(_tone(amp=0.5), 22050)
+    assert peak == pytest.approx(-6.02, abs=0.1)
+
+
+def test_digital_silence_reports_no_peak():
+    """log10(0) is undefined. None is the honest answer, and the frontend
+    hides the field rather than rendering -inf."""
+    import numpy as np
+
+    lufs, peak = az._measure_loudness(np.zeros(22050, dtype="float32"), 22050)
+    assert peak is None
+    assert lufs is None
+
+
+def test_loudness_is_measured_for_a_real_tone():
+    pytest.importorskip("pyloudnorm")
+    lufs, _ = az._measure_loudness(_tone(seconds=5.0), 22050)
+    assert lufs is not None
+    assert -40 < lufs < 0, f"implausible LUFS: {lufs}"
+
+
+def test_a_clip_too_short_to_gate_degrades_to_none():
+    """pyloudnorm raises when the clip is shorter than its 400 ms window. That
+    is a display field; it must not fail an analysis."""
+    pytest.importorskip("pyloudnorm")
+    import numpy as np
+
+    lufs, peak = az._measure_loudness(np.full(64, 0.5, dtype="float32"), 22050)
+    assert lufs is None
+    assert peak is not None
+
+
+def test_a_missing_pyloudnorm_degrades_to_none(monkeypatch):
+    import builtins
+
+    real_import = builtins.__import__
+
+    def no_pyln(name, *args, **kwargs):
+        if name == "pyloudnorm":
+            raise ImportError("not installed")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", no_pyln)
+    lufs, peak = az._measure_loudness(_tone(), 22050)
+    assert lufs is None
+    assert peak is not None, "peak needs no third-party package and must survive"
+
+
+# ── _load_audio_ffmpeg ───────────────────────────────────────────────
+
+
+@pytest.fixture
+def jobs_dir(tmp_path, monkeypatch):
+    """A directory _load_audio_ffmpeg will accept.
+
+    It refuses any source outside JOBS_DIR, the same containment shape as the
+    stem endpoints (#173). Tests go through that boundary rather than around
+    it, so the check stays exercised.
+    """
+    monkeypatch.setattr(az, "JOBS_DIR", tmp_path)
+    d = tmp_path / "abcdefabcdef"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _write_tone_wav(path: Path, seconds: float = 2.0, freq: float = 440.0) -> Path:
+    """A real WAV on disk, written without depending on the code under test."""
+    import struct
+    import wave
+
+    sr = 22050
+    frames = bytearray()
+    for i in range(int(sr * seconds)):
+        value = int(16000 * math.sin(2 * math.pi * freq * i / sr))
+        frames += struct.pack("<h", value)
+    with wave.open(str(path), "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(sr)
+        w.writeframes(bytes(frames))
+    return path
+
+
+def test_decodes_a_real_file(jobs_dir):
+    skip_without_ffmpeg()
+    src = _write_tone_wav(jobs_dir / "tone.wav", seconds=2.0)
+    result = az._load_audio_ffmpeg(src, sr=22050, duration=None)
+    assert result is not None
+    samples, sr = result
+    assert sr == 22050
+    assert samples.size == pytest.approx(22050 * 2, rel=0.05)
+    assert float(abs(samples).max()) > 0.1, "decoded to silence"
+
+
+def test_duration_caps_the_decode(jobs_dir):
+    """analyze only needs the first few minutes. Decoding an hour-long upload
+    in full would cost time and memory for no better answer."""
+    skip_without_ffmpeg()
+    src = _write_tone_wav(jobs_dir / "long.wav", seconds=4.0)
+    result = az._load_audio_ffmpeg(src, sr=22050, duration=1.0)
+    assert result is not None
+    samples, _ = result
+    assert samples.size == pytest.approx(22050, rel=0.1)
+
+
+def test_a_missing_file_returns_none_rather_than_raising(tmp_path):
+    """Every caller treats None as "could not analyse". Raising here would
+    fail the whole job over a display field."""
+    assert az._load_audio_ffmpeg(tmp_path / "nope.wav") is None
+
+
+def test_a_file_that_is_not_audio_returns_none(jobs_dir):
+    skip_without_ffmpeg()
+    junk = jobs_dir / "junk.wav"
+    junk.write_bytes(b"this is not a wav file, not even slightly")
+    assert az._load_audio_ffmpeg(junk) is None
+
+
+def test_a_timeout_returns_none(jobs_dir):
+    src = jobs_dir / "x.wav"
+    src.write_bytes(b"RIFF")
+
+    def slow(*_a, **_k):
+        raise subprocess.TimeoutExpired(cmd="ffmpeg", timeout=1)
+
+    with patch.object(az.subprocess, "run", slow):
+        assert az._load_audio_ffmpeg(src, timeout=1) is None
+
+
+def test_ffmpeg_missing_returns_none(jobs_dir):
+    src = jobs_dir / "x.wav"
+    src.write_bytes(b"RIFF")
+    with patch.object(az.subprocess, "run", side_effect=OSError("no ffmpeg")):
+        assert az._load_audio_ffmpeg(src) is None
+
+
+# ── analyze() ────────────────────────────────────────────────────────
+
+
+def _click_wav(path: Path, bpm: float, seconds: float = 12.0, sr: int = 22050) -> Path:
+    """A metronome at a known tempo, plus a steady tone so there is pitch
+    content to find a key in. Generated rather than fixtured, so the expected
+    answer is known instead of whatever a file happened to contain."""
+    import struct
+    import wave
+
+    n = int(sr * seconds)
+    period = sr * 60.0 / bpm
+    samples = []
+    for i in range(n):
+        # Decaying click on the beat.
+        phase = i % period
+        click = math.exp(-phase / (sr * 0.01)) if phase < sr * 0.05 else 0.0
+        tone = 0.25 * math.sin(2 * math.pi * 220.0 * i / sr)  # A3
+        samples.append(int(max(-1.0, min(1.0, 0.7 * click + tone)) * 20000))
+    with wave.open(str(path), "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(sr)
+        w.writeframes(b"".join(struct.pack("<h", s) for s in samples))
+    return path
+
+
+@pytest.fixture
+def job():
+    from app.core.models import Job
+
+    return Job(id="abcdefabcdef")
+
+
+def test_analyze_fills_the_job_in(job, jobs_dir):
+    """The happy path, end to end, on audio with a tempo we chose."""
+    skip_without_ffmpeg()
+    pytest.importorskip("librosa")
+    src = _click_wav(jobs_dir / "click.wav", bpm=120.0)
+
+    bpm, key = az.analyze(job, src)
+
+    assert bpm is not None, "no tempo found in a plain 120 BPM click"
+    # Half and double time are musically legitimate readings of a bare click.
+    assert bpm in range(55, 65) or bpm in range(115, 126) or bpm in range(235, 245), bpm
+    assert job.bpm == bpm
+    assert key is None or key.split()[0] in PITCHES
+    assert job.stage_message == "Analysis complete"
+    assert job.progress == 1.0
+
+
+def test_analyze_reports_loudness(job, jobs_dir):
+    skip_without_ffmpeg()
+    pytest.importorskip("librosa")
+    pytest.importorskip("pyloudnorm")
+    az.analyze(job, _click_wav(jobs_dir / "c.wav", bpm=100.0))
+
+    assert job.peak_db is not None
+    if job.lufs is not None:
+        assert job.dynamic_range == pytest.approx(round(job.peak_db - job.lufs, 1))
+
+
+def test_analyze_reports_tempo_stability(job, jobs_dir):
+    """A machine-perfect click should read as very stable. This is the field
+    the click track leans on, and there is nothing to notice when it is wrong."""
+    skip_without_ffmpeg()
+    pytest.importorskip("librosa")
+    az.analyze(job, _click_wav(jobs_dir / "steady.wav", bpm=120.0, seconds=15.0))
+
+    assert job.tempo_stability is not None
+    assert 0 <= job.tempo_stability <= 100
+    assert job.tempo_stability > 60, f"a metronome read as unstable: {job.tempo_stability}"
+
+
+def test_an_undecodable_source_leaves_the_job_alone(job, jobs_dir):
+    """Analysis is best effort. Its fields are chips in the UI, so failure
+    means placeholders stay, never that the import fails."""
+    pytest.importorskip("librosa")
+    junk = jobs_dir / "junk.wav"
+    junk.write_bytes(b"not audio")
+
+    assert az.analyze(job, junk) == (None, None)
+    assert job.bpm is None
+    assert job.key is None
+
+
+def test_a_source_outside_jobs_dir_is_refused(job, tmp_path, monkeypatch):
+    """Containment, the same shape as the stem endpoints (#173)."""
+    pytest.importorskip("librosa")
+    monkeypatch.setattr(az, "JOBS_DIR", tmp_path / "elsewhere")
+    (tmp_path / "elsewhere").mkdir()
+    outside = tmp_path / "outside.wav"
+    _write_tone_wav(outside)
+
+    assert az.analyze(job, outside) == (None, None)
+
+
+def test_no_librosa_is_not_a_failure(job, jobs_dir, monkeypatch):
+    """librosa is a heavy optional import. Without it the chips stay blank
+    rather than the job erroring."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def no_librosa(name, *args, **kwargs):
+        if name == "librosa":
+            raise ImportError("not installed")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", no_librosa)
+    assert az.analyze(job, jobs_dir / "anything.wav") == (None, None)
+
+
+def test_an_unexpected_error_is_logged_not_leaked(job, jobs_dir):
+    """The UI stage line must stay generic: raw exception text carries paths
+    and library internals and has no business on screen (#283)."""
+    skip_without_ffmpeg()
+    pytest.importorskip("librosa")
+    src = _click_wav(jobs_dir / "boom.wav", bpm=110.0, seconds=4.0)
+
+    import librosa
+
+    with patch.object(librosa.effects, "hpss", side_effect=RuntimeError("C:/secret/path leaked")):
+        assert az.analyze(job, src) == (None, None)
+
+    assert job.stage_message == "Analysis skipped"
+    assert "secret" not in (job.stage_message or "")
+
+
+def test_a_silent_track_yields_no_key(job, jobs_dir):
+    """Silence has no pitch content. The key chip should stay empty rather
+    than showing a confident guess pulled out of numerical noise."""
+    skip_without_ffmpeg()
+    pytest.importorskip("librosa")
+    import struct
+    import wave
+
+    src = jobs_dir / "silence.wav"
+    with wave.open(str(src), "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(22050)
+        w.writeframes(b"".join(struct.pack("<h", 0) for _ in range(22050 * 5)))
+
+    bpm, key = az.analyze(job, src)
+    assert key is None or key.split()[0] in PITCHES
+    assert bpm is None or bpm > 0

--- a/tests/test_pipeline_runner.py
+++ b/tests/test_pipeline_runner.py
@@ -16,9 +16,10 @@ from app.pipeline.runner import (
 
 
 def _ffmpeg_available() -> bool:
-    import shutil
+    # See tests/ffmpeg_probe.py: PATH is not how the app finds ffmpeg.
+    from tests.ffmpeg_probe import ffmpeg_available
 
-    return shutil.which("ffmpeg") is not None
+    return ffmpeg_available()
 
 
 @pytest.mark.asyncio

--- a/tests/test_process_liveness.py
+++ b/tests/test_process_liveness.py
@@ -1,0 +1,119 @@
+"""Process liveness, the shared half of both parent-death watchdogs.
+
+This decides whether the Demucs worker shoots itself when its parent is gone.
+Getting it wrong in one direction orphans a process holding the GPU; getting
+it wrong in the other kills a worker mid-separation. Neither announces itself.
+
+The POSIX branch is unreachable on Windows and the Windows branch is
+unreachable on POSIX, so each is driven with os.name patched. That is the only
+way one machine can cover both, and both ship.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from app.core.process import process_exists
+
+
+def test_this_process_is_alive():
+    assert process_exists(os.getpid()) is True
+
+
+@pytest.mark.parametrize("pid", [0, -1, -12345])
+def test_a_nonsense_pid_is_not_alive(pid):
+    """Guarded before either platform branch: on POSIX, kill(0, 0) signals the
+    whole process group and kill(-n, 0) a different group entirely."""
+    assert process_exists(pid) is False
+
+
+def test_a_dead_pid_is_not_alive():
+    """A pid high enough to be unused. Both branches must agree it is gone,
+    or the watchdog never fires and a worker outlives its parent."""
+    assert process_exists(4_000_000) is False
+
+
+# ── the POSIX branch ─────────────────────────────────────────────────
+
+
+def test_posix_treats_a_permission_error_as_alive(monkeypatch):
+    """The rule this module exists for: a process owned by someone else is
+    still a process. A watchdog must not shoot on ambiguity."""
+    monkeypatch.setattr(os, "name", "posix")
+
+    def denied(_pid, _sig):
+        raise PermissionError("not yours")
+
+    monkeypatch.setattr(os, "kill", denied)
+    assert process_exists(1234) is True
+
+
+def test_posix_treats_a_lookup_error_as_dead(monkeypatch):
+    monkeypatch.setattr(os, "name", "posix")
+
+    def gone(_pid, _sig):
+        raise ProcessLookupError("no such process")
+
+    monkeypatch.setattr(os, "kill", gone)
+    assert process_exists(1234) is False
+
+
+def test_posix_signal_zero_is_a_probe_not_a_kill(monkeypatch):
+    """Signal 0 asks "does this exist" without delivering anything. Sending a
+    real signal here would kill the process the watchdog is checking on."""
+    monkeypatch.setattr(os, "name", "posix")
+    sent = []
+    monkeypatch.setattr(os, "kill", lambda pid, sig: sent.append((pid, sig)))
+    assert process_exists(4321) is True
+    assert sent == [(4321, 0)]
+
+
+# ── the Windows branch ───────────────────────────────────────────────
+
+
+class _Kernel32:
+    """Stands in for kernel32, so the Windows path runs anywhere."""
+
+    def __init__(self, handle: int, last_error: int = 0):
+        self._handle = handle
+        self.last_error = last_error
+        self.closed: list[int] = []
+
+    def OpenProcess(self, _access, _inherit, _pid):  # noqa: N802 - Win32 name
+        return self._handle
+
+    def CloseHandle(self, handle):  # noqa: N802 - Win32 name
+        self.closed.append(handle)
+        return True
+
+
+def _run_windows_branch(monkeypatch, handle: int, last_error: int = 0):
+    import ctypes
+
+    monkeypatch.setattr(os, "name", "nt")
+    fake = _Kernel32(handle, last_error)
+    monkeypatch.setattr(ctypes, "WinDLL", lambda *_a, **_k: fake, raising=False)
+    monkeypatch.setattr(ctypes, "get_last_error", lambda: fake.last_error, raising=False)
+    return fake, process_exists(1234)
+
+
+def test_windows_an_open_handle_means_alive(monkeypatch):
+    fake, alive = _run_windows_branch(monkeypatch, handle=42)
+    assert alive is True
+    assert fake.closed == [42], "the handle leaked; this runs on a watchdog timer"
+
+
+def test_windows_invalid_parameter_means_dead(monkeypatch):
+    """ERROR_INVALID_PARAMETER (87) is what OpenProcess returns for a pid that
+    does not exist. It is the only failure that proves absence."""
+    _, alive = _run_windows_branch(monkeypatch, handle=0, last_error=87)
+    assert alive is False
+
+
+def test_windows_access_denied_means_alive(monkeypatch):
+    """ERROR_ACCESS_DENIED (5): the process is there and owned by someone
+    else. Same ambiguity rule as the POSIX branch."""
+    _, alive = _run_windows_branch(monkeypatch, handle=0, last_error=5)
+    assert alive is True

--- a/tests/test_stems_api.py
+++ b/tests/test_stems_api.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 
 from app.core.models import Job
 from app.core.registry import _jobs
+from tests.ffmpeg_probe import ffmpeg_available, skip_without_ffmpeg
 
 
 @pytest.fixture(autouse=True)
@@ -370,10 +371,9 @@ def test_all_stems_zip_404_when_no_stem_files(client, tmp_path):
 def test_all_stems_zip_mp3(client, tmp_path):
     """MP3 zip transcodes via ffmpeg; skip if ffmpeg isn't available."""
     import io
-    import shutil
     import zipfile
 
-    if shutil.which("ffmpeg") is None:
+    if not ffmpeg_available():
         import pytest
 
         pytest.skip("ffmpeg not available")
@@ -405,10 +405,9 @@ def test_all_stems_zip_mp3(client, tmp_path):
 def test_all_stems_zip_ogg(client, tmp_path):
     """OGG zip transcodes via ffmpeg (libvorbis); skip if ffmpeg isn't available."""
     import io
-    import shutil
     import zipfile
 
-    if shutil.which("ffmpeg") is None:
+    if not ffmpeg_available():
         import pytest
 
         pytest.skip("ffmpeg not available")
@@ -533,12 +532,10 @@ def test_mixdown_404_for_missing_stem_file(client, tmp_path):
 
 
 def _skip_without_ffmpeg():
-    import shutil
-
-    if shutil.which("ffmpeg") is None:
-        import pytest
-
-        pytest.skip("ffmpeg not available")
+    # Resolves ffmpeg the way the app does, not by looking at PATH. See
+    # tests/ffmpeg_probe.py: the PATH-only check silently skipped twenty tests
+    # on machines where the bundled binary works fine.
+    skip_without_ffmpeg()
 
 
 def test_mixdown_wav_happy(client, tmp_path):


### PR DESCRIPTION
Closes #448
Closes #449
Closes #450
Closes #451

Coverage went 82.6% to **85.0%**. The more useful part is why the starting number was not the one anyone had been looking at.

## The measurement was broken (#448)

Every ffmpeg-dependent test guarded on `shutil.which("ffmpeg")`, which is not how the app finds ffmpeg. `ffmpeg_executable()` prefers the bundled binary and only falls back to PATH, so on a machine with a working bundled ffmpeg and nothing on PATH, twenty-odd tests skipped while the code they covered ran perfectly.

Silent, and it lied about coverage:

| | Reported | Actual |
|---|---|---|
| `app/api/stems.py` | 51.3% | **85%** |
| Whole app | 78.0% | **82.6%** |
| Failures | 14 | 4 |

CI installs ffmpeg, so CI measured one thing and every developer machine measured another with nothing surfacing the gap. `stems.py` was the top candidate for this work on those numbers and turned out not to need it.

One probe now, in `tests/ffmpeg_probe.py`, resolving ffmpeg the way the app does and actually running it. A path that exists but is not executable counts as unavailable, which is a real state for a Linux portable install.

## Key and tempo detection (#449)

26.4% to **99.2%**. The least covered module in the app and the one where a bug is quietest: nothing crashes, a mis-detected key just renders a confident wrong label and a wrong tempo silently misplaces every beat in the click track and grid editor.

Audio is generated at a known tempo and pitch rather than committed as a fixture, so the expected answer is known instead of being whatever the file contained.

Three assertions worth naming:

**All twelve rotations**, not a sample. An off-by-one there makes exactly one key permanently undetectable and changes nothing else.

**The near-tie prefers minor.** A deliberate pop and rock prior, documented in the source with Come As You Are as the example. It reads like a bug to anyone meeting it cold, and without a test someone will "fix" it.

**The minor profile weights b7 above M7.** The whole reason this project uses Albrecht-Shanahan rather than a Bach-derived profile. Swapping in a classical one would look like an improvement and be wrong for the repertoire.

## A real bug, found while writing those (#450)

`_load_audio_ffmpeg` caught `FileNotFoundError` but not `OSError`. A missing ffmpeg degraded to `None` as intended; an ffmpeg present but **not executable** raised `PermissionError` and failed the analysis outright.

Everything that function produces is a display field, so `None` is always the right answer on failure. Widened to `OSError`, which subsumes the missing-binary case.

## The watchdog's liveness check (#451)

63.6% to **100%**. Half of `process_exists` is unreachable on any single machine: CI is Linux, so the Windows branch had never been executed by a test, and it is the branch most desktop users run.

Both failure directions are silent. Reporting a live process as dead kills a worker mid-separation; reporting a dead one as alive orphans a process holding the GPU, which is what the parent-PID watchdog exists to prevent.

Patching `os.name` and stubbing `kernel32` drives both. The rule the module exists for is now pinned on both sides: a permission error means the process is there and owned by someone else, so it counts as alive. A watchdog must not shoot on ambiguity. On Windows that is `ERROR_ACCESS_DENIED` meaning alive against `ERROR_INVALID_PARAMETER` meaning gone, a distinction easy to collapse into "the call failed".

Also asserted: the POSIX branch sends signal 0 rather than a real one, and the Windows branch closes its handle. This runs on a timer, so a leaked handle leaks per tick.

## Result

| | Before | After |
|---|---|---|
| Total | 82.6% | **85.0%** |
| `analyze.py` | 26.4% | 99.2% |
| `process.py` | 63.6% | 100% |
| Tests | 759 | **814** |

`ruff check` and `ruff format --check` clean, bandit 0 medium and 0 high.

The 4 remaining failures also fail on `main` in this environment: a CRLF assertion in the logs zip test, the Linux executable bit, and two watchdog tests. All Windows-local, none related to this branch.

## Note for review

Only one production line changed, the `except` clause in #450. Everything else is tests.