### PR TITLE
Pin the Unraid template to 0.15.2

### DIFF
--- a/templates/stemdeck.xml
+++ b/templates/stemdeck.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>StemDeck</Name>
-  <Repository>ghcr.io/stemdeckapp/stemdeck:0.15.1</Repository>
+  <Repository>ghcr.io/stemdeckapp/stemdeck:0.15.2</Repository>
   <Registry>https://github.com/stemdeckapp/stemdeck/pkgs/container/stemdeck</Registry>
   <Network>bridge</Network>
   <Shell>sh</Shell>


### PR DESCRIPTION
Closes #470

One line: `ghcr.io/stemdeckapp/stemdeck:0.15.1` becomes `:0.15.2`.

## What this actually gives Unraid users

Very little, and it is better to say so than to imply otherwise. For a container, 0.15.1 and 0.15.2 are near enough the same software:

```
f059ad1  The shell recognises its own backend by token, not by PID (#460)
6ab7edc  Pin the Unraid template to 0.15.1 (#456)
```

The only part of that reaching Docker is one extra field in the `/api/health` payload. `desktop/src-tauri/src/main.rs` is the bulk of the change and containers never ship it.

What it does give is version identity, the same thing #453 was about. An Unraid bug report names whatever the template handed out, and a pin that habitually lags means every report needs translating before it can be acted on. Letting the gap grow also turns the eventual bump into several changes landing at once, none of them individually observed in the container path.

## The image exists

Checked before pinning, since a pin to an unpublished tag is an immediate pull failure for every Unraid user and Community Applications serves this file from `main` live.

`Docker Publish` succeeded on the `release` event for `v0.15.2`. Worth noting for anyone repeating the check: an anonymous GHCR manifest request is not evidence here either way, because `0.15.1` and `latest` return 404 on the same query despite both existing.

XML still parses.
