### PR TITLE
Fix the macOS release build's QuickJS arch mapping

### DIFF
--- a/scripts/macos/make-runtime-pack.sh
+++ b/scripts/macos/make-runtime-pack.sh
@@ -178,11 +178,14 @@ JSON
 #
 # Pinned by version and SHA256, the same rule as the macOS FFmpeg download
 # (#172).
+# ARCH is this script's own value, validated at the top as arm64 or x64. It is
+# not the asset naming, which uses x86_64: mapping between the two is the whole
+# job of this case, and conflating them is what broke the first x64 build.
 QJS_VERSION="v0.16.2"
 case "$ARCH" in
-  arm64)  QJS_ASSET="qjs-darwin-arm64";  QJS_SHA256="f6200e9856c45578a5d42ac873a32f3f994b421e29df9f63b452d9c7145015fc" ;;
-  x86_64) QJS_ASSET="qjs-darwin-x86_64"; QJS_SHA256="4448991c0500dbe40c7b2f91ba39275995413aa4ee59db3b513b68350908a413" ;;
-  *) echo "unknown arch for QuickJS: $ARCH" >&2; exit 1 ;;
+  arm64) QJS_ASSET="qjs-darwin-arm64";  QJS_SHA256="f6200e9856c45578a5d42ac873a32f3f994b421e29df9f63b452d9c7145015fc" ;;
+  x64)   QJS_ASSET="qjs-darwin-x86_64"; QJS_SHA256="4448991c0500dbe40c7b2f91ba39275995413aa4ee59db3b513b68350908a413" ;;
+  *) echo "ERROR: no QuickJS mapping for ARCH '${ARCH}'" >&2; exit 1 ;;
 esac
 QJS_DIR="${BACKEND_DIR}/jsruntime"
 mkdir -p "$QJS_DIR"


### PR DESCRIPTION
Closes #454

The macOS x64 build for 0.15.0 failed at backend staging with `unknown arch for QuickJS: x64`.

`ARCH` is this script's own value, validated at the top of the file as `arm64` or `x64`. The quickjs-ng release assets use a different vocabulary: `qjs-darwin-arm64` and `qjs-darwin-x86_64`. Translating between the two is the entire purpose of that `case`, and it was written as though both used the same names, so arm64 worked and x64 fell through to the error branch.

A comment now names which vocabulary `ARCH` belongs to, because the resemblance between `x64` and `x86_64` is what makes this easy to write wrong twice.

## Scope

macOS only. Neither Linux nor Windows takes an `ARCH` variable; both name their asset directly.

## What the failed release already tells us

| | |
|---|---|
| Linux Release | **success**, `Fetching QuickJS v0.16.2` in the log for both CPU and NVIDIA |
| Docker Publish | success |
| macOS Release | failed here |
| Windows Release | still running at the time of writing |

So the approach holds and this is a naming slip in one of the three scripts.

## Verified

`bash -n` passes, and all three branches were exercised directly:

```
ARCH=arm64 -> qjs-darwin-arm64
ARCH=x64   -> qjs-darwin-x86_64
ARCH=ppc   -> ERROR: no QuickJS mapping for ARCH 'ppc'
```

Beyond that this needs a real macOS build to confirm, which is the same residual risk noted when #438 landed: these scripts have no automated coverage and cannot be exercised outside a release.