### PR TITLE
One Discord invite, and a website that exists

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,7 @@ contact_links:
     url: https://github.com/stemdeckapp/stemdeck/discussions
     about: Ask questions, share setups, or discuss ideas with the community.
   - name: Discord
-    url: https://discord.gg/2MVsWqaPRe
+    url: https://discord.gg/YhCKsjhcwB
     about: Chat with the StemDeck community in real time.
   - name: Report a security vulnerability
     url: https://github.com/stemdeckapp/stemdeck/security/advisories/new

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,4 +79,4 @@ contributions are licensed under the same terms.
 ## Questions
 
 Open a [Discussion](https://github.com/stemdeckapp/stemdeck/discussions) or join the
-[Discord](https://discord.gg/2MVsWqaPRe). Thanks for helping make StemDeck better.
+[Discord](https://discord.gg/YhCKsjhcwB). Thanks for helping make StemDeck better.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 <p align="center"><sub>JOIN THE COMMUNITY</sub></p>
 <div align="center">
   <a href="https://github.com/stemdeckapp/stemdeck"><img src="https://img.shields.io/badge/GitHub-stemdeckapp-181717?style=flat-square&logo=github&logoColor=white" alt="GitHub"></a>
-  <a href="https://discord.gg/2MVsWqaPRe"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord"></a>
+  <a href="https://discord.gg/YhCKsjhcwB"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord"></a>
   <a href="https://www.reddit.com/r/StemDeckApp/"><img src="https://img.shields.io/badge/Reddit-r%2FStemDeckApp-FF4500?style=flat-square&logo=reddit&logoColor=white" alt="Reddit"></a>
   <a href="https://www.instagram.com/stemdeck"><img src="https://img.shields.io/badge/Instagram-stemdeck-E4405F?style=flat-square&logo=instagram&logoColor=white" alt="Instagram"></a>
   <a href="https://x.com/StemDeckApp"><img src="https://img.shields.io/badge/X-StemDeckApp-000000?style=flat-square&logo=x&logoColor=white" alt="X"></a>
@@ -410,11 +410,11 @@ The author(s) of StemDeck provide this software "as is", without warranty of any
 | Platform | Link |
 |---|---|
 | GitHub | [stemdeckapp/stemdeck](https://github.com/stemdeckapp/stemdeck) |
-| Discord | [discord.gg/2MVsWqaPRe](https://discord.gg/2MVsWqaPRe) |
+| Discord | [discord.gg/YhCKsjhcwB](https://discord.gg/YhCKsjhcwB) |
 | Reddit | [r/StemDeckApp](https://www.reddit.com/r/StemDeckApp/) |
 | Instagram | [@stemdeck](https://www.instagram.com/stemdeck) |
 | X | [@StemDeckApp](https://x.com/StemDeckApp) |
-| Website | [stemdeck.app](https://stemdeck.app) *(coming soon)* |
+| Website | [stemdeck.app](https://stemdeck.app) |
 
 ---
 

--- a/static/index.html
+++ b/static/index.html
@@ -849,7 +849,7 @@
         <div class="about-divider"></div>
 
         <div class="about-socials">
-          <a class="about-social-btn" href="https://discord.gg/JGk7FdZb9N" target="_blank" rel="noopener noreferrer" title="Discord" aria-label="Discord">
+          <a class="about-social-btn" href="https://discord.gg/YhCKsjhcwB" target="_blank" rel="noopener noreferrer" title="Discord" aria-label="Discord">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"/></svg>
           </a>
           <a class="about-social-btn" href="https://www.reddit.com/r/StemDeckApp/" target="_blank" rel="noopener noreferrer" title="Reddit" aria-label="Reddit">

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -20,7 +20,7 @@ const MAX_FAILURES = 20;
 const NEW_ISSUE_URL = "https://github.com/stemdeckapp/stemdeck/issues/new";
 // Support channel for a quicker back-and-forth than a public issue -- same
 // invite as the About dialog's Discord icon (index.html).
-const DISCORD_URL = "https://discord.gg/JGk7FdZb9N";
+const DISCORD_URL = "https://discord.gg/YhCKsjhcwB";
 // Named views the Settings -> Logs viewer offers (app/main.py _LOG_VIEWS).
 // Opt-in only (fetchRecentLogs): unlike the per-job traceback, these cover
 // more than one failure and are worth a deliberate click, not an automatic


### PR DESCRIPTION
Closes #465

Two invites were live in the tree, pointing at different servers, and neither was the one in use. Where someone landed depended on which door they came through.

| File | Was | Now |
|---|---|---|
| `README.md` (badge + links table) | `2MVsWqaPRe` | `YhCKsjhcwB` |
| `CONTRIBUTING.md` | `2MVsWqaPRe` | `YhCKsjhcwB` |
| `.github/ISSUE_TEMPLATE/config.yml` | `2MVsWqaPRe` | `YhCKsjhcwB` |
| `static/index.html` (About panel) | `JGk7FdZb9N` | `YhCKsjhcwB` |
| `static/js/notifications.js` (report a failure) | `JGk7FdZb9N` | `YhCKsjhcwB` |

The README also still carried `*(coming soon)*` next to a working link to stemdeck.app. The site is deployed, so that is gone.

Seven lines, no logic. `node --check` passes on `notifications.js` and `config.yml` still parses as YAML, which matters because a malformed chooser file drops the "ask a question" entry silently rather than failing.

Worth knowing: the two `static/` changes only reach users in a release. The three docs changes take effect the moment this merges.
