### PR TITLE
Pin the Unraid template to 0.15.1

### DIFF
--- a/templates/stemdeck.xml
+++ b/templates/stemdeck.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>StemDeck</Name>
-  <Repository>ghcr.io/stemdeckapp/stemdeck:edge</Repository>
+  <Repository>ghcr.io/stemdeckapp/stemdeck:0.15.1</Repository>
   <Registry>https://github.com/stemdeckapp/stemdeck/pkgs/container/stemdeck</Registry>
   <Network>bridge</Network>
   <Shell>sh</Shell>


### PR DESCRIPTION
Closes #453

Moves Community Applications off `edge` and onto a specific published tag.

`edge` is rebuilt on every merge to `main`, so Unraid users have been running whatever landed most recently, before it was tagged or verified. Desktop users are only offered a build once a release has been promoted by hand, precisely so nothing reaches them inside the verification window. Unraid had no such window at all.

It also made bug reports hard to act on: `edge` from Tuesday and `edge` from Thursday are different software with the same name.

## Why 0.15.1 and not 0.15.0

0.15.0's macOS build failed on the QuickJS arch mapping (#454). 0.15.1 is the first tag carrying that fix, so it is the first one worth pinning.

## Do not merge before 0.15.1 is published

The image publishes on the `release: published` event, and the template on `main` is what Community Applications serves live. Merging this before 0.15.1 exists gives every Unraid user a pull failure.

Sequence: publish 0.15.1, confirm `ghcr.io/stemdeckapp/stemdeck:0.15.1` exists, then merge this.