### PR TITLE
Transpose the whole track, or one lane at a time, on one clock

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Shell scripts are executed by bash, which treats a trailing CR as part of the
+# command and fails on every line. On Windows `core.autocrlf=true` would check
+# them out with CRLF, so the browser test harness (tests/e2e/serve.sh) is only
+# runnable on Linux. Pin them to LF regardless of the developer's setting.
+*.sh text eol=lf

--- a/static/css/daw.css
+++ b/static/css/daw.css
@@ -1687,7 +1687,7 @@ input, textarea { font-family: inherit; }
 .lane-header.mx-row {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 5px;
   padding: 0 10px;
   height: var(--lane-h, 72px);
   min-height: 72px;
@@ -1705,12 +1705,16 @@ input, textarea { font-family: inherit; }
 .lane-stripe { display: none; }
 
 /* Name + VU stacked vertically */
+/* The name and its meter share a fixed column, and the fader takes whatever is
+   left of the row. So this width is the fader's length: every pixel taken off
+   here is a pixel the fader gains. 76px left the fader badly compressed once
+   the key stepper joined the row. */
 .lane-name-vu {
   display: flex;
   flex-direction: column;
   justify-content: center;
   gap: 5px;
-  width: 76px;
+  width: 58px;
   flex-shrink: 0;
 }
 
@@ -1777,9 +1781,11 @@ input, textarea { font-family: inherit; }
 }
 
 /* VU meter — sits below stem name in .lane-left-col, spans full column width */
+/* 5px read as a hairline rather than a meter: at that height the gradient had
+   nowhere to show and a moving level was hard to see at a glance. */
 .lane-vu.mx-meter {
   position: relative;
-  height: 5px;
+  height: 10px;
   width: 100%;
   background: var(--bg);
   border: 1px solid var(--border);
@@ -2383,6 +2389,48 @@ input, textarea { font-family: inherit; }
 .speed-btn.active:hover {
   background: rgba(232,200,64,0.16); color: var(--accent);
 }
+/* Transpose stepper (#245). Sits in a .footer-seg so it inherits the frame and
+   hover behaviour of the speed and click controls beside it; only the readout
+   between the two buttons is new. */
+.pitch-value {
+  display: flex; align-items: center; justify-content: center;
+  min-width: 34px; padding: 0 6px;
+  border-left: 1px solid var(--border); border-right: 1px solid var(--border);
+  color: var(--muted);
+  font-family: var(--font-mono); font-size: 11px; font-weight: 600; line-height: 1;
+  font-variant-numeric: tabular-nums;  /* so +10 and -6 do not shift the buttons */
+  transition: color var(--t-fast), background var(--t-fast);
+}
+/* Lit only when transposed, so "this track is not in its original key" is
+   visible at a glance rather than needing the number to be read. */
+.pitch-value.active {
+  background: rgba(232,200,64,0.16); color: var(--accent);
+}
+.pitch-btn:disabled {
+  opacity: 0.35; cursor: default;
+}
+.pitch-btn:disabled:hover { background: transparent; color: var(--muted); }
+
+/* Reset. Outside the stepper's frame, because it does something to the whole
+   mix rather than one more step: it returns every mixer lane to the key the
+   recording is in, which the stepper alone cannot do once lanes have been moved
+   individually. */
+.pitch-reset {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 28px; height: 28px; padding: 0;
+  background: transparent;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  color: var(--muted);
+  font-size: 15px; line-height: 1;
+  cursor: pointer;
+  transition: background var(--t-fast), color var(--t-fast), border-color var(--t-fast);
+}
+.pitch-reset:hover:not(:disabled) {
+  background: var(--panel-3); color: var(--fg); border-color: var(--border);
+}
+.pitch-reset:disabled { opacity: 0.35; cursor: default; }
+
 .metro-mult-btn.active,
 .metro-mult-btn.active:hover {
   background: rgba(74,140,255,0.16); color: #4a8cff;
@@ -3366,3 +3414,82 @@ input, textarea { font-family: inherit; }
   width: 100%; box-sizing: border-box;
   min-height: 260px; white-space: pre; overflow-wrap: normal; overflow-x: auto;
 }
+
+/* ── Per-lane transpose (the K stepper) ────────────────────────────────────
+   Sits in the row just left of M, with its arrows stacked above and below the
+   reading, and drawn from the same kit as M and S: same border, same radius,
+   same mono face, same width. It reads as one more control in that cluster
+   rather than as a different kind of thing parked next to it.
+
+   Stacked rather than inline because the lane row only has about 300px, and at
+   the inline width the fader collapsed to 10px. The vertical form costs 22px
+   instead of 55px, and the row has the height spare. */
+.lane-key {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  width: 22px;
+  flex-shrink: 0;
+}
+/* The K is the button, and it is the same box as M and S: same size, same
+   border, same radius, same mono face. Boxing the arrows instead put two
+   look-alike buttons around a floating letter, which is the opposite of the
+   family it belongs to -- M and S are each one box with one character in it. */
+.lane-key-value {
+  width: 22px;
+  height: 20px;
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid var(--border-strong);
+  border-radius: 5px;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+  transition: background var(--t-fast), color var(--t-fast), border-color var(--t-fast);
+}
+/* Lit while the lane is off its own key, the way S lights when soloed. */
+.lane-key.active .lane-key-value {
+  background: rgba(244, 183, 64, 0.18);
+  color: var(--accent);
+  border-color: rgba(244, 183, 64, 0.4);
+}
+
+/* The arrows are the stepper around it, not two more buttons: no border, so
+   they stay quiet next to the three boxes they sit beside. */
+.lane-key-step {
+  width: 22px;
+  height: 11px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: 3px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  font-family: var(--font-mono);
+  line-height: 1;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: color var(--t-fast), background var(--t-fast);
+}
+.lane-key-step:hover:not(:disabled) {
+  color: var(--fg);
+  background: rgba(255, 255, 255, 0.07);
+}
+.lane-key-step:disabled { opacity: 0.3; cursor: default; }
+/* Drums, and anything else that must never be resampled. */
+.lane-key.locked,
+.lane-key.unsupported { opacity: 0.35; }
+.lane-key.locked .lane-key-step,
+.lane-key.unsupported .lane-key-step { cursor: not-allowed; }

--- a/static/index.html
+++ b/static/index.html
@@ -742,6 +742,20 @@
 
           <span class="footer-divider" aria-hidden="true"></span>
 
+          <div class="footer-group footer-group-key">
+            <span class="footer-group-label" id="t-pitch-label" data-i18n="pitch.group">Global key</span>
+            <div class="footer-group-body">
+              <div class="footer-seg pitch-group" id="t-pitch-wrap" role="group" aria-labelledby="t-pitch-label">
+                <button class="pitch-btn" id="t-pitch-down" type="button" title="Transpose down a semitone" aria-label="Transpose down a semitone" data-i18n-title="pitch.downTitle" data-i18n-aria-label="pitch.downTitle" disabled>&minus;</button>
+                <output class="pitch-value" id="t-pitch-value" for="t-pitch-down t-pitch-up" aria-labelledby="t-pitch-label" aria-live="polite">0</output>
+                <button class="pitch-btn" id="t-pitch-up" type="button" title="Transpose up a semitone" aria-label="Transpose up a semitone" data-i18n-title="pitch.upTitle" data-i18n-aria-label="pitch.upTitle" disabled>+</button>
+              </div>
+              <button class="pitch-reset" id="t-pitch-reset" type="button" title="Put every lane back in the original key" aria-label="Put every lane back in the original key" data-i18n-title="pitch.resetTitle" data-i18n-aria-label="pitch.resetTitle" disabled>&#8634;</button>
+            </div>
+          </div>
+
+          <span class="footer-divider" aria-hidden="true"></span>
+
           <div class="footer-group footer-group-click" id="t-metro-wrap">
             <span class="footer-group-label"><span data-i18n="click.group">Click track</span> <span class="alpha-badge" data-i18n="click.alpha">Alpha</span></span>
             <div class="footer-group-body">

--- a/static/js/audioEngine.js
+++ b/static/js/audioEngine.js
@@ -16,9 +16,13 @@
 const AudioCtx = window.AudioContext || window.webkitAudioContext;
 
 /**
- * @param {{name:string,url:string}[]} stems  Active stems only (caller filters).
+ * @param {{name:string,url:string,controlName?:string,pitched?:boolean,visualOnly?:boolean}[]} stems
  * @param {{onTime?:(t:number)=>void, onEnded?:()=>void}} cbs
  */
+import {
+  INPUT_COUNT, ZERO_INPUT, clampPitch, effectivePitch, inputForPitch,
+} from "./pitchBus.js";
+
 export function createAudioEngine(stems, { onTime, onEnded, context } = {}) {
   // Mobile/iOS only starts audio from a context resumed inside a user gesture.
   // Callers can pass a shared, gesture-unlocked `context` (the mobile UI does);
@@ -26,22 +30,44 @@ export function createAudioEngine(stems, { onTime, onEnded, context } = {}) {
   const ctx = context || new AudioCtx();
   const ownsCtx = !context;
   const master = ctx.createGain();
+  // One bus per semitone the worklet offers. A lane's transpose is expressed
+  // as which bus it is connected to, so several lanes can sit in different
+  // keys at once while still sharing the worklet's single tempo stage.
+  const buses = Array.from({ length: INPUT_COUNT }, () => ctx.createGain());
+  master.connect(ctx.destination);
 
-  // SoundTouch pitch-preserving time-stretch on the master bus.
-  // Falls back to tape-effect (playbackRate) if AudioWorklet is unavailable.
+  let _playbackRate = 1.0;
+
+  // SoundTouch takes one input per semitone. Input ZERO_INPUT is the plain
+  // delay line: drums, the click, and any lane sitting at its own key.
   let stNode = null;
+  // Reported by the processor, because deriving it here would mean keeping a
+  // copy of its buffering constants in sync by hand.
+  let _workletLatencyFrames = 0;
   const _workletReady = (ctx.audioWorklet
     ? ctx.audioWorklet.addModule('/vendor/soundtouch-processor.js').then(() => {
-        stNode = new AudioWorkletNode(ctx, 'soundtouch-processor');
-        master.connect(stNode);
-        stNode.connect(ctx.destination);
+        stNode = new AudioWorkletNode(ctx, 'soundtouch-processor', {
+          numberOfInputs: INPUT_COUNT,
+          numberOfOutputs: 1,
+          outputChannelCount: [2],
+        });
+        stNode.port.onmessage = (event) => {
+          if (event?.data?.type === 'latency') _workletLatencyFrames = event.data.frames || 0;
+        };
+        // The worklet loads asynchronously, so anything set before it arrived
+        // would otherwise be dropped. Re-apply the current value now.
+        stNode.parameters.get('tempo').value = _playbackRate;
+        for (let k = 0; k < INPUT_COUNT; k++) buses[k].connect(stNode, 0, k);
+        stNode.connect(master);
       }).catch((err) => {
         console.warn('[audioEngine] SoundTouch worklet load failed, using tape-effect fallback:', err);
-        master.connect(ctx.destination);
+        for (const bus of buses) bus.connect(master);
       })
-    : Promise.resolve().then(() => { master.connect(ctx.destination); }));
+    : Promise.resolve().then(() => {
+        for (const bus of buses) bus.connect(master);
+      }));
 
-  /** @type {Map<string,{buffer:AudioBuffer,gain:GainNode,analyser:AnalyserNode,source:AudioBufferSourceNode|null}>} */
+  /** @type {Map<string,{buffer:AudioBuffer,gain:GainNode,analyser:AnalyserNode,source:AudioBufferSourceNode|null,controlName:string,pitched:boolean,visualOnly:boolean}>} */
   const tracks = new Map();
   let duration = 0;
   let playing = false;
@@ -50,7 +76,6 @@ export function createAudioEngine(stems, { onTime, onEnded, context } = {}) {
   let rafId = null;
   let destroyed = false;
   let loop = { enabled: false, start: 0, end: 0 };
-  let _playbackRate = 1.0;
   // Bumped whenever the media-time -> ctx-time mapping below changes (start,
   // seek, loop jump, rate change, pause). The metronome watches this to know
   // when its already-scheduled clicks are stale and must be torn down.
@@ -85,12 +110,28 @@ export function createAudioEngine(stems, { onTime, onEnded, context } = {}) {
         try {
           const buffer = await ctx.decodeAudioData(bytes);
           if (destroyed) return;
+          const visualOnly = s.visualOnly === true;
+          const pitchable = s.name !== "drums" && s.pitched !== false;
           const gain = ctx.createGain();
           const analyser = ctx.createAnalyser();
           analyser.fftSize = 1024;
-          gain.connect(analyser);
-          analyser.connect(master);
-          tracks.set(s.name, { buffer, gain, analyser, source: null });
+          if (!visualOnly) gain.connect(analyser);
+          const track = {
+            buffer,
+            gain,
+            analyser,
+            source: null,
+            name: s.name,
+            controlName: s.controlName || s.name,
+            pitchable,
+            pitched: pitchable,
+            pitch: 0,
+            bus: null,
+            level: 1,
+            visualOnly,
+          };
+          tracks.set(s.name, track);
+          routeTrack(track, true);
           duration = Math.max(duration, buffer.duration);
         } catch (e) {
           undecodable++;
@@ -99,14 +140,15 @@ export function createAudioEngine(stems, { onTime, onEnded, context } = {}) {
       }),
     ]);
 
-    if (tracks.size === 0) {
+    const hasPlaybackTrack = [...tracks.values()].some((track) => !track.visualOnly);
+    if (!hasPlaybackTrack) {
       _loadError = undecodable
         ? "This track's audio files are in a format StemDeck could not read."
         : unreachable
           ? "Could not load this track's audio files."
           : "This track has no stem files to play.";
     }
-    return tracks.size > 0;
+    return hasPlaybackTrack;
   })();
 
   // Clamped so the reported playhead never reads before the start position.
@@ -114,8 +156,34 @@ export function createAudioEngine(stems, { onTime, onEnded, context } = {}) {
   // (startCtxTime > ctx.currentTime), which would otherwise make this go
   // negative -- the playhead must sit still at the start until the audio enters.
   // A no-op for a normal start, where startCtxTime == the moment play() ran.
-  const now = () =>
-    playing ? Math.max(startOffset, (ctx.currentTime - startCtxTime) * _playbackRate + startOffset) : startOffset;
+  const wsolaLatencySeconds = () => {
+    const needed = Math.round(0.012 * ctx.sampleRate)
+      + Math.round(0.028 * ctx.sampleRate)
+      + Math.round(0.082 * ctx.sampleRate);
+    return Math.floor(needed / 128) * 128 / ctx.sampleRate;
+  };
+  const anyLaneTransposed = () => {
+    for (const t of tracks.values()) {
+      if (t.visualOnly) continue;
+      if (effectivePitch(t.name, t.pitch, t.pitchable) !== 0) return true;
+    }
+    return false;
+  };
+  const pipelineLatencySeconds = () => {
+    if (!stNode) return 0;
+    // The pitch buses only buffer once something is actually transposed. Until
+    // then the worklet hands its input straight back, with no delay to correct.
+    const pitchLatency = anyLaneTransposed() ? _workletLatencyFrames / ctx.sampleRate : 0;
+    const tempoStages = Math.abs(_playbackRate - 1) >= 1e-3 ? 1 : 0;
+    return pitchLatency + tempoStages * wsolaLatencySeconds();
+  };
+  const now = () => playing
+    ? Math.max(
+        startOffset,
+        Math.max(0, ctx.currentTime - startCtxTime - pipelineLatencySeconds())
+          * _playbackRate + startOffset,
+      )
+    : startOffset;
 
   // Extra headroom folded into a count-in's lead so every count click lands
   // safely in the future even after the small gap between scheduling the
@@ -132,8 +200,14 @@ export function createAudioEngine(stems, { onTime, onEnded, context } = {}) {
     }
   }
 
+  function resetProcessor() {
+    try { stNode?.port?.postMessage({ type: "reset" }); } catch { /* processor is gone */ }
+  }
+
   function startSources(offset, when = ctx.currentTime) {
+    resetProcessor();
     for (const t of tracks.values()) {
+      if (t.visualOnly) continue;
       const src = ctx.createBufferSource();
       src.buffer = t.buffer;
       // SoundTouch handles time-stretch; playbackRate stays 1.0.
@@ -155,9 +229,8 @@ export function createAudioEngine(stems, { onTime, onEnded, context } = {}) {
 
   // Inverse of the scheduling in startSources: the AudioContext time at which
   // media time `t` is fed into the graph. Scheduling a click here puts it in
-  // the same sample frame as the stems, which is what keeps the two locked
-  // together -- and because it describes the *input* to SoundTouch, it holds
-  // whatever the worklet does downstream, since the click goes through it too.
+  // the same sample frame as the stems. The click uses the unpitched input and
+  // shares the worklet's tempo stage with the combined audio.
   const sourceTimeToCtxTime = (t) => startCtxTime + (t - startOffset) / srcRate();
 
   // True inverse of the above. The metronome re-anchors with this rather than
@@ -206,6 +279,7 @@ export function createAudioEngine(stems, { onTime, onEnded, context } = {}) {
     if (!playing) return;
     const t = now();
     stopSources();
+    resetProcessor();
     playing = false;
     startOffset = Math.max(0, Math.min(t, duration));
     _epoch++;
@@ -218,6 +292,7 @@ export function createAudioEngine(stems, { onTime, onEnded, context } = {}) {
       stopSources();
       startSources(clamped); // bumps _epoch
     } else {
+      resetProcessor();
       startOffset = clamped;
       _epoch++;
     }
@@ -225,8 +300,40 @@ export function createAudioEngine(stems, { onTime, onEnded, context } = {}) {
   }
 
   function setGain(name, v) {
-    const t = tracks.get(name);
-    if (t) t.gain.gain.setTargetAtTime(Math.max(0, v), ctx.currentTime, 0.01);
+    for (const t of tracks.values()) {
+      if (!t.visualOnly && t.controlName === name) {
+        t.level = Math.max(0, v);
+        t.gain.gain.setTargetAtTime(t.level, ctx.currentTime, 0.01);
+      }
+    }
+  }
+
+  // Ducking either side of a bus change. Both buses are delayed by the same
+  // amount, so a dip scheduled at the source lands at the output as one short
+  // dip rather than as a click from splicing two different keys together.
+  const ROUTE_FADE = 0.006;
+  const ROUTE_HOLD = 0.02;
+
+  /** Connect a track to the bus for its current transpose. */
+  function routeTrack(t, immediate = false) {
+    if (t.visualOnly) return;
+    const target = buses[inputForPitch(effectivePitch(t.name, t.pitch, t.pitchable))];
+    if (t.bus === target) return;
+    const swap = () => {
+      if (destroyed) return;
+      try { t.analyser.disconnect(); } catch { /* was not connected yet */ }
+      t.analyser.connect(target);
+      t.bus = target;
+    };
+    if (immediate || !playing) { swap(); return; }
+    const g = t.gain.gain;
+    const at = ctx.currentTime;
+    g.cancelScheduledValues(at);
+    g.setValueAtTime(g.value, at);
+    g.linearRampToValueAtTime(0, at + ROUTE_FADE);
+    g.setValueAtTime(0, at + ROUTE_FADE + ROUTE_HOLD);
+    g.linearRampToValueAtTime(t.level, at + ROUTE_FADE + ROUTE_HOLD + ROUTE_FADE);
+    setTimeout(swap, (ROUTE_FADE + ROUTE_HOLD / 2) * 1000);
   }
 
   function setMasterGain(v) {
@@ -236,6 +343,7 @@ export function createAudioEngine(stems, { onTime, onEnded, context } = {}) {
   function destroy() {
     destroyed = true;
     stopSources();
+    resetProcessor();
     if (rafId) { cancelAnimationFrame(rafId); rafId = null; }
     tracks.clear();
     if (stNode) { try { stNode.disconnect(); } catch { /* noop */ } }
@@ -264,16 +372,57 @@ export function createAudioEngine(stems, { onTime, onEnded, context } = {}) {
     ctxTimeToSourceTime,
     getScheduleEpoch: () => _epoch,
     isClockReady: () => playing,
-    // The click connects here, not to ctx.destination: same bus as the stems,
-    // so it inherits master gain and the identical SoundTouch path.
-    getMasterNode: () => master,
+    // The click shares the unpitched input with drums. It still passes through
+    // the common tempo stage and master gain.
+    getMasterNode: () => buses[ZERO_INPUT],
+    /**
+     * Put one mixer lane in a given key.
+     *
+     * Nothing restarts and nothing is flushed. Every bus is delayed by the same
+     * amount, so the lane's old bus plays out the couple of hundred
+     * milliseconds it has already buffered while its new bus, primed with
+     * exactly that much silence, takes over at the instant the old one runs
+     * dry. The handover is a duck, not a gap.
+     */
+    setStemPitch(name, semitones) {
+      if (!stNode) return false;
+      const next = clampPitch(semitones);
+      let found = false;
+      for (const t of tracks.values()) {
+        if (t.visualOnly || t.controlName !== name) continue;
+        found = true;
+        if (t.pitch === next) continue;
+        t.pitch = next;
+        routeTrack(t);
+      }
+      return found;
+    },
+    getStemPitch(name) {
+      for (const t of tracks.values()) {
+        if (!t.visualOnly && t.controlName === name) return t.pitch;
+      }
+      return 0;
+    },
+    /** False for lanes that must never be resampled, so the UI can say so. */
+    isStemPitchable(name) {
+      for (const t of tracks.values()) {
+        if (!t.visualOnly && t.controlName === name) return t.pitchable;
+      }
+      return false;
+    },
+    supportsPitchShift: () => !!stNode,
     setPlaybackRate(rate) {
       if (stNode) {
-        // Pitch-preserving: update SoundTouch tempo parameter. The sources keep
-        // running at 1.0x, so the source-domain clock anchor is untouched.
+        const t = now();
         _playbackRate = rate;
-        _epoch++;
         stNode.parameters.get('tempo').value = rate;
+        if (playing) {
+          stopSources();
+          startSources(Math.max(0, Math.min(t, duration)));
+        } else {
+          resetProcessor();
+          _epoch++;
+        }
         return;
       }
       // Tape-effect fallback: the sources themselves resample, so the new rate
@@ -294,7 +443,11 @@ export function createAudioEngine(stems, { onTime, onEnded, context } = {}) {
     },
     setGain,
     setMasterGain,
-    getAnalyser: (name) => tracks.get(name)?.analyser ?? null,
+    getAnalysers: (name) => [...tracks.values()]
+      .filter((track) => !track.visualOnly && track.controlName === name)
+      .map((track) => track.analyser),
+    getAnalyser: (name) => [...tracks.values()]
+      .find((track) => !track.visualOnly && track.controlName === name)?.analyser ?? null,
     // Decoded AudioBuffers keyed by stem name — reused by the visuals (overview
     // waveforms, mini-waves, VU envelopes, energy bars) so they don't need the
     // multitrack to also decode the audio. Map<name, AudioBuffer>.

--- a/static/js/chunkedAudioEngine.js
+++ b/static/js/chunkedAudioEngine.js
@@ -182,45 +182,87 @@ function _pcmToAudioBuffer(ctx, pcmData, header) {
 // ---------------------------------------------------------------------------
 
 /**
- * @param {{name:string,url:string}[]} stems  Active stems (WAV URLs).
+ * @param {{name:string,url:string,controlName?:string,pitched?:boolean}[]} stems
  * @param {{onTime?:(t:number)=>void, onEnded?:()=>void, context?:AudioContext}} opts
  */
+import {
+  INPUT_COUNT, ZERO_INPUT, clampPitch, effectivePitch, inputForPitch,
+} from "./pitchBus.js";
+
 export function createChunkedAudioEngine(stems, { onTime, onEnded, context } = {}) {
   const AC = window.AudioContext || window.webkitAudioContext;
   const ctx = context || new AC();
   const ownsCtx = !context;
   const master = ctx.createGain();
+  // One bus per semitone the worklet offers. A lane's transpose is expressed
+  // as which bus it is connected to, so several lanes can sit in different
+  // keys at once while still sharing the worklet's single tempo stage.
+  const buses = Array.from({ length: INPUT_COUNT }, () => ctx.createGain());
+  master.connect(ctx.destination);
 
   let stNode = null;
   let _playbackRate = 1.0;
+  // Reported by the processor, because deriving it here would mean keeping a
+  // copy of its buffering constants in sync by hand.
+  let _workletLatencyFrames = 0;
   const _workletReady = (ctx.audioWorklet
     ? ctx.audioWorklet.addModule('/vendor/soundtouch-processor.js').then(() => {
-        stNode = new AudioWorkletNode(ctx, 'soundtouch-processor');
-        master.connect(stNode);
-        stNode.connect(ctx.destination);
+        stNode = new AudioWorkletNode(ctx, 'soundtouch-processor', {
+          numberOfInputs: INPUT_COUNT,
+          numberOfOutputs: 1,
+          outputChannelCount: [2],
+        });
+        stNode.port.onmessage = (event) => {
+          if (event?.data?.type === 'latency') _workletLatencyFrames = event.data.frames || 0;
+        };
+        // The worklet loads asynchronously, so anything set before it arrived
+        // would otherwise be dropped. Re-apply the current value now.
+        stNode.parameters.get('tempo').value = _playbackRate;
+        for (let k = 0; k < INPUT_COUNT; k++) buses[k].connect(stNode, 0, k);
+        stNode.connect(master);
       }).catch((err) => {
         console.warn('[chunkedEngine] SoundTouch worklet failed, tape-effect fallback:', err);
-        master.connect(ctx.destination);
+        for (const bus of buses) bus.connect(master);
       })
-    : Promise.resolve().then(() => { master.connect(ctx.destination); }));
+    : Promise.resolve().then(() => {
+        for (const bus of buses) bus.connect(master);
+      }));
+
+  // Declared ahead of the stem loop below, which routes each stem to its bus
+  // as it is built and would otherwise read these before initialisation.
+  let playing = false;
+  let destroyed = false;
 
   // Per-stem state: url, parsed WAV header, gain node, analyser (VU tap), and
   // currently playing nodes. Graph per stem: sources -> gain -> analyser -> master.
   // The analyser sits post-gain so VU meters reflect volume/mute/solo.
   const stemMap = new Map();
   for (const s of stems) {
-    if (!s?.url) continue;
+    if (!s?.url || s.visualOnly) continue;
+    const pitchable = s.name !== "drums" && s.pitched !== false;
     const gain = ctx.createGain();
     const analyser = ctx.createAnalyser();
     analyser.fftSize = 1024;
     gain.connect(analyser);
-    analyser.connect(master);
-    stemMap.set(s.name, { url: s.url, header: null, gain, analyser, activeNodes: [] });
+    const stem = {
+      url: s.url,
+      header: null,
+      gain,
+      analyser,
+      activeNodes: [],
+      name: s.name,
+      controlName: s.controlName || s.name,
+      pitchable,
+      pitched: pitchable,
+      pitch: 0,
+      bus: null,
+      level: 1,
+    };
+    stemMap.set(s.name, stem);
+    routeStem(stem, true);
   }
 
   let _duration = 0;
-  let playing = false;
-  let destroyed = false;
   let rafId = null;
   // Why ready() resolved false, in words fit to show a user. Read via
   // getLoadError() by the caller that decides what to put on screen.
@@ -251,6 +293,54 @@ export function createChunkedAudioEngine(stems, { onTime, onEnded, context } = {
   // schedule chunk 0 without an async await after ready() completes.
   const _cache = new Map();
 
+  const _wsolaLatencySeconds = () => {
+    const needed = Math.round(0.012 * ctx.sampleRate)
+      + Math.round(0.028 * ctx.sampleRate)
+      + Math.round(0.082 * ctx.sampleRate);
+    return Math.floor(needed / 128) * 128 / ctx.sampleRate;
+  };
+  const _anyLaneTransposed = () => {
+    for (const stem of stemMap.values()) {
+      if (effectivePitch(stem.name, stem.pitch, stem.pitchable) !== 0) return true;
+    }
+    return false;
+  };
+  const _pipelineLatencySeconds = () => {
+    if (!stNode) return 0;
+    // The pitch buses only buffer once something is actually transposed. Until
+    // then the worklet hands its input straight back, with no delay to correct.
+    const pitchLatency = _anyLaneTransposed() ? _workletLatencyFrames / ctx.sampleRate : 0;
+    const tempoStages = Math.abs(_playbackRate - 1) >= 1e-3 ? 1 : 0;
+    return pitchLatency + tempoStages * _wsolaLatencySeconds();
+  };
+
+  // Ducking either side of a bus change. Both buses are delayed by the same
+  // amount, so a dip scheduled at the source lands at the output as one short
+  // dip rather than as a click from splicing two different keys together.
+  const ROUTE_FADE = 0.006;
+  const ROUTE_HOLD = 0.02;
+
+  /** Connect a stem to the bus for its current transpose. */
+  function routeStem(stem, immediate = false) {
+    const target = buses[inputForPitch(effectivePitch(stem.name, stem.pitch, stem.pitchable))];
+    if (stem.bus === target) return;
+    const swap = () => {
+      if (destroyed) return;
+      try { stem.analyser.disconnect(); } catch { /* was not connected yet */ }
+      stem.analyser.connect(target);
+      stem.bus = target;
+    };
+    if (immediate || !playing) { swap(); return; }
+    const g = stem.gain.gain;
+    const at = ctx.currentTime;
+    g.cancelScheduledValues(at);
+    g.setValueAtTime(g.value, at);
+    g.linearRampToValueAtTime(0, at + ROUTE_FADE);
+    g.setValueAtTime(0, at + ROUTE_FADE + ROUTE_HOLD);
+    g.linearRampToValueAtTime(stem.level, at + ROUTE_FADE + ROUTE_HOLD + ROUTE_FADE);
+    setTimeout(swap, (ROUTE_FADE + ROUTE_HOLD / 2) * 1000);
+  }
+
   function _getCurrentTime() {
     if (!playing || !_audioStarted) return _startOffset;
     // Clamped to >= _startOffset: during a count-in the first chunk is
@@ -258,7 +348,11 @@ export function createChunkedAudioEngine(stems, { onTime, onEnded, context } = {
     // would otherwise read as negative before the audio actually starts.
     return Math.max(
       _startOffset,
-      Math.min((ctx.currentTime - _startCtxTime) * _playbackRate + _startOffset, _duration),
+      Math.min(
+        Math.max(0, ctx.currentTime - _startCtxTime - _pipelineLatencySeconds())
+          * _playbackRate + _startOffset,
+        _duration,
+      ),
     );
   }
 
@@ -269,8 +363,8 @@ export function createChunkedAudioEngine(stems, { onTime, onEnded, context } = {
 
   // Inverse of the chunk scheduling: the AudioContext time at which media time
   // `t` enters the graph. A click scheduled here shares a sample frame with the
-  // stems, and because this describes SoundTouch's *input* the alignment holds
-  // regardless of what the worklet does downstream (the click goes through it).
+  // stems. The click uses the unpitched input and shares the worklet's tempo
+  // stage with the combined audio.
   const sourceTimeToCtxTime = (t) => _startCtxTime + (t - _startOffset) / _srcRate();
 
   // True inverse of the above -- see the matching note in audioEngine.js. The
@@ -384,6 +478,10 @@ export function createChunkedAudioEngine(stems, { onTime, onEnded, context } = {
     }
   }
 
+  function _resetProcessor() {
+    try { stNode?.port?.postMessage({ type: "reset" }); } catch { /* processor is gone */ }
+  }
+
   // Schedule all stems' AudioBufferSourceNodes to start at `when` (AudioContext
   // time), beginning `startSecs` into each buffer. Returns the duration of audio
   // that will play (max over stems of buffer.duration - startSecs).
@@ -493,6 +591,7 @@ export function createChunkedAudioEngine(stems, { onTime, onEnded, context } = {
     // lead overrides either when it asks for more room than that.
     const startWith = (buffers, lead) => {
       if (!playing || destroyed) return;
+      _resetProcessor();
       const when = ctx.currentTime + Math.max(lead, countInLead);
       _startCtxTime = when;
       const dur = _scheduleChunk(buffers, when, offsetWithin);
@@ -522,6 +621,7 @@ export function createChunkedAudioEngine(stems, { onTime, onEnded, context } = {
     if (!playing) return;
     _startOffset = _getCurrentTime();
     _stopNodes();
+    _resetProcessor();
     playing = false;
     _audioStarted = false;
     _epoch++;
@@ -538,6 +638,7 @@ export function createChunkedAudioEngine(stems, { onTime, onEnded, context } = {
       _audioStarted = false;
       if (rafId) { cancelAnimationFrame(rafId); rafId = null; }
     }
+    _resetProcessor();
     _startOffset = clamped;
     _scheduledTo = clamped;
     _epoch++;
@@ -617,38 +718,89 @@ export function createChunkedAudioEngine(stems, { onTime, onEnded, context } = {
     getDuration: () => _duration,
     setLoop: (enabled, start, end) => { loop = { enabled, start, end }; },
     setGain(name, v) {
-      const stem = stemMap.get(name);
-      if (stem) stem.gain.gain.setTargetAtTime(Math.max(0, v), ctx.currentTime, 0.01);
+      for (const stem of stemMap.values()) {
+        if (stem.controlName === name) {
+          stem.level = Math.max(0, v);
+          stem.gain.gain.setTargetAtTime(stem.level, ctx.currentTime, 0.01);
+        }
+      }
     },
     setMasterGain(v) {
       master.gain.setTargetAtTime(Math.max(0, v), ctx.currentTime, 0.01);
     },
-    // Metronome support -- see the matching block in audioEngine.js. The click
-    // connects to the master bus so it rides the same path as the stems.
+    // The click shares the unpitched input with drums while still using the
+    // common tempo stage and master gain.
     sourceTimeToCtxTime,
     ctxTimeToSourceTime,
     getScheduleEpoch: () => _epoch,
     // `playing` flips before the async chunk fetch resolves, so the clock is
     // only trustworthy once _audioStarted is set.
     isClockReady: () => playing && _audioStarted,
-    getMasterNode: () => master,
+    getMasterNode: () => buses[ZERO_INPUT],
+    /**
+     * Put one mixer lane in a given key.
+     *
+     * Nothing seeks and nothing is flushed. Every bus is delayed by the same
+     * amount, so the lane's old bus plays out the couple of hundred
+     * milliseconds it has already buffered while its new bus, primed with
+     * exactly that much silence, takes over at the instant the old one runs
+     * dry. The handover is a duck, not a gap.
+     */
+    setStemPitch(name, semitones) {
+      if (!stNode) return false;
+      const next = clampPitch(semitones);
+      let found = false;
+      for (const stem of stemMap.values()) {
+        if (stem.controlName !== name) continue;
+        found = true;
+        if (stem.pitch === next) continue;
+        stem.pitch = next;
+        routeStem(stem);
+      }
+      return found;
+    },
+    getStemPitch(name) {
+      for (const stem of stemMap.values()) {
+        if (stem.controlName === name) return stem.pitch;
+      }
+      return 0;
+    },
+    /** False for lanes that must never be resampled, so the UI can say so. */
+    isStemPitchable(name) {
+      for (const stem of stemMap.values()) {
+        if (stem.controlName === name) return stem.pitchable;
+      }
+      return false;
+    },
+    supportsPitchShift: () => !!stNode,
     setPlaybackRate(rate) {
       const t = _getCurrentTime(); // capture before updating rate
       _playbackRate = rate;
-      _epoch++;
       if (stNode) {
         stNode.parameters.get('tempo').value = rate;
+        if (playing) seek(t);
+        else {
+          _resetProcessor();
+          _epoch++;
+        }
       } else if (playing) {
         // Tape-effect fallback: seek to current position so new source nodes
         // are created with the updated playbackRate and scheduling math resets.
         seek(t);
+      } else {
+        _epoch++;
       }
     },
-    getAnalyser: (name) => stemMap.get(name)?.analyser ?? null,
+    getAnalysers: (name) => [...stemMap.values()]
+      .filter((stem) => stem.controlName === name)
+      .map((stem) => stem.analyser),
+    getAnalyser: (name) => [...stemMap.values()]
+      .find((stem) => stem.controlName === name)?.analyser ?? null,
     getBuffers: () => new Map(),
     destroy() {
       destroyed = true;
       if (playing) pause();
+      else _resetProcessor();
       if (stNode) { try { stNode.disconnect(); } catch { /* noop */ } }
       _cache.clear();
       stemMap.clear();

--- a/static/js/i18n.js
+++ b/static/js/i18n.js
@@ -242,6 +242,11 @@ const en = {
 
   "aria.mute": "Mute {name}",
   "aria.solo": "Solo {name}",
+  "aria.laneKeyUp": "Transpose {name} up one semitone",
+  "aria.laneKeyDown": "Transpose {name} down one semitone",
+  "mixer.key.title": "Transpose this lane: {n} semitones",
+  "mixer.key.drumsLocked": "Drums are never transposed",
+  "mixer.key.unavailable": "Transpose needs Web Audio",
   "aria.soloOnly": "Solo only {name}",
   "aria.download": "Download {name}",
   "aria.volume": "{name} volume",
@@ -384,6 +389,10 @@ const en = {
   "position.loopEndAria": "Loop end",
 
   "speed.group": "Speed",
+  "pitch.group": "Global key",
+  "pitch.resetTitle": "Put every lane back in the original key",
+  "pitch.downTitle": "Transpose down a semitone",
+  "pitch.upTitle": "Transpose up a semitone",
   "speed.ariaLabel": "Playback speed",
 
   "click.group": "Click track",
@@ -770,6 +779,11 @@ const pl = {
 
   "aria.mute": "Wycisz: {name}",
   "aria.solo": "Solo: {name}",
+  "aria.laneKeyUp": "Transponuj {name} o półton w górę",
+  "aria.laneKeyDown": "Transponuj {name} o półton w dół",
+  "mixer.key.title": "Transpozycja tej ścieżki: {n} półtonu",
+  "mixer.key.drumsLocked": "Perkusja nigdy nie jest transponowana",
+  "mixer.key.unavailable": "Transpozycja wymaga Web Audio",
   "aria.soloOnly": "Tylko solo: {name}",
   "aria.download": "Pobierz: {name}",
   "aria.volume": "Głośność: {name}",
@@ -910,6 +924,10 @@ const pl = {
   "position.loopEndAria": "Koniec pętli",
 
   "speed.group": "Prędkość",
+  "pitch.group": "Tonacja globalna",
+  "pitch.resetTitle": "Przywróć wszystkim ścieżkom oryginalną tonację",
+  "pitch.downTitle": "Transponuj w dół o półton",
+  "pitch.upTitle": "Transponuj w górę o półton",
   "speed.ariaLabel": "Prędkość odtwarzania",
 
   "click.group": "Metronom",
@@ -1288,6 +1306,11 @@ const ja = {
 
   "aria.mute": "{name}をミュート",
   "aria.solo": "{name}をソロ",
+  "aria.laneKeyUp": "{name}を半音上げる",
+  "aria.laneKeyDown": "{name}を半音下げる",
+  "mixer.key.title": "このトラックの移調: {n} 半音",
+  "mixer.key.drumsLocked": "ドラムは移調されません",
+  "mixer.key.unavailable": "移調には Web Audio が必要です",
   "aria.soloOnly": "{name}のみソロ",
   "aria.download": "{name}をダウンロード",
   "aria.volume": "{name}の音量",
@@ -1427,6 +1450,10 @@ const ja = {
   "position.loopEndAria": "ループ終了",
 
   "speed.group": "速度",
+  "pitch.group": "全体のキー",
+  "pitch.resetTitle": "すべてのトラックを元のキーに戻す",
+  "pitch.downTitle": "半音下げる",
+  "pitch.upTitle": "半音上げる",
   "speed.ariaLabel": "再生速度",
 
   "click.group": "クリックトラック",
@@ -1781,6 +1808,11 @@ const zhHans = {
 
   "aria.mute": "静音{name}",
   "aria.solo": "独奏{name}",
+  "aria.laneKeyUp": "将{name}升高半音",
+  "aria.laneKeyDown": "将{name}降低半音",
+  "mixer.key.title": "此音轨移调：{n} 个半音",
+  "mixer.key.drumsLocked": "鼓声部不会被移调",
+  "mixer.key.unavailable": "移调需要 Web Audio",
   "aria.soloOnly": "仅独奏{name}",
   "aria.download": "下载{name}",
   "aria.volume": "{name}音量",
@@ -1920,6 +1952,10 @@ const zhHans = {
   "position.loopEndAria": "循环终点",
 
   "speed.group": "速度",
+  "pitch.group": "全局变调",
+  "pitch.resetTitle": "将所有音轨恢复为原调",
+  "pitch.downTitle": "降低半音",
+  "pitch.upTitle": "升高半音",
   "speed.ariaLabel": "播放速度",
 
   "click.group": "节拍器",
@@ -2274,6 +2310,11 @@ const de = {
 
   "aria.mute": "{name} stummschalten",
   "aria.solo": "{name} solo",
+  "aria.laneKeyUp": "{name} um einen Halbton höher transponieren",
+  "aria.laneKeyDown": "{name} um einen Halbton tiefer transponieren",
+  "mixer.key.title": "Transposition dieser Spur: {n} Halbtöne",
+  "mixer.key.drumsLocked": "Schlagzeug wird nie transponiert",
+  "mixer.key.unavailable": "Transposition benötigt Web Audio",
   "aria.soloOnly": "Nur {name} solo",
   "aria.download": "{name} herunterladen",
   "aria.volume": "Lautstärke von {name}",
@@ -2414,6 +2455,10 @@ const de = {
   "position.loopEndAria": "Loop-Ende",
 
   "speed.group": "Geschwindigkeit",
+  "pitch.group": "Globale Tonart",
+  "pitch.resetTitle": "Alle Spuren in die Originaltonart zurücksetzen",
+  "pitch.downTitle": "Einen Halbton tiefer transponieren",
+  "pitch.upTitle": "Einen Halbton höher transponieren",
   "speed.ariaLabel": "Wiedergabegeschwindigkeit",
 
   "click.group": "Click-Track",
@@ -2778,6 +2823,11 @@ const pt = {
 
   "aria.mute": "Mudo {name}",
   "aria.solo": "Solo {name}",
+  "aria.laneKeyUp": "Transpor {name} um semitom para cima",
+  "aria.laneKeyDown": "Transpor {name} um semitom para baixo",
+  "mixer.key.title": "Transposição desta faixa: {n} semitons",
+  "mixer.key.drumsLocked": "A bateria nunca é transposta",
+  "mixer.key.unavailable": "A transposição precisa de Web Audio",
   "aria.soloOnly": "Apenas solo {name}",
   "aria.download": "Baixar {name}",
   "aria.volume": "Volume de {name}",
@@ -2918,6 +2968,10 @@ const pt = {
   "position.loopEndAria": "Fim do loop",
 
   "speed.group": "Velocidade",
+  "pitch.group": "Tom global",
+  "pitch.resetTitle": "Retornar todas as faixas ao tom original",
+  "pitch.downTitle": "Transpor um semitom para baixo",
+  "pitch.upTitle": "Transpor um semitom para cima",
   "speed.ariaLabel": "Velocidade de reprodução",
 
   "click.group": "Clique de referência",
@@ -3284,6 +3338,11 @@ const id = {
 
   "aria.mute": "Bisukan {name}",
   "aria.solo": "Solo {name}",
+  "aria.laneKeyUp": "Naikkan {name} satu semiton",
+  "aria.laneKeyDown": "Turunkan {name} satu semiton",
+  "mixer.key.title": "Transposisi trek ini: {n} semiton",
+  "mixer.key.drumsLocked": "Drum tidak pernah ditransposisi",
+  "mixer.key.unavailable": "Transposisi memerlukan Web Audio",
   "aria.soloOnly": "Hanya solo {name}",
   "aria.download": "Unduh {name}",
   "aria.volume": "Volume {name}",
@@ -3423,6 +3482,10 @@ const id = {
   "position.loopEndAria": "Akhir loop",
 
   "speed.group": "Kecepatan",
+  "pitch.group": "Nada dasar global",
+  "pitch.resetTitle": "Kembalikan semua trek ke nada aslinya",
+  "pitch.downTitle": "Turunkan satu semitone",
+  "pitch.upTitle": "Naikkan satu semitone",
   "speed.ariaLabel": "Kecepatan putar",
 
   "click.group": "Click Track",
@@ -3777,6 +3840,11 @@ const fr = {
 
   "aria.mute": "Couper {name}",
   "aria.solo": "Solo {name}",
+  "aria.laneKeyUp": "Transposer {name} d'un demi-ton vers le haut",
+  "aria.laneKeyDown": "Transposer {name} d'un demi-ton vers le bas",
+  "mixer.key.title": "Transposition de cette piste : {n} demi-tons",
+  "mixer.key.drumsLocked": "La batterie n'est jamais transposée",
+  "mixer.key.unavailable": "La transposition nécessite Web Audio",
   "aria.soloOnly": "Solo uniquement {name}",
   "aria.download": "Télécharger {name}",
   "aria.volume": "Volume {name}",
@@ -3917,6 +3985,10 @@ const fr = {
   "position.loopEndAria": "Fin de la boucle",
 
   "speed.group": "Vitesse",
+  "pitch.group": "Tonalité globale",
+  "pitch.resetTitle": "Remettre toutes les pistes dans la tonalité d'origine",
+  "pitch.downTitle": "Transposer d'un demi-ton vers le bas",
+  "pitch.upTitle": "Transposer d'un demi-ton vers le haut",
   "speed.ariaLabel": "Vitesse de lecture",
 
   "click.group": "Métronome",
@@ -4261,6 +4333,7 @@ const fr = {
 // added to pt later is picked up here rather than reverting to English.
 const ptPT = {
   "settings.autoDelete.title": "Eliminar automaticamente as faixas concluídas",
+  "pitch.resetTitle": "Repor todas as faixas no tom original",
   "settings.autoDelete.desc": "Desativado por predefinição. As faixas separadas são mantidas para sempre. A eliminação não pode ser anulada.",
   "settings.autoDelete.daysTitle": "Eliminar após",
   "settings.autoDelete.daysDesc": "Dias que uma faixa concluída é mantida antes de ser eliminada (máx. {max}).",
@@ -4380,6 +4453,11 @@ const es = {
 
   "aria.mute": "Mute {name}",
   "aria.solo": "Solo {name}",
+  "aria.laneKeyUp": "Transponer {name} un semitono hacia arriba",
+  "aria.laneKeyDown": "Transponer {name} un semitono hacia abajo",
+  "mixer.key.title": "Transposición de esta pista: {n} semitonos",
+  "mixer.key.drumsLocked": "La batería nunca se transpone",
+  "mixer.key.unavailable": "La transposición necesita Web Audio",
   "aria.soloOnly": "Solo únicamente {name}",
   "aria.download": "Descargar {name}",
   "aria.volume": "Volumen de {name}",
@@ -4520,6 +4598,10 @@ const es = {
   "position.loopEndAria": "Fin del loop",
 
   "speed.group": "Velocidad",
+  "pitch.group": "Tonalidad global",
+  "pitch.resetTitle": "Devolver todas las pistas al tono original",
+  "pitch.downTitle": "Transponer un semitono hacia abajo",
+  "pitch.upTitle": "Transponer un semitono hacia arriba",
   "speed.ariaLabel": "Velocidad",
 
   "click.group": "Click",

--- a/static/js/metronome.js
+++ b/static/js/metronome.js
@@ -8,10 +8,9 @@
 //   Clicks are scheduled in the engine's *source* time domain via
 //   `engine.sourceTimeToCtxTime(mediaTime)` -- the exact inverse of the maths
 //   the engine uses to start its own stem sources -- and are connected to the
-//   engine's master bus rather than straight to ctx.destination. So a click
-//   and the audio sample it belongs with enter the graph in the same frame and
-//   travel an identical path to the speakers. Whatever SoundTouch does
-//   downstream, it does to both equally.
+//   engine's unpitched bus rather than straight to ctx.destination. So a click
+//   and the drum sample it belongs with enter the graph in the same frame and
+//   share the tempo stage. Key transposition never resamples either one.
 //
 // Timers cannot be trusted for audio, so nothing here decides *when* a click
 // sounds: setInterval only wakes us up to hand future clicks to the Web Audio

--- a/static/js/mixer.js
+++ b/static/js/mixer.js
@@ -18,9 +18,15 @@ import {
 } from "./state.js";
 import { storeGet, storeSetDebounced } from "./utils.js";
 import { t } from "./i18n.js";
+import { PITCH_MAX, PITCH_MIN, clampPitch } from "./pitchBus.js";
 
 function defaultMixerEntry() {
-  return { volume: 1, muted: false, soloed: false };
+  // `pitch` is the key this lane is actually in, in semitones from the
+  // recording's own key. Absolute rather than an offset from the global
+  // control, so the number on a lane never has to be added to another number to
+  // know what you are hearing. It rides along in the same per-track store as
+  // volume and mute, so a lane's key survives a reload.
+  return { volume: 1, muted: false, soloed: false, pitch: 0 };
 }
 
 export function ensureMixerStateDefaults() {
@@ -54,6 +60,102 @@ export function resetMixerState() {
 function saveMix() {
   if (!currentJobId) return;
   storeSetDebounced(`stemdeck:mix:${currentJobId}`, mixerState);
+}
+
+/** Push one lane's transpose into whichever engine is playing. */
+export function applyLanePitch(name) {
+  if (!audioEngine?.setStemPitch) return;
+  audioEngine.setStemPitch(name, mixerState[name]?.pitch ?? 0);
+}
+
+/** Re-send every lane transpose. Called once an engine finishes starting. */
+export function applyAllLanePitches() {
+  for (const name of allTrackNames()) {
+    if (mixerState[name]) applyLanePitch(name);
+    refreshLaneKeyVisual(name);
+  }
+}
+
+/**
+ * Move every lane by `delta` semitones.
+ *
+ * This is what the transport bar's global control does. It nudges rather than
+ * overrides, so a lane deliberately put in a different key keeps its distance
+ * from the rest instead of being flattened back in with them.
+ */
+export function nudgeAllLanePitches(delta) {
+  if (!delta) return;
+  for (const name of allTrackNames()) {
+    const state = mixerState[name];
+    if (!state || name === "drums") continue;
+    setLanePitch(name, state.pitch + delta);
+  }
+}
+
+/** Put every lane back in the recording's own key. */
+export function resetAllLanePitches() {
+  for (const name of allTrackNames()) {
+    if (mixerState[name]) setLanePitch(name, 0);
+  }
+}
+
+/**
+ * Transpose one lane.
+ *
+ * Drums are refused here as well as in the engine and the worklet. Three
+ * refusals sounds excessive for one rule, but each covers a different way in:
+ * this one is the UI, the engine covers a caller reaching past it, and the
+ * worklet covers a bus being wired wrong.
+ */
+export function setLanePitch(name, semitones) {
+  const state = mixerState[name];
+  if (!state || name === "drums") return;
+  const next = clampPitch(semitones);
+  if (state.pitch === next) return;
+  state.pitch = next;
+  saveMix();
+  applyLanePitch(name);
+  refreshLaneKeyVisual(name);
+}
+
+/** Redraw one lane's key stepper from state. */
+export function refreshLaneKeyVisual(name) {
+  const wrap = mixerEl?.querySelector(`.lane-key[data-stem="${name}"]`);
+  if (!wrap) return;
+  const n = mixerState[name]?.pitch ?? 0;
+  const signed = n > 0 ? `+${n}` : String(n);
+  const valueEl = wrap.querySelector(".lane-key-value");
+  // "K" while the lane is in its own key, so the control reads as a label
+  // until it is doing something, and as a number the moment it is.
+  if (valueEl) valueEl.textContent = n === 0 ? "K" : signed;
+  wrap.classList.toggle("active", n !== 0);
+
+  const locked = wrap.classList.contains("locked");
+  const unsupported = wrap.classList.contains("unsupported");
+  const up = wrap.querySelector(".lane-key-step.up");
+  const down = wrap.querySelector(".lane-key-step.down");
+  if (up) up.disabled = locked || unsupported || n >= PITCH_MAX;
+  if (down) down.disabled = locked || unsupported || n <= PITCH_MIN;
+  // One place decides the tooltip. Setting it from both here and from
+  // availability left a drum lane explaining the wrong thing after the engine
+  // came up, because whichever ran last won and neither restored the other.
+  if (locked) wrap.title = t("mixer.key.drumsLocked");
+  else if (unsupported) wrap.title = t("mixer.key.unavailable");
+  else wrap.title = t("mixer.key.title", { n: signed });
+}
+
+/**
+ * Mark every lane's key stepper usable or not.
+ *
+ * Without AudioWorklet there is no pitch stage at all, and a stepper that
+ * changes its own label while the sound never moves is worse than one that
+ * plainly says it cannot.
+ */
+export function setLaneKeysAvailable(available) {
+  for (const wrap of mixerEl?.querySelectorAll(".lane-key") || []) {
+    wrap.classList.toggle("unsupported", !available);
+    refreshLaneKeyVisual(wrap.dataset.stem);
+  }
 }
 
 export function applyMix() {
@@ -389,7 +491,14 @@ export function renderMixerRow(stem) {
   const initFrac = Math.max(0, Math.min(1, (state?.volume ?? 1) / LANE_VOLUME_MAX));
   val.textContent = String(Math.round(initFrac * 100));
 
-  // Col 6: M button
+  // Col 6: this lane's key, just left of the mute button.
+  //
+  // Laid out along the row like everything beside it. The original version
+  // stacked its buttons vertically next to M and S, which put one widget on the
+  // opposite axis to its neighbours and read as a jumble.
+  const key = makeLaneKey(stem.name, display);
+
+  // Col 7: M button
   const muteBtn = document.createElement("button");
   muteBtn.type = "button";
   muteBtn.className = "lane-icon-toggle mx-btn mute";
@@ -420,15 +529,62 @@ export function renderMixerRow(stem) {
   nameVuCol.className = "lane-name-vu";
   nameVuCol.append(nameEl, vu);
 
-  row.append(iconCell, nameVuCol, fader, val, muteBtn, soloBtn, dl);
+  row.append(iconCell, nameVuCol, fader, val, key, muteBtn, soloBtn, dl);
 
   muteBtn.addEventListener("click", () => toggleStemMute(stem.name));
   soloBtn.addEventListener("click", () => toggleStemSolo(stem.name));
 
   row.classList.toggle("muted", state?.muted ?? false);
   if (state) updateLaneKnobVisual(fader, state.volume);
+  refreshLaneKeyVisual(stem.name);
 
   return { row, vuEl: vu };
+}
+
+/**
+ * The per-lane key stepper: plus above, the reading in the middle, minus below.
+ *
+ * Drums get the control too, disabled and saying why, rather than no control at
+ * all. A missing button on one row reads as a rendering bug; a disabled one
+ * that explains itself teaches the rule.
+ */
+function makeLaneKey(stemName, display) {
+  const wrap = document.createElement("div");
+  wrap.className = "lane-key";
+  wrap.dataset.stem = stemName;
+
+  const up = document.createElement("button");
+  up.type = "button";
+  up.className = "lane-key-step up";
+  up.textContent = "+";
+  up.setAttribute("aria-label", t("aria.laneKeyUp", { name: display }));
+
+  const valueEl = document.createElement("span");
+  valueEl.className = "lane-key-value";
+  valueEl.textContent = "K";
+
+  const down = document.createElement("button");
+  down.type = "button";
+  down.className = "lane-key-step down";
+  // A real minus sign: a hyphen next to a plus sign reads as a dash.
+  down.textContent = "\u2212";
+  down.setAttribute("aria-label", t("aria.laneKeyDown", { name: display }));
+
+  // Plus above, the reading, minus below.
+  wrap.append(up, valueEl, down);
+
+  if (stemName === "drums") {
+    wrap.classList.add("locked");
+    wrap.title = t("mixer.key.drumsLocked");
+    up.disabled = true;
+    down.disabled = true;
+    return wrap;
+  }
+
+  const step = (delta) => setLanePitch(stemName, (mixerState[stemName]?.pitch ?? 0) + delta);
+  up.addEventListener("click", () => step(1));
+  down.addEventListener("click", () => step(-1));
+  return wrap;
 }
 
 // ─── Stem-list panel (Stems sidebar) ───

--- a/static/js/pitchBus.js
+++ b/static/js/pitchBus.js
@@ -1,0 +1,42 @@
+// Which worklet input a mixer lane belongs on.
+//
+// The SoundTouch worklet exposes one input per semitone it offers, so a lane's
+// transpose is expressed as a *connection*, not as a parameter: routing the
+// lane to input k is what makes it sound k - ZERO_INPUT semitones away. Both
+// audio engines have to agree on that mapping exactly, which is why it lives
+// here rather than twice.
+
+export const PITCH_MIN = -6;
+export const PITCH_MAX = 6;
+export const INPUT_COUNT = PITCH_MAX - PITCH_MIN + 1;
+// Input for semitone 0. It is the plain delay line, so it carries drums, the
+// click, and every lane sitting at its own key.
+export const ZERO_INPUT = -PITCH_MIN;
+
+export function clampPitch(semitones) {
+  const n = Math.round(Number(semitones) || 0);
+  return Math.max(PITCH_MIN, Math.min(PITCH_MAX, n));
+}
+
+/**
+ * The shift a lane actually gets.
+ *
+ * A lane's stored key is absolute, not an offset from the global control. The
+ * global control moves every lane by the amount it changed, so the number on a
+ * lane is always the key that lane is actually in, and there is never a second
+ * number to add in your head to know what you are hearing.
+ *
+ * Drums are never transposed, whatever any control says. Resampling a snare
+ * does not move it to another key, it makes it a different drum.
+ * `pitchable === false` covers the same refusal for a rendered complement lane
+ * that still has drums mixed into it.
+ */
+export function effectivePitch(name, semitones, pitchable) {
+  if (name === "drums" || pitchable === false) return 0;
+  return clampPitch(semitones);
+}
+
+/** Worklet input index for a given shift. */
+export function inputForPitch(semitones) {
+  return clampPitch(semitones) + ZERO_INPUT;
+}

--- a/static/js/playbackStems.js
+++ b/static/js/playbackStems.js
@@ -1,0 +1,77 @@
+// Build the source list used by the Web Audio engines.
+//
+// The visible "original" lane is a mix of every base stem the user did not
+// select. Feeding original.wav through a pitch shifter would also transpose
+// any drums inside it. Current jobs retain the individual Demucs stems, so the
+// engine can rebuild that lane as a control group and route drums separately.
+
+function playable(stem) {
+  return !!stem?.name && !!stem?.url;
+}
+
+function sourceSpec(stem, controlName = stem.name, pitched = stem.name !== "drums") {
+  return {
+    name: stem.name,
+    url: stem.url,
+    controlName,
+    // Never allow the drums stem onto the pitched bus, even if a future caller
+    // supplies a mistaken override.
+    pitched: stem.name !== "drums" && pitched !== false,
+  };
+}
+
+/**
+ * Convert visible mixer lanes into independently routable playback sources.
+ *
+ * @param {{name:string,url:string}[]} rawStems Every source returned by the job.
+ * @param {{name:string,url:string}[]} visibleStems Lanes shown in the mixer.
+ * @param {string[]} baseStemNames Canonical separation stems for this server.
+ */
+export function buildPlaybackStems(rawStems, visibleStems, baseStemNames) {
+  const rawByName = new Map(rawStems.filter(playable).map((stem) => [stem.name, stem]));
+  const visible = visibleStems.filter(playable);
+  const dedicated = visible.filter((stem) => stem.name !== "original");
+  const result = dedicated.map((stem) => sourceSpec(stem));
+
+  if (!visible.some((stem) => stem.name === "original")) return result;
+
+  const dedicatedNames = new Set(dedicated.map((stem) => stem.name));
+  // A completed lead/backing split replaces the base vocals source. Treat the
+  // base stem as selected so it is not added to the complement as well.
+  if (dedicatedNames.has("lead_vocals") && dedicatedNames.has("backing_vocals")) {
+    dedicatedNames.add("vocals");
+  }
+
+  const complementNames = baseStemNames.filter((name) => !dedicatedNames.has(name));
+  if (complementNames.length === 0) return result;
+
+  const canReconstruct = complementNames.every((name) => rawByName.has(name));
+  if (canReconstruct) {
+    for (const name of complementNames) {
+      result.push(sourceSpec(rawByName.get(name), "original"));
+    }
+    return result;
+  }
+
+  // Older or partial jobs may not expose every component. Their rendered mix
+  // cannot be separated client-side, so keep the entire lane unpitched. This
+  // is intentionally conservative: melodic content may remain in the old key,
+  // but drums are never resampled and no source is played twice.
+  const original = rawByName.get("original");
+  if (original) result.push(sourceSpec(original, "original", false));
+  return result;
+}
+
+/**
+ * Full-decode mode also supplies AudioBuffers for waveform rendering. Add any
+ * visible source that playback reconstructed from other files as decode-only.
+ */
+export function addVisualOnlyStems(playbackStems, visibleStems) {
+  const loadedNames = new Set(playbackStems.map((stem) => stem.name));
+  return [
+    ...playbackStems,
+    ...visibleStems
+      .filter((stem) => playable(stem) && !loadedNames.has(stem.name))
+      .map((stem) => ({ ...stem, controlName: stem.name, pitched: false, visualOnly: true })),
+  ];
+}

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -29,6 +29,7 @@ import {
 } from "./state.js";
 import { createAudioEngine, estimateDecodedBytes } from "./audioEngine.js";
 import { createChunkedAudioEngine } from "./chunkedAudioEngine.js";
+import { vuLevel } from "./vuScale.js";
 import { createMetronome } from "./metronome.js";
 import { initBeatGrid, destroyBeatGrid } from "./beatgrid.js";
 import { setBeatGridAvailable, syncBeatGridButtons } from "./beatgridUi.js";
@@ -670,7 +671,10 @@ function startAnalyserVuLoop(stems, engine, token) {
     return {
       name: stem.name,
       analyser,
-      data: new Uint8Array(analyser.fftSize),
+      // Float rather than byte samples. On a dB scale the 8-bit path's own
+      // quantisation step, one part in 128, is -42 dBFS: it would light every
+      // meter to roughly a third of full even over silence.
+      data: new Float32Array(analyser.fftSize),
       miniMeterEl: document.querySelector(`.stem-list [data-stem="${stem.name}"] .mini-meter`),
       vuEl: mixerEl.querySelector(`.lane-vu[data-stem="${stem.name}"]`),
       peak: 0,
@@ -691,13 +695,10 @@ function startAnalyserVuLoop(stems, engine, token) {
       const gain = stemVuGain(m.name);
       let input = 0;
       if (playing && gain > 0) {
-        m.analyser.getByteTimeDomainData(m.data);
+        m.analyser.getFloatTimeDomainData(m.data);
         let sum = 0;
-        for (let i = 0; i < m.data.length; i++) {
-          const v = (m.data[i] - 128) / 128;
-          sum += v * v;
-        }
-        input = Math.min(1, Math.sqrt(sum / m.data.length) * 2.5);
+        for (let i = 0; i < m.data.length; i++) sum += m.data[i] * m.data[i];
+        input = vuLevel(Math.sqrt(sum / Math.max(1, m.data.length)));
       } else {
         m.peak = 0;
         m.peakHold = 0;

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -29,6 +29,7 @@ import {
 } from "./state.js";
 import { createAudioEngine, estimateDecodedBytes } from "./audioEngine.js";
 import { createChunkedAudioEngine } from "./chunkedAudioEngine.js";
+import { addVisualOnlyStems, buildPlaybackStems } from "./playbackStems.js";
 import { vuLevel } from "./vuScale.js";
 import { createMetronome } from "./metronome.js";
 import { initBeatGrid, destroyBeatGrid } from "./beatgrid.js";
@@ -37,11 +38,13 @@ import {
   loadMixIntoState, resetMixerState, refreshMixerVisuals,
   setLaneControlsEnabled, ensureMixerStateDefaults, applyMix,
   renderRealMiniWave, renderRealMiniWaveFromPeaks, renderMixerRow,
+  applyAllLanePitches, setLaneKeysAvailable,
 } from "./mixer.js";
 import {
   buildRuler, updatePlayheadMarker, updateLoopRegionVisual,
   applyWaveZoom, buildPresenceRuler, buildFooterWaveTicks, updateFooterTimes,
-  updatePresencePlayhead, resetSpeed, updateMetronomeAvailability, applyMetronomeAccent,
+  updatePresencePlayhead, resetSpeed, resetPitch, updatePitchAvailability,
+  updateMetronomeAvailability, applyMetronomeAccent,
 } from "./transport.js";
 import { stopVuLoop } from "./audio.js";
 import { destroySections } from "./sections.js";
@@ -666,15 +669,16 @@ function startStemVuLoop(stems, decodedMap, token) {
 function startAnalyserVuLoop(stems, engine, token) {
   stopStemVuLoop();
   const meters = stems.map((stem) => {
-    const analyser = engine.getAnalyser?.(stem.name);
-    if (!analyser) return null;
+    const analysers = engine.getAnalysers?.(stem.name)
+      ?? [engine.getAnalyser?.(stem.name)].filter(Boolean);
+    if (!analysers.length) return null;
     return {
       name: stem.name,
-      analyser,
+      analysers,
       // Float rather than byte samples. On a dB scale the 8-bit path's own
       // quantisation step, one part in 128, is -42 dBFS: it would light every
       // meter to roughly a third of full even over silence.
-      data: new Float32Array(analyser.fftSize),
+      data: analysers.map((analyser) => new Float32Array(analyser.fftSize)),
       miniMeterEl: document.querySelector(`.stem-list [data-stem="${stem.name}"] .mini-meter`),
       vuEl: mixerEl.querySelector(`.lane-vu[data-stem="${stem.name}"]`),
       peak: 0,
@@ -695,10 +699,18 @@ function startAnalyserVuLoop(stems, engine, token) {
       const gain = stemVuGain(m.name);
       let input = 0;
       if (playing && gain > 0) {
-        m.analyser.getFloatTimeDomainData(m.data);
         let sum = 0;
-        for (let i = 0; i < m.data.length; i++) sum += m.data[i] * m.data[i];
-        input = vuLevel(Math.sqrt(sum / Math.max(1, m.data.length)));
+        let samples = 0;
+        for (let a = 0; a < m.analysers.length; a++) {
+          const analyser = m.analysers[a];
+          const data = m.data[a];
+          analyser.getFloatTimeDomainData(data);
+          samples = Math.max(samples, data.length);
+          for (let i = 0; i < data.length; i++) sum += data[i] * data[i];
+        }
+        // Summed across the group's analysers, so a control group like
+        // "original" meters the power of everything it plays, not one source.
+        input = vuLevel(Math.sqrt(sum / Math.max(1, samples)));
       } else {
         m.peak = 0;
         m.peakHold = 0;
@@ -742,7 +754,7 @@ function startAnalyserVuLoop(stems, engine, token) {
   stemVuRafId = requestAnimationFrame(tick);
 }
 
-// The metronome holds nodes on the engine's master bus, so it must never
+// The metronome holds nodes on the engine's unpitched bus, so it must never
 // outlive the engine that owns them. Called at every engine teardown site.
 function teardownMetronome() {
   if (metronome) {
@@ -763,6 +775,8 @@ export function destroyPlayer() {
   stopVuLoop();
   stopStemVuLoop();
   resetSpeed();
+  resetPitch();
+  updatePitchAvailability(false);
   teardownMetronome();
   updateMetronomeAvailability(null, t("click.reason.loadTrack"));
   setExportClickAvailable(false);
@@ -959,6 +973,7 @@ function _applyLaneHeight(count) {
 }
 
 export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, title = "", peaksPromise = null, hasVideo = false, videoStatus = null) {
+  const rawStems = stems.filter((stem) => stem?.name && stem?.url);
   const app = document.querySelector(".app");
   app?.classList.remove("is-import");
   app?.classList.remove("no-track");
@@ -971,6 +986,8 @@ export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, ti
   }
   playBtn.classList.remove("playing");
   stopBtn.classList.remove("stopped");
+  resetPitch();
+  updatePitchAvailability(false);
   visualRenderToken += 1;
   const token = visualRenderToken;
   window.setTimeout(() => {
@@ -1021,6 +1038,8 @@ export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, ti
     if (s.name === "lead_vocals" || s.name === "backing_vocals") return wantsVocals && splitDone;
     return selectedStems.has(s.name);
   });
+  const playbackStems = buildPlaybackStems(rawStems, stems, STEM_NAMES);
+  const fullDecodeStems = addVisualOnlyStems(playbackStems, stems);
   _currentStems = stems;
   _mixUrl = mixUrl || null;
   _currentTitle = title || "";
@@ -1107,7 +1126,7 @@ export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, ti
   // WAVs — otherwise its 6 blob fetches compete with the engine's 6 decodes for
   // the 6-connection HTTP/1.1 limit and `canplay` stalls (the WebView2/WKWebView
   // freeze). Null URLs make the multitrack's <audio> elements ready instantly.
-  const engineStemCount = stems.filter((s) => s.url).length;
+  const engineStemCount = fullDecodeStems.filter((s) => s.url).length;
   const mode = engineMode();
   // Only the full-decode engine holds all PCM in RAM, so only it is size-capped;
   // the chunked engine streams and is never "too large".
@@ -1323,12 +1342,14 @@ export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, ti
       // backend's documented degradation for missing peaks is client-side
       // decode — which only the full-decode engine can provide.
       const startEngine = (kind) => {
+        updatePitchAvailability(false);
+        setLaneKeysAvailable(false);
         // Retract a previous track's playback failure. Without this the box
         // stays up over a track that plays fine, since nothing else clears it.
         clearPlaybackError();
         const eng = kind === "chunked"
-          ? createChunkedAudioEngine(stems, { onTime: driveTransportUi, onEnded })
-          : createAudioEngine(stems, { onTime: driveTransportUi, onEnded });
+          ? createChunkedAudioEngine(playbackStems, { onTime: driveTransportUi, onEnded })
+          : createAudioEngine(fullDecodeStems, { onTime: driveTransportUi, onEnded });
         setAudioEngine(eng);
         eng.ready.then((ok) => {
           // Bail if the user switched tracks while we were initialising.
@@ -1369,7 +1390,12 @@ export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, ti
           // "playback failed" notification if one was sitting there (#401).
           resolvePlaybackSuccess(jobId);
           eng.setLoop(loopEnabled, loopStart, loopEnd);
+          updatePitchAvailability(eng.supportsPitchShift?.() === true);
           applyMix(); // push per-stem gains (incl. >1.0 boost) into the engine
+          // Lane keys ride on the same engine, so they are restored from the
+          // per-track store in the same breath as the gains.
+          setLaneKeysAvailable(eng.supportsPitchShift?.() === true);
+          applyAllLanePitches();
 
           // Click track. Bound to this engine instance, so it is rebuilt on
           // every engine bring-up (including the chunked -> fulldecode swap
@@ -1485,6 +1511,8 @@ export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, ti
       // worse than not offering it.
       teardownMetronome();
       updateMetronomeAvailability(null, t("click.reason.needsWebAudio"));
+      updatePitchAvailability(false);
+      setLaneKeysAvailable(false);
     }
   });
 }

--- a/static/js/state.js
+++ b/static/js/state.js
@@ -18,6 +18,10 @@ export const stemsChip = $("t-stems-chip");
 export const timeEl = $("t-time");
 export const masterFader = $("t-master");
 export const speedBtns = ["t-speed-075", "t-speed-1"].map($);
+export const pitchDownBtn = $("t-pitch-down");
+export const pitchUpBtn = $("t-pitch-up");
+export const pitchValueEl = $("t-pitch-value");
+export const pitchResetBtn = $("t-pitch-reset");
 export const npArt = $("np-art");
 export const npThumb = $("np-thumb");
 

--- a/static/js/transport.js
+++ b/static/js/transport.js
@@ -2,6 +2,10 @@ import { fmtTime, fmtTickLabel, fmtTimeMs, parseTimecode, storeGet, storeSet } f
 import {
   playBtn, playMiniBtn, stopBtn, loopBtn, timeEl, masterFader,
   speedBtns,
+  pitchDownBtn,
+  pitchUpBtn,
+  pitchValueEl,
+  pitchResetBtn,
   rulerTime, wavesGrid, loopRegionEl, playheadMarker,
   multitrack, audioEngine, totalDuration, loopEnabled, loopStart, loopEnd, masterVolume,
   waveScroll, waveCanvas, multitrackContainer,
@@ -16,7 +20,7 @@ import {
   setMetronomeEnabled, setMetronomeVolume, setMetronomeBeatsPerBar,
   setLoopEnabled, setLoopStart, setLoopEnd, setMasterVolume, setPlaybackSpeed,
 } from "./state.js";
-import { applyMix } from "./mixer.js";
+import { applyMix, nudgeAllLanePitches, resetAllLanePitches } from "./mixer.js";
 import { isDownbeatIndex, getBeats as getGridBeats, getBars as getGridBars } from "./beatgrid.js";
 import { computeCountIn } from "./metronome.js";
 import { t } from "./i18n.js";
@@ -598,6 +602,7 @@ export function wireTransportButtons() {
   });
   wireSpeedControl();
   wireMetronomeControl();
+  wirePitchControl();
 }
 
 // Fixed presets, not a continuous dial -- practice speeds for slowing a part
@@ -627,6 +632,84 @@ function applySpeed(rate) {
       try { a.playbackRate = clamped; } catch { /* noop */ }
     }
   }
+}
+
+
+// ── Transpose (#245) ────────────────────────────────────────────────────────
+//
+// Semitones, not a continuous dial, for the same reason the speed control uses
+// presets: this is for moving a backing track into a singer's range, and every
+// useful destination is a whole semitone away.
+//
+// Capped at a fifth rather than an octave. The worklet stretches then resamples,
+// and past roughly five semitones that starts to be audible on sustained
+// material. A control whose extremes sound broken is worse than a narrower one
+// that always sounds right.
+const PITCH_MIN = -6;
+const PITCH_MAX = 6;
+
+let _pitchSemitones = 0;
+let _pitchAvailable = false;
+
+/** Redraw the global key readout and its buttons. Touches no lane. */
+function renderPitch() {
+  if (pitchValueEl) {
+    // Signed, so "+2" and "-2" are distinguishable at a glance; bare "0" for
+    // the default rather than a redundant "+0".
+    pitchValueEl.textContent = _pitchSemitones > 0 ? `+${_pitchSemitones}` : String(_pitchSemitones);
+    pitchValueEl.classList.toggle("active", _pitchSemitones !== 0);
+  }
+  // A stepper that silently stops responding reads as broken, so say which end
+  // has been reached rather than only going inert.
+  if (pitchDownBtn) pitchDownBtn.disabled = !_pitchAvailable || _pitchSemitones <= PITCH_MIN;
+  if (pitchUpBtn) pitchUpBtn.disabled = !_pitchAvailable || _pitchSemitones >= PITCH_MAX;
+  if (pitchResetBtn) pitchResetBtn.disabled = !_pitchAvailable;
+}
+
+/**
+ * Move the global key, and every lane with it.
+ *
+ * The lanes carry absolute keys, so this applies the *change* rather than the
+ * new value: a lane deliberately put a third above the rest stays a third above
+ * the rest when the whole track moves. Overriding instead would flatten every
+ * per-lane decision the moment the global control was touched.
+ */
+function applyPitch(semitones) {
+  const clamped = Math.max(PITCH_MIN, Math.min(PITCH_MAX, Math.round(semitones)));
+  const delta = clamped - _pitchSemitones;
+  _pitchSemitones = clamped;
+  renderPitch();
+  if (delta !== 0) nudgeAllLanePitches(delta);
+}
+
+/**
+ * Clear the readout when a track is torn down or swapped.
+ *
+ * Deliberately does not touch the lanes: their keys are saved per track and are
+ * about to be reloaded from the store for whatever is being opened.
+ */
+export function resetPitch() {
+  _pitchSemitones = 0;
+  renderPitch();
+}
+
+/** The user's reset: the global key and every lane, back to the original. */
+export function resetAllKeys() {
+  _pitchSemitones = 0;
+  resetAllLanePitches();
+  renderPitch();
+}
+
+export function updatePitchAvailability(available) {
+  _pitchAvailable = available === true;
+  if (!_pitchAvailable && _pitchSemitones !== 0) _pitchSemitones = 0;
+  renderPitch();
+}
+
+function wirePitchControl() {
+  pitchDownBtn?.addEventListener("click", () => applyPitch(_pitchSemitones - 1));
+  pitchUpBtn?.addEventListener("click", () => applyPitch(_pitchSemitones + 1));
+  pitchResetBtn?.addEventListener("click", () => resetAllKeys());
 }
 
 export function resetSpeed() {

--- a/static/js/vuScale.js
+++ b/static/js/vuScale.js
@@ -1,0 +1,29 @@
+// How a lane meter turns an RMS amplitude into a bar length.
+//
+// This was linear once, `min(1, rms * 2.5)`, which sounds reasonable and is
+// not: loudness is logarithmic, and a separated stem sits around -20 to
+// -30 dBFS. Measured across a real library the median lane filled 10.4% of its
+// meter and the drum and "other" stems sat under 2%, so the top three quarters
+// of every bar were decoration.
+//
+// Its own module so the mapping can be measured directly. player.js cannot be
+// imported outside a browser, and a scale nothing can check is how the linear
+// version survived as long as it did.
+
+// Lowest level a meter draws. Below this a lane reads as silent.
+//
+// -60 dB is the usual floor for a small console meter: quiet passages still
+// register, and full scale stays reachable without being reached constantly.
+export const VU_FLOOR_DB = -60;
+
+/**
+ * Map an RMS amplitude onto 0..1, in dB rather than in amplitude.
+ *
+ * Takes RMS, not peak: peak meters on separated stems are dominated by
+ * transients and read as a row of bars slamming to full on every beat.
+ */
+export function vuLevel(rms) {
+  if (!(rms > 0)) return 0;
+  const db = 20 * Math.log10(rms);
+  return Math.max(0, Math.min(1, (db - VU_FLOOR_DB) / -VU_FLOOR_DB));
+}

--- a/static/vendor/soundtouch-processor.js
+++ b/static/vendor/soundtouch-processor.js
@@ -1,11 +1,88 @@
 'use strict';
-// SoundTouch WSOLA time-stretcher - AudioWorkletProcessor
+// SoundTouch WSOLA time-stretcher + pitch shifter - AudioWorkletProcessor
 // Adapted from SoundTouch C++ by Olli Parviainen. MIT License.
 // Self-contained; no imports required.
+//
+// ONE INPUT PER SEMITONE, ON PURPOSE (#245).
+//
+//   input k   everything to be shifted by (k - 6) semitones
+//   input 6   semitone 0: drums, the click, and any lane at its own key
+//
+// Drums are unpitched. Resampling a snare does not move it to another key, it
+// makes it a different drum, so the pitch stage has to skip them. What it may
+// not skip is the time-stretch: at 0.75x the kit still has to slow down with
+// the band.
+//
+// The obvious implementation, two independent stretch chains, is broken.
+// Measured end-to-end latency of a single chain:
+//
+//     pitch  0, tempo 1       0 ms   (bypass)
+//     pitch +2, tempo 1     115 ms
+//     pitch -5, tempo 1     144 ms
+//     pitch  0, tempo 0.75  437 ms
+//
+// Latency moves with both parameters, so independent chains put the drums up to
+// 144 ms away from the band. This processor has one music-only pitch stage,
+// then sends the combined music and drum buses through one shared tempo stage.
+// There is only one output clock.
+//
+// An earlier revision also split attacks out of the music bus and passed them
+// at unity to "protect" them from the WSOLA grain. That is unsound: the tonal
+// half is delayed by the pitch stage and the attack half is not, so the two
+// cannot sum back to the input. Measured against a mix with attacks it put a
+// 0.64 full-scale step into the output at every detected onset, five times
+// anything in the source, heard as a click. It also had nothing left to
+// protect once drums got their own unpitched input.
+//
+// The two chains produce the same duration by construction. With s = speed,
+// n = semitones and r = 2^(n/12), a resampler stepping r input samples per
+// output sample multiplies pitch by r and divides duration by r, while WSOLA
+// multiplies duration by 1/tempo:
+//
+//     music     WSOLA(1 / r), resample(r), then shared WSOLA(s)
+//     drums     unity pitch, then shared WSOLA(s)
+//
+// Both have duration 1/s. Only music has pitch multiplied by r.
 
 const SEQUENCE_MS = 82;
 const SEEK_MS     = 28;
 const OVERLAP_MS  = 12;
+
+// Semitone range offered to the UI. Past roughly +/-5 this design audibly
+// degrades, so the control stops before it starts sounding broken rather than
+// offering an octave nobody would use.
+const PITCH_MIN_SEMITONES = -6;
+const PITCH_MAX_SEMITONES = 6;
+
+// Below this, a parameter counts as "off" and its stage is bypassed.
+const EPS = 1e-3;
+
+// Spare samples kept queued past what this render quantum needs.
+//
+// A WSOLA sequence emits 70 ms in one go and then consumes input for the same
+// 70 ms of playback before it can emit again, so supply and demand balance only
+// on average, never within a quantum. Reading the pitch stage directly means a
+// quantum occasionally comes up a few samples short and is written out as a
+// partial block with a hard zero edge in the middle, which is a click.
+//
+// Raising the fill target alone cannot fix that: the stage produces exactly the
+// input it is given, so there is no surplus to build a reserve out of. The
+// reserve has to live downstream of the resampler, where it is filled during
+// the priming silence and then absorbs the sequence sawtooth for good. 512
+// samples is 12 ms, below the pitch stage's own latency and inaudible.
+const OUTPUT_RESERVE = 512;
+
+// Extra input a WSOLA chain banks before its first sequence.
+//
+// A sequence needs `needed` samples queued to run, and consumes exactly what it
+// emits, so input arriving in 128-sample quanta lands the FIFO right back on
+// the threshold every cycle. Whether it is a few samples over or a few under at
+// the instant output runs dry is then pure phase, and under means the chain
+// emits nothing for several quanta. Holding back the first sequence until a
+// cushion has accumulated leaves that cushion in the FIFO for the rest of the
+// run, because the rates are balanced from then on. Two quanta covers the block
+// quantisation; the rest is the fractional advance, which is under a sample.
+const PRIME_CUSHION = 512;
 
 class FloatFifo {
   constructor() {
@@ -55,105 +132,489 @@ function findBestOffset(ref, refLen, fifo, seekLen) {
   return bestOff;
 }
 
+/**
+ * Transposed-Direct-Form-II biquad, used as the anti-alias lowpass.
+ *
+ * Only engaged when pitching UP, where the resampler decimates and everything
+ * above Nyquist/r folds back into the audible band as metallic grit. Pitching
+ * down interpolates instead and needs no filter.
+ *
+ * 0.47 rather than 0.5 leaves a little room below the fold-back frequency, so
+ * the filter is not merely 3 dB down exactly where the aliases arrive.
+ */
+class Biquad {
+  constructor() { this.reset(); this.setPassthrough(); }
+  reset() { this._z1 = 0; this._z2 = 0; }
+  setPassthrough() { this._b0 = 1; this._b1 = 0; this._b2 = 0; this._a1 = 0; this._a2 = 0; }
+  /** Lowpass at `freq` Hz with quality `q`, per the RBJ audio EQ cookbook. */
+  setLowpass(freq, sr, q) {
+    const w0 = 2 * Math.PI * Math.min(freq, sr * 0.49) / sr;
+    const cos0 = Math.cos(w0);
+    const alpha = Math.sin(w0) / (2 * q);
+    const a0 = 1 + alpha;
+    this._b0 = ((1 - cos0) / 2) / a0;
+    this._b1 = (1 - cos0) / a0;
+    this._b2 = this._b0;
+    this._a1 = (-2 * cos0) / a0;
+    this._a2 = (1 - alpha) / a0;
+  }
+  process(x) {
+    const y = this._b0 * x + this._z1;
+    this._z1 = this._b1 * x - this._a1 * y + this._z2;
+    this._z2 = this._b2 * x - this._a2 * y;
+    return y;
+  }
+}
+
+// Butterworth pole Qs for an 8th-order cascade, Q_k = 1/(2*cos((2k+1)*pi/16)).
+// Fourth order measured only 15 dB of alias rejection, because the frequency
+// that folds sits a fifth of an octave above the cutoff, well inside a
+// 4th-order transition band. Eight poles put the stopband where the aliases
+// actually land, and four biquads on one bus cost nothing worth counting.
+const BUTTERWORTH_Q8 = [0.50979558, 0.60134489, 0.89997622, 2.56291545];
+
+/**
+ * One WSOLA time-stretch chain: stereo in, stereo out, its own buffers.
+ *
+ * Used once for the music-only pitch stage and once for the shared tempo stage.
+ * `postFilter` runs over a finished sequence before it is queued, which is
+ * where the anti-alias filter belongs:
+ * ahead of the resampler, because filtering after decimation cannot undo
+ * folding, only attenuate whatever the fold produced.
+ */
+class Wsola {
+  constructor(sr) {
+    this.ovLen   = Math.round(OVERLAP_MS  * sr / 1000);
+    this.seekLen = Math.round(SEEK_MS     * sr / 1000);
+    this.seqLen  = Math.round(SEQUENCE_MS * sr / 1000);
+    this.midLen  = this.seqLen - 2 * this.ovLen;
+    this.needed  = this.ovLen + this.seekLen + this.seqLen;
+
+    this.inL  = new FloatFifo();
+    this.inR  = new FloatFifo();
+    this.outL = new FloatFifo();
+    this.outR = new FloatFifo();
+
+    this._carryL = new Float32Array(this.ovLen);
+    this._carryR = new Float32Array(this.ovLen);
+    const outPerSeq = this.ovLen + this.midLen;
+    this._tmpL = new Float32Array(outPerSeq);
+    this._tmpR = new Float32Array(outPerSeq);
+
+    // The input advance carries its fractional part between sequences. The
+    // effective tempo is irrational for every semitone but 0 and +/-12, so
+    // rounding it away each time drifts the duration by a sample every few
+    // sequences, which shows up as slow desync against the click track.
+    this._advanceRem = 0;
+    this._primed = false;
+
+    this.postFilter = null;
+  }
+
+  clear() {
+    this.inL.clear(); this.inR.clear();
+    this.outL.clear(); this.outR.clear();
+    this._carryL.fill(0); this._carryR.fill(0);
+    this._advanceRem = 0;
+    this._primed = false;
+  }
+
+  push(l, r, n) {
+    this.inL.push(l, 0, n);
+    this.inR.push(r, 0, n);
+  }
+
+  /** Run sequences until `want` output samples are queued, or input runs out. */
+  fill(tempo, want) {
+    if (!this._primed) {
+      if (this.inL.avail < this.needed + PRIME_CUSHION) return;
+      this._primed = true;
+    }
+    while (this.outL.avail < want && this.inL.avail >= this.needed) this._sequence(tempo);
+  }
+
+  _sequence(tempo) {
+    const ovLen = this.ovLen, midLen = this.midLen, seqLen = this.seqLen;
+    const outLen = ovLen + midLen;
+    const bestOff = findBestOffset(this._carryL, ovLen, this.inL, this.seekLen);
+
+    for (let i = 0; i < ovLen; i++) {
+      const w = i / ovLen;
+      this._tmpL[i] = this._carryL[i] * (1 - w) + this.inL.peek(bestOff + i) * w;
+      this._tmpR[i] = this._carryR[i] * (1 - w) + this.inR.peek(bestOff + i) * w;
+    }
+    for (let i = 0; i < midLen; i++) {
+      this._tmpL[ovLen + i] = this.inL.peek(bestOff + ovLen + i);
+      this._tmpR[ovLen + i] = this.inR.peek(bestOff + ovLen + i);
+    }
+    for (let i = 0; i < ovLen; i++) {
+      this._carryL[i] = this.inL.peek(bestOff + ovLen + midLen + i);
+      this._carryR[i] = this.inR.peek(bestOff + ovLen + midLen + i);
+    }
+
+    if (this.postFilter) this.postFilter(this._tmpL, this._tmpR, outLen);
+
+    this.outL.push(this._tmpL, 0, outLen);
+    this.outR.push(this._tmpR, 0, outLen);
+
+    const exact = (seqLen - ovLen) * tempo + this._advanceRem;
+    const whole = Math.floor(exact);
+    this._advanceRem = exact - whole;
+    // The similarity search is local to this sequence. Folding bestOff into
+    // the nominal advance makes content-dependent offsets accumulate into a
+    // clock error, which is especially audible against unpitched drums.
+    this.inL.consume(whole);
+    this.inR.consume(whole);
+  }
+}
+
+/** FIFO sample at `idx`, falling back to the carried history for idx < 0. */
+function sampleAt(fifo, hist, idx) {
+  if (idx >= 0) return fifo.peek(idx);
+  const h = hist.length + idx;
+  return h >= 0 ? hist[h] : 0;
+}
+
+/** 4-point, 3rd-order Hermite (Catmull-Rom) interpolation. */
+function hermite(ym1, y0, y1, y2, t) {
+  const c0 = y0;
+  const c1 = 0.5 * (y1 - ym1);
+  const c2 = ym1 - 2.5 * y0 + 2 * y1 - 0.5 * y2;
+  const c3 = 0.5 * (y2 - ym1) + 1.5 * (y0 - y1);
+  return ((c3 * t + c2) * t + c1) * t + c0;
+}
+
+const SILENCE = new Float32Array(128);
+
+// One input per semitone the UI offers, and input `ZERO_INPUT` is semitone 0.
+//
+// Per-lane transpose means several different shifts have to be audible at once,
+// and the obvious build -- one worklet per lane -- is the same mistake the
+// two-bus design was written to avoid, only worse. Latency moves with the
+// shift, so six independently clocked chains put six stems up to 144 ms apart
+// from each other. Here every bus is a chain into one shared tempo stage, so
+// there is still exactly one output clock no matter how many different keys are
+// playing at once.
+//
+// Semitone 0 needs no resampling, so it is not a chain at all: it is the plain
+// delay line carrying drums, the click, and any lane whose net transpose works
+// out to zero. That caps the design at twelve chains, and means the common case
+// of one global shift with drums held out of it allocates exactly one.
+const INPUT_COUNT = PITCH_MAX_SEMITONES - PITCH_MIN_SEMITONES + 1;
+const ZERO_INPUT = -PITCH_MIN_SEMITONES;
+
+// How long a chain is kept after its lane leaves. Its buffers still hold that
+// lane's last couple of hundred milliseconds, and dropping it early would cut
+// the tail off mid-note. Past this it is silent, so keeping it would only cost
+// memory and a correlation search per block.
+const CHAIN_LINGER_BLOCKS = 256;
+
+/**
+ * How far ahead of true time a chain at `ratio` runs, in samples.
+ *
+ * WSOLA copies a sequence verbatim and then jumps its read position by
+ * `outLen * tempo`, so inside a sequence the source runs at 1:1 while across
+ * sequences it runs at `tempo`. The mean is exact, which is why nothing drifts,
+ * but the sawtooth in between leaves a fixed offset that scales with the
+ * interval: measured at 18 ms for six semitones before this was corrected.
+ */
+function runsEarlyBy(outLen, ratio) {
+  return (outLen * (1 - 1 / ratio)) / 2;
+}
+
+/**
+ * Silence a bus is primed with so that every bus ends up on the same clock.
+ *
+ * Referenced against the most negative offset the *offered range* can produce
+ * rather than against whichever buses happen to exist right now, so a bus
+ * created later lands in step with the ones already playing instead of shifting
+ * them.
+ */
+function alignmentPad(outLen, ratio) {
+  const latest = runsEarlyBy(outLen, Math.pow(2, PITCH_MIN_SEMITONES / 12));
+  return Math.max(0, Math.round(runsEarlyBy(outLen, ratio) - latest));
+}
+
+/** WSOLA at 1/r, anti-aliased, then resampled by r: pitch without tempo. */
+class PitchChain {
+  constructor(sr, semitones, commonPrime) {
+    this.ratio = Math.pow(2, semitones / 12);
+    this.wsola = new Wsola(sr);
+    this.readPos = 0;
+    this.histL = new Float32Array(3);
+    this.histR = new Float32Array(3);
+    this._commonPrime = commonPrime;
+
+    // Only pitching up decimates, and only decimation folds. Filtering after
+    // the resampler cannot undo a fold, only attenuate what it produced, so
+    // this runs on finished sequences, ahead of it.
+    // A zero cutoff means no filter, not a filter that removes everything: a
+    // biquad configured at 0 Hz has all-zero numerator coefficients and
+    // silences the bus. The measurement in tests/js/pitch-shift.test.mjs
+    // defeats the filter exactly this way to get its reference reading.
+    const cutoff = (0.47 * sr) / this.ratio;
+    if (this.ratio > 1 && cutoff > 0) {
+      const aaL = BUTTERWORTH_Q8.map(() => new Biquad());
+      const aaR = BUTTERWORTH_Q8.map(() => new Biquad());
+      for (let i = 0; i < BUTTERWORTH_Q8.length; i++) {
+        aaL[i].setLowpass(cutoff, sr, BUTTERWORTH_Q8[i]);
+        aaR[i].setLowpass(cutoff, sr, BUTTERWORTH_Q8[i]);
+      }
+      this._aaL = aaL;
+      this._aaR = aaR;
+      this.wsola.postFilter = (l, r, n) => {
+        for (let i = 0; i < n; i++) {
+          let a = l[i];
+          let b = r[i];
+          for (let k = 0; k < aaL.length; k++) {
+            a = aaL[k].process(a);
+            b = aaR[k].process(b);
+          }
+          l[i] = a;
+          r[i] = b;
+        }
+      };
+    }
+    this.reset();
+  }
+
+  /**
+   * Prime with silence so the chain is productive from its very first block.
+   *
+   * A chain priming on real audio emits nothing for its first ~130 ms. Blocking
+   * the mix on it would stall every other lane for that long; not blocking
+   * would leave its lane permanently 130 ms late. Feeding it that much silence
+   * up front makes it behave exactly like a chain that has been running since
+   * the transport started, so a lane can change key mid-playback and the tail
+   * still draining from its previous chain meets the new one seamlessly.
+   */
+  reset() {
+    this.wsola.clear();
+    this.readPos = 0;
+    this.histL.fill(0);
+    this.histR.fill(0);
+    if (this._aaL) {
+      for (let i = 0; i < this._aaL.length; i++) {
+        this._aaL[i].reset();
+        this._aaR[i].reset();
+      }
+    }
+    const outLen = this.wsola.ovLen + this.wsola.midLen;
+    const pad = new Float32Array(this._commonPrime + alignmentPad(outLen, this.ratio));
+    this.wsola.push(pad, pad, pad.length);
+  }
+
+  push(l, r, n) { this.wsola.push(l, r, n); }
+
+  /** Output samples this chain could hand over right now. */
+  available() {
+    return Math.max(0, Math.floor((this.wsola.outL.avail - 3) / this.ratio));
+  }
+
+  fill(want) { this.wsola.fill(1 / this.ratio, Math.ceil(want * this.ratio) + 4); }
+
+  /** Resample `n` samples and sum them into the mix buffers. */
+  addInto(dstL, dstR, n) {
+    const mL = this.wsola.outL;
+    const mR = this.wsola.outR;
+    const histL = this.histL;
+    const histR = this.histR;
+    const ratio = this.ratio;
+    let pos = this.readPos;
+    for (let i = 0; i < n; i++) {
+      const idx = Math.floor(pos);
+      const frac = pos - idx;
+      dstL[i] += hermite(sampleAt(mL, histL, idx - 1), sampleAt(mL, histL, idx),
+                         sampleAt(mL, histL, idx + 1), sampleAt(mL, histL, idx + 2), frac);
+      dstR[i] += hermite(sampleAt(mR, histR, idx - 1), sampleAt(mR, histR, idx),
+                         sampleAt(mR, histR, idx + 1), sampleAt(mR, histR, idx + 2), frac);
+      pos += ratio;
+    }
+    const consumed = Math.floor(pos);
+    if (consumed > 0) {
+      for (let k = 0; k < 3; k++) {
+        const src = consumed - 3 + k;
+        histL[k] = src >= 0 ? mL.peek(src) : histL[histL.length + src];
+        histR[k] = src >= 0 ? mR.peek(src) : histR[histR.length + src];
+      }
+      mL.consume(consumed);
+      mR.consume(consumed);
+    }
+    this.readPos = pos - consumed;
+  }
+}
+
 class SoundTouchProcessor extends AudioWorkletProcessor {
   static get parameterDescriptors() {
-    return [{
-      name: 'tempo',
-      defaultValue: 1.0,
-      minValue: 0.25,
-      maxValue: 4.0,
-      automationRate: 'k-rate',
-    }];
+    return [
+      {
+        name: 'tempo',
+        defaultValue: 1.0,
+        minValue: 0.25,
+        maxValue: 4.0,
+        automationRate: 'k-rate',
+      },
+    ];
   }
 
   constructor() {
     super();
-    const sr = sampleRate;
-    this._ovLen   = Math.round(OVERLAP_MS  * sr / 1000);
-    this._seekLen = Math.round(SEEK_MS     * sr / 1000);
-    this._seqLen  = Math.round(SEQUENCE_MS * sr / 1000);
-    this._midLen  = this._seqLen - 2 * this._ovLen;
+    this._tempo = new Wsola(sampleRate);
+    // Silence every bus is primed with, before its own alignment pad, so they
+    // share one clock and each chain can produce from its first block.
+    this._commonPrime = this._tempo.needed + PRIME_CUSHION;
+    this._chains = new Array(INPUT_COUNT).fill(null);
+    this._idle = new Array(INPUT_COUNT).fill(0);
+    this._unpitchedL = new FloatFifo();
+    this._unpitchedR = new FloatFifo();
+    this._mixL = new Float32Array(128 + OUTPUT_RESERVE);
+    this._mixR = new Float32Array(128 + OUTPUT_RESERVE);
+    this._mixFifoL = new FloatFifo();
+    this._mixFifoR = new FloatFifo();
 
-    this._inL  = new FloatFifo();
-    this._inR  = new FloatFifo();
-    this._outL = new FloatFifo();
-    this._outR = new FloatFifo();
+    this._bypassing = true;
+    this._lastTempo = 1;
+    this._resetRequested = false;
+    if (this.port) {
+      this.port.onmessage = (event) => {
+        if (event?.data?.type === 'reset') this._resetRequested = true;
+      };
+    }
+    this._primeUnpitched();
+    // The engine needs this to place the playhead, and deriving it there would
+    // mean keeping a copy of every constant above in sync by hand.
+    if (this.port) {
+      this.port.postMessage({
+        type: 'latency',
+        frames: this._commonPrime
+          + alignmentPad(this._tempo.ovLen + this._tempo.midLen, 1),
+      });
+    }
+  }
 
-    // Overlap carry-over buffers (crossfade region saved from previous sequence)
-    this._carryL = new Float32Array(this._ovLen);
-    this._carryR = new Float32Array(this._ovLen);
+  _primeUnpitched() {
+    const outLen = this._tempo.ovLen + this._tempo.midLen;
+    const pad = new Float32Array(this._commonPrime + alignmentPad(outLen, 1));
+    this._unpitchedL.clear();
+    this._unpitchedR.clear();
+    this._unpitchedL.push(pad, 0, pad.length);
+    this._unpitchedR.push(pad, 0, pad.length);
+  }
 
-    // Pre-allocated temp output (seqLen - ovLen samples per sequence max)
-    const outPerSeq = this._ovLen + this._midLen;
-    this._tmpL = new Float32Array(outPerSeq);
-    this._tmpR = new Float32Array(outPerSeq);
+  _flush() {
+    this._tempo.clear();
+    this._mixFifoL.clear();
+    this._mixFifoR.clear();
+    for (let k = 0; k < INPUT_COUNT; k++) if (this._chains[k]) this._chains[k].reset();
+    this._primeUnpitched();
   }
 
   process(inputs, outputs, parameters) {
-    const inp    = inputs[0];
-    const outp   = outputs[0];
     const frames = 128;
-    const tempo  = parameters.tempo[0];
+    const tempo = parameters.tempo[0];
+    const tempoActive = Math.abs(tempo - 1) >= EPS;
 
-    const inL  = inp?.[0]  || new Float32Array(frames);
-    const inR  = inp?.[1]  || inL;
+    const outp = outputs[0];
     const outL = outp[0];
     const outR = outp[1] || outL;
+    const stereo = outR !== outL;
 
-    // Passthrough at 1.0 - zero DSP cost
-    if (Math.abs(tempo - 1.0) < 0.001) {
-      outL.set(inL);
-      if (outR !== outL) outR.set(inR);
+    if (this._resetRequested || Math.abs(tempo - this._lastTempo) >= EPS) {
+      this._flush();
+      this._resetRequested = false;
+    }
+    this._lastTempo = tempo;
+
+    // An unconnected input arrives as an empty array, which is how a lane
+    // moving between keys is noticed without any message from the main thread.
+    let pitched = false;
+    for (let k = 0; k < INPUT_COUNT; k++) {
+      if (k === ZERO_INPUT) continue;
+      const connected = !!(inputs[k] && inputs[k].length);
+      if (connected) {
+        if (!this._chains[k]) {
+          this._chains[k] = new PitchChain(sampleRate, k - ZERO_INPUT, this._commonPrime);
+        }
+        this._idle[k] = 0;
+      } else if (this._chains[k] && ++this._idle[k] > CHAIN_LINGER_BLOCKS) {
+        this._chains[k] = null;
+      }
+      if (this._chains[k]) pitched = true;
+    }
+
+    const zero = inputs[ZERO_INPUT];
+    const uL = (zero && zero[0]) || SILENCE;
+    const uR = (zero && zero[1]) || uL;
+
+    // Nothing to do to the signal: hand it back sample for sample.
+    if (!pitched && !tempoActive) {
+      if (!this._bypassing) {
+        this._flush();
+        this._bypassing = true;
+      }
+      for (let i = 0; i < frames; i++) {
+        outL[i] = uL[i];
+        if (stereo) outR[i] = uR[i];
+      }
       return true;
     }
+    this._bypassing = false;
 
-    this._inL.push(inL, 0, frames);
-    this._inR.push(inR, 0, frames);
+    this._unpitchedL.push(uL, 0, frames);
+    this._unpitchedR.push(uR, 0, frames);
+    for (let k = 0; k < INPUT_COUNT; k++) {
+      const chain = this._chains[k];
+      if (!chain) continue;
+      const inp = inputs[k];
+      const l = (inp && inp[0]) || SILENCE;
+      const r = (inp && inp[1]) || l;
+      chain.push(l, r, frames);
+    }
 
-    const needed = this._ovLen + this._seekLen + this._seqLen;
-    while (this._inL.avail >= needed) this._processSeq(tempo);
+    const wanted = frames + OUTPUT_RESERVE - this._mixFifoL.avail;
+    if (wanted > 0) {
+      let n = Math.min(wanted, this._unpitchedL.avail);
+      for (let k = 0; k < INPUT_COUNT; k++) {
+        const chain = this._chains[k];
+        if (!chain) continue;
+        chain.fill(wanted);
+        n = Math.min(n, chain.available());
+      }
+      if (n > 0) {
+        this._unpitchedL.shift(this._mixL, 0, n);
+        this._unpitchedR.shift(this._mixR, 0, n);
+        for (let k = 0; k < INPUT_COUNT; k++) {
+          if (this._chains[k]) this._chains[k].addInto(this._mixL, this._mixR, n);
+        }
+        this._mixFifoL.push(this._mixL, 0, n);
+        this._mixFifoR.push(this._mixR, 0, n);
+      }
+    }
+    const mixedFrames = this._mixFifoL.shift(this._mixL, 0, frames);
+    this._mixFifoR.shift(this._mixR, 0, frames);
 
-    const got = this._outL.shift(outL, 0, frames);
-    this._outR.shift(outR, 0, frames);
-    for (let i = got; i < frames; i++) { outL[i] = 0; if (outR !== outL) outR[i] = 0; }
-
+    if (tempoActive) {
+      if (mixedFrames > 0) this._tempo.push(this._mixL, this._mixR, mixedFrames);
+      this._tempo.fill(tempo, frames);
+      const n = Math.min(frames, this._tempo.outL.avail);
+      this._tempo.outL.shift(outL, 0, n);
+      if (stereo) this._tempo.outR.shift(outR, 0, n);
+      else this._tempo.outR.consume(n);
+      for (let i = n; i < frames; i++) {
+        outL[i] = 0;
+        if (stereo) outR[i] = 0;
+      }
+    } else {
+      for (let i = 0; i < mixedFrames; i++) {
+        outL[i] = this._mixL[i];
+        if (stereo) outR[i] = this._mixR[i];
+      }
+      for (let i = mixedFrames; i < frames; i++) {
+        outL[i] = 0;
+        if (stereo) outR[i] = 0;
+      }
+    }
     return true;
-  }
-
-  _processSeq(tempo) {
-    const ovLen   = this._ovLen;
-    const midLen  = this._midLen;
-    const seqLen  = this._seqLen;
-    const outLen  = ovLen + midLen;
-
-    const bestOff = findBestOffset(this._carryL, ovLen, this._inL, this._seekLen);
-
-    // Crossfade carry-over with the new sequence start
-    for (let i = 0; i < ovLen; i++) {
-      const w = i / ovLen;
-      this._tmpL[i] = this._carryL[i] * (1 - w) + this._inL.peek(bestOff + i) * w;
-      this._tmpR[i] = this._carryR[i] * (1 - w) + this._inR.peek(bestOff + i) * w;
-    }
-
-    // Copy middle section verbatim
-    for (let i = 0; i < midLen; i++) {
-      this._tmpL[ovLen + i] = this._inL.peek(bestOff + ovLen + i);
-      this._tmpR[ovLen + i] = this._inR.peek(bestOff + ovLen + i);
-    }
-
-    // Save last ovLen samples as new carry-over for next crossfade
-    for (let i = 0; i < ovLen; i++) {
-      this._carryL[i] = this._inL.peek(bestOff + ovLen + midLen + i);
-      this._carryR[i] = this._inR.peek(bestOff + ovLen + midLen + i);
-    }
-
-    this._outL.push(this._tmpL, 0, outLen);
-    this._outR.push(this._tmpR, 0, outLen);
-
-    // Advance input: tempo controls how many input samples map to one output sequence
-    const advance = Math.round((seqLen - ovLen) * tempo) + bestOff;
-    this._inL.consume(advance);
-    this._inR.consume(advance);
   }
 }
 

--- a/tests/e2e/transpose.spec.mjs
+++ b/tests/e2e/transpose.spec.mjs
@@ -1,0 +1,331 @@
+// The transpose controls: the transport stepper and the per-lane key steppers.
+//
+// The DSP is measured in tests/js/pitch-shift.test.mjs and the graph wiring in
+// tests/js/audio-routing.test.mjs. What can only be checked in a real browser
+// is that the controls reach a real Web Audio graph at all, that their readouts
+// agree with what was sent, and that the ends of the range are reachable but
+// not passable.
+
+import { test, expect } from "@playwright/test";
+import { JOB_ID, openStudio } from "./helpers.mjs";
+
+const down = (page) => page.locator("#t-pitch-down");
+const up = (page) => page.locator("#t-pitch-up");
+const value = (page) => page.locator("#t-pitch-value");
+const reset = (page) => page.locator("#t-pitch-reset");
+
+const laneKey = (page, stem) => page.locator(`.lane-key[data-stem="${stem}"]`);
+const laneUp = (page, stem) => laneKey(page, stem).locator(".lane-key-step.up");
+const laneDown = (page, stem) => laneKey(page, stem).locator(".lane-key-step.down");
+const laneValue = (page, stem) => laneKey(page, stem).locator(".lane-key-value");
+
+// Input 6 is semitone 0, so input (6 + n) is a shift of n semitones.
+const ZERO_INPUT = 6;
+
+/**
+ * Record which worklet input each lane gets wired to.
+ *
+ * A lane's transpose is a connection, not a parameter, so the only honest way
+ * to check that a control reached the audio graph is to watch the graph being
+ * rewired. Installed from the test side rather than exposing the engine on
+ * `window`: a stepper that updates its own label while never reconnecting
+ * anything would satisfy every other assertion here, and that is precisely the
+ * wiring bug worth catching.
+ */
+async function recordRouting(page) {
+  await page.addInitScript(() => {
+    window.__transposeWorkletOptions = null;
+    window.__routes = [];
+    const busInput = new WeakMap();
+    let workletNode = null;
+
+    const Orig = window.AudioWorkletNode;
+    if (Orig) {
+      window.AudioWorkletNode = class extends Orig {
+        constructor(...args) {
+          super(...args);
+          if (args[1] === "soundtouch-processor") {
+            window.__transposeWorkletOptions = args[2] || null;
+            workletNode = this;
+          }
+        }
+      };
+    }
+
+    const origConnect = AudioNode.prototype.connect;
+    AudioNode.prototype.connect = function connect(destination, output, input) {
+      const result = origConnect.apply(this, arguments);
+      if (workletNode && destination === workletNode) {
+        // A bus announcing which input it owns.
+        busInput.set(this, input || 0);
+      } else if (busInput.has(destination)) {
+        // A lane arriving on one of those buses.
+        window.__routes.push(busInput.get(destination));
+      }
+      return result;
+    };
+  });
+}
+
+const clearRoutes = (page) => page.evaluate(() => { window.__routes.length = 0; });
+
+/**
+ * Wait for the engine to finish wiring every lane up, then start recording.
+ *
+ * Stems are decoded asynchronously and each one is routed as it lands, so a
+ * test that clears the log the moment the page is interactive still catches
+ * the tail of that initial wiring and reads it as a lane that moved.
+ */
+async function settleRoutes(page) {
+  let previous = -1;
+  await expect.poll(async () => {
+    const count = await page.evaluate(() => window.__routes.length);
+    const settled = count > 0 && count === previous;
+    previous = count;
+    return settled;
+  }, { timeout: 20000 }).toBe(true);
+  await clearRoutes(page);
+}
+const recentInputs = (page) => page.evaluate(
+  () => [...new Set(window.__routes || [])].sort((a, b) => a - b),
+);
+
+test.describe("transpose", () => {
+  test("the group is labelled as the global key", async ({ page }) => {
+    await openStudio(page);
+    // "Key" alone read as the only key control once the lanes gained their own.
+    await expect(page.locator("#t-pitch-label")).toHaveText(/global/i);
+  });
+
+  test("starts at zero and is not lit", async ({ page }) => {
+    await openStudio(page);
+    await expect(value(page)).toHaveText("0");
+    // The readout is only highlighted while the track is off its own key, so
+    // "this is not the original key" is visible without reading the number.
+    await expect(value(page)).not.toHaveClass(/active/);
+    await expect(down(page)).toBeEnabled();
+    await expect(up(page)).toBeEnabled();
+  });
+
+  test("steps up and down in semitones and signs the value", async ({ page }) => {
+    await openStudio(page);
+    await up(page).click();
+    await up(page).click();
+    await expect(value(page)).toHaveText("+2");
+    await expect(value(page)).toHaveClass(/active/);
+
+    for (let i = 0; i < 3; i++) await down(page).click();
+    await expect(value(page)).toHaveText("-1");
+
+    await up(page).click();
+    await expect(value(page)).toHaveText("0");
+    await expect(value(page)).not.toHaveClass(/active/);
+  });
+
+  test("the range ends are reachable and the buttons say so", async ({ page }) => {
+    await openStudio(page);
+    for (let i = 0; i < 6; i++) await up(page).click();
+    await expect(value(page)).toHaveText("+6");
+    // Disabled rather than merely inert: a stepper that stops responding with
+    // no visible reason reads as broken.
+    await expect(up(page)).toBeDisabled();
+    await expect(down(page)).toBeEnabled();
+
+    for (let i = 0; i < 12; i++) await down(page).click();
+    await expect(value(page)).toHaveText("-6");
+    await expect(down(page)).toBeDisabled();
+    await expect(up(page)).toBeEnabled();
+  });
+
+  test("the production worklet has one input per semitone", async ({ page }) => {
+    await recordRouting(page);
+    await openStudio(page);
+    await expect
+      .poll(() => page.evaluate(() => window.__transposeWorkletOptions?.numberOfInputs ?? null))
+      .toBe(13);
+  });
+
+  test("what the label shows is what the graph was rewired to", async ({ page }) => {
+    await recordRouting(page);
+    await openStudio(page);
+    await settleRoutes(page);
+
+    await up(page).click();
+    await up(page).click();
+    // Each step rewires, so the log is cleared just before the last one: what
+    // is being checked is where the graph ended up, not the route it took.
+    await clearRoutes(page);
+    await up(page).click();
+    await expect(value(page)).toHaveText("+3");
+
+    // Every lane that moved went to the same input, and it is the one that
+    // corresponds to the number on screen.
+    await expect.poll(() => recentInputs(page)).toEqual([ZERO_INPUT + 3]);
+  });
+
+  test("transposing does not disturb the speed control", async ({ page }) => {
+    // The two share a worklet, and the pitch stage changes the stretch ratio
+    // the speed control also depends on. They have to stay independent.
+    await openStudio(page);
+    await page.locator("#t-speed-075").click();
+    await expect(page.locator("#t-speed-075")).toHaveClass(/active/);
+
+    await up(page).click();
+    await expect(value(page)).toHaveText("+1");
+    await expect(page.locator("#t-speed-075")).toHaveClass(/active/);
+    await expect(page.locator("#t-speed-1")).not.toHaveClass(/active/);
+  });
+
+  test("reopening a track resets its displayed and applied key", async ({ page }) => {
+    await recordRouting(page);
+    await openStudio(page);
+    await up(page).click();
+    await up(page).click();
+    await expect(value(page)).toHaveText("+2");
+
+    await page.locator(`.cat-item[data-id="${JOB_ID}"]`).first().click();
+    await expect(value(page)).toHaveText("0");
+    await expect(value(page)).not.toHaveClass(/active/);
+  });
+
+  test("disables transpose when AudioWorklet setup is unavailable", async ({ page }) => {
+    await page.addInitScript(() => { window.AudioWorkletNode = undefined; });
+    await openStudio(page);
+    await expect(value(page)).toHaveText("0");
+    await expect(down(page)).toBeDisabled();
+    await expect(up(page)).toBeDisabled();
+  });
+});
+
+test.describe("per-lane transpose", () => {
+  test("every instrument lane carries a key stepper", async ({ page }) => {
+    await openStudio(page);
+    await expect(laneKey(page, "vocals")).toBeVisible();
+    // Reads as a label until it is doing something, then as a number.
+    await expect(laneValue(page, "vocals")).toHaveText("K");
+    await expect(laneKey(page, "vocals")).not.toHaveClass(/active/);
+  });
+
+  test("the drum lane has the control, disabled, and says why", async ({ page }) => {
+    await openStudio(page);
+    // Present rather than absent: a missing button on one row reads as a
+    // rendering bug, a disabled one that explains itself teaches the rule.
+    await expect(laneKey(page, "drums")).toBeVisible();
+    await expect(laneKey(page, "drums")).toHaveClass(/locked/);
+    await expect(laneUp(page, "drums")).toBeDisabled();
+    await expect(laneDown(page, "drums")).toBeDisabled();
+    await expect(laneKey(page, "drums")).toHaveAttribute("title", /drum/i);
+  });
+
+  test("a lane steps, signs its value and lights up", async ({ page }) => {
+    await openStudio(page);
+    await laneUp(page, "vocals").click();
+    await laneUp(page, "vocals").click();
+    await expect(laneValue(page, "vocals")).toHaveText("+2");
+    await expect(laneKey(page, "vocals")).toHaveClass(/active/);
+
+    for (let i = 0; i < 3; i++) await laneDown(page, "vocals").click();
+    await expect(laneValue(page, "vocals")).toHaveText("-1");
+
+    await laneUp(page, "vocals").click();
+    await expect(laneValue(page, "vocals")).toHaveText("K");
+    await expect(laneKey(page, "vocals")).not.toHaveClass(/active/);
+  });
+
+  test("a lane offset rewires only that lane", async ({ page }) => {
+    await recordRouting(page);
+    await openStudio(page);
+    await settleRoutes(page);
+
+    await laneUp(page, "vocals").click();
+    await expect(laneValue(page, "vocals")).toHaveText("+1");
+    await expect.poll(() => recentInputs(page)).toEqual([ZERO_INPUT + 1]);
+  });
+
+  test("the global key carries every lane with it", async ({ page }) => {
+    await openStudio(page);
+    await up(page).click();
+    await up(page).click();
+    await expect(value(page)).toHaveText("+2");
+    // A lane reads the key it is actually in, so moving the whole track moves
+    // the numbers on the lanes too. There is never a second number to add.
+    await expect(laneValue(page, "vocals")).toHaveText("+2");
+    await expect(laneValue(page, "bass")).toHaveText("+2");
+    // Except drums, which never move.
+    await expect(laneValue(page, "drums")).toHaveText("K");
+  });
+
+  test("a lane keeps its distance when the global key moves", async ({ page }) => {
+    await openStudio(page);
+    await laneUp(page, "vocals").click();
+    await laneUp(page, "vocals").click();
+    await laneUp(page, "vocals").click();
+    await expect(laneValue(page, "vocals")).toHaveText("+3");
+
+    await up(page).click();
+    // The global control nudges rather than overrides: a lane deliberately put
+    // above the rest stays above the rest.
+    await expect(laneValue(page, "vocals")).toHaveText("+4");
+    await expect(laneValue(page, "bass")).toHaveText("+1");
+  });
+
+  test("a lane moved on its own rewires only itself", async ({ page }) => {
+    await recordRouting(page);
+    await openStudio(page);
+
+    await settleRoutes(page);
+    await up(page).click();
+    await up(page).click();
+    await expect(value(page)).toHaveText("+2");
+
+    await clearRoutes(page);
+    await laneDown(page, "vocals").click();
+    await expect(laneValue(page, "vocals")).toHaveText("+1");
+    await expect.poll(() => recentInputs(page)).toEqual([ZERO_INPUT + 1]);
+  });
+
+  test("a lane stops at the ends of the range", async ({ page }) => {
+    await openStudio(page);
+    for (let i = 0; i < 6; i++) await laneUp(page, "vocals").click();
+    await expect(laneValue(page, "vocals")).toHaveText("+6");
+    await expect(laneUp(page, "vocals")).toBeDisabled();
+    await expect(laneDown(page, "vocals")).toBeEnabled();
+
+    for (let i = 0; i < 12; i++) await laneDown(page, "vocals").click();
+    await expect(laneValue(page, "vocals")).toHaveText("-6");
+    await expect(laneDown(page, "vocals")).toBeDisabled();
+  });
+
+  test("reset returns the global key and every lane to the original", async ({ page }) => {
+    await openStudio(page);
+    await up(page).click();
+    await up(page).click();
+    await laneUp(page, "vocals").click();
+    await laneDown(page, "bass").click();
+    await expect(value(page)).toHaveText("+2");
+    await expect(laneValue(page, "vocals")).toHaveText("+3");
+    await expect(laneValue(page, "bass")).toHaveText("+1");
+
+    await reset(page).click();
+    // Everything, not just the global control: once lanes have been moved
+    // individually, stepping the global back to zero cannot undo them.
+    await expect(value(page)).toHaveText("0");
+    await expect(value(page)).not.toHaveClass(/active/);
+    await expect(laneValue(page, "vocals")).toHaveText("K");
+    await expect(laneValue(page, "bass")).toHaveText("K");
+    await expect(laneKey(page, "vocals")).not.toHaveClass(/active/);
+  });
+
+  test("reset is unavailable when transpose is", async ({ page }) => {
+    await page.addInitScript(() => { window.AudioWorkletNode = undefined; });
+    await openStudio(page);
+    await expect(reset(page)).toBeDisabled();
+  });
+
+  test("lane keys are disabled when AudioWorklet is unavailable", async ({ page }) => {
+    await page.addInitScript(() => { window.AudioWorkletNode = undefined; });
+    await openStudio(page);
+    await expect(laneKey(page, "vocals")).toHaveClass(/unsupported/);
+    await expect(laneUp(page, "vocals")).toBeDisabled();
+  });
+});

--- a/tests/js/audio-routing.test.mjs
+++ b/tests/js/audio-routing.test.mjs
@@ -1,0 +1,334 @@
+import { addVisualOnlyStems, buildPlaybackStems } from '../../static/js/playbackStems.js';
+
+let passed = 0;
+let failed = 0;
+
+function check(name, condition, detail = '') {
+  if (condition) {
+    passed++;
+    console.log(`PASS  ${name}`);
+  } else {
+    failed++;
+    console.log(`FAIL  ${name}${detail ? `  -- ${detail}` : ''}`);
+  }
+}
+
+const BASE = ['vocals', 'drums', 'bass', 'guitar', 'piano', 'other'];
+const stem = (name) => ({ name, url: `/${name}.wav` });
+
+{
+  const raw = ['original', ...BASE].map(stem);
+  const visible = [stem('original'), stem('vocals'), stem('guitar')];
+  const playback = buildPlaybackStems(raw, visible, BASE);
+  check(
+    'original is reconstructed from each unselected raw stem',
+    playback.map((item) => `${item.name}:${item.controlName}`).join(',')
+      === 'vocals:vocals,guitar:guitar,drums:original,bass:original,piano:original,other:original',
+  );
+  check(
+    'the reconstructed drum source is always unpitched',
+    playback.find((item) => item.name === 'drums')?.pitched === false,
+  );
+  check(
+    'melodic sources in the original control group remain pitchable',
+    playback.filter((item) => item.controlName === 'original' && item.name !== 'drums')
+      .every((item) => item.pitched === true),
+  );
+
+  const full = addVisualOnlyStems(playback, visible);
+  check(
+    'full decode retains original.wav only for waveform rendering',
+    full.some((item) => item.name === 'original' && item.visualOnly === true),
+  );
+}
+
+{
+  const raw = [stem('original'), stem('vocals'), stem('bass')];
+  const visible = [stem('original'), stem('vocals')];
+  const playback = buildPlaybackStems(raw, visible, BASE);
+  const fallback = playback.find((item) => item.name === 'original');
+  check('an incomplete legacy complement is played exactly once', playback.length === 2);
+  check('an incomplete legacy complement stays wholly unpitched', fallback?.pitched === false);
+}
+
+{
+  const raw = ['original', ...BASE, 'lead_vocals', 'backing_vocals'].map(stem);
+  const visible = [stem('original'), stem('lead_vocals'), stem('backing_vocals')];
+  const playback = buildPlaybackStems(raw, visible, BASE);
+  check(
+    'split vocals replace base vocals without doubling them into original',
+    !playback.some((item) => item.name === 'vocals'),
+  );
+}
+
+class FakeParam {
+  constructor(value = 0) { this.value = value; }
+}
+
+class FakeNode {
+  constructor(ctx, type) {
+    this.ctx = ctx;
+    this.type = type;
+    this.connections = [];
+    ctx.nodes.push(this);
+  }
+
+  connect(destination, output = 0, input = 0) {
+    this.connections.push({ destination, output, input });
+    return destination;
+  }
+
+  disconnect() { this.connections = []; }
+}
+
+class FakeGain extends FakeNode {
+  constructor(ctx) {
+    super(ctx, 'gain');
+    this.gain = {
+      value: 1,
+      setTargetAtTime: (value) => { this.gain.value = value; },
+    };
+  }
+}
+
+class FakeAnalyser extends FakeNode {
+  constructor(ctx) {
+    super(ctx, 'analyser');
+    this.fftSize = 1024;
+  }
+
+  getByteTimeDomainData(data) { data.fill(128); }
+
+  getFloatTimeDomainData(data) { data.fill(0); }
+}
+
+class FakeSource extends FakeNode {
+  constructor(ctx) {
+    super(ctx, 'source');
+    this.playbackRate = new FakeParam(1);
+    this.buffer = null;
+    this.stopped = false;
+  }
+
+  start() {}
+  stop() { this.stopped = true; }
+}
+
+class FakeContext {
+  constructor() {
+    this.nodes = [];
+    this.currentTime = 0;
+    this.sampleRate = 44100;
+    this.state = 'running';
+    this.destination = new FakeNode(this, 'destination');
+    this.audioWorklet = { addModule: async () => {} };
+  }
+
+  createGain() { return new FakeGain(this); }
+  createAnalyser() { return new FakeAnalyser(this); }
+  createBufferSource() { return new FakeSource(this); }
+  createBuffer(channels, length, sampleRate) {
+    const data = Array.from({ length: channels }, () => new Float32Array(length));
+    return {
+      duration: length / sampleRate,
+      getChannelData: (channel) => data[channel],
+    };
+  }
+  async decodeAudioData() {
+    return { duration: 1, numberOfChannels: 2, sampleRate: 44100, length: 44100 };
+  }
+  async resume() {}
+  async close() {}
+}
+
+class FakeWorkletNode extends FakeNode {
+  constructor(ctx, name, options) {
+    super(ctx, 'worklet');
+    this.name = name;
+    this.options = options;
+    this.parameters = new Map([['tempo', new FakeParam(1)]]);
+    this.messages = [];
+    this.port = { postMessage: (message) => this.messages.push(message) };
+    // The real processor reports its buffering the moment it is constructed,
+    // and the engine needs that number to hold the playhead while the pitch
+    // buses prime. tests/js/pitch-shift.test.mjs checks the value itself; what
+    // matters here is that the engine listens and uses it.
+    queueMicrotask(() => this.port.onmessage?.({ data: { type: 'latency', frames: WORKLET_LATENCY_FRAMES } }));
+  }
+}
+
+// Roughly what the processor reports at 44.1 kHz: its common priming plus the
+// unpitched bus's alignment pad. Only the order of magnitude matters here.
+const WORKLET_LATENCY_FRAMES = 6541;
+
+globalThis.window = { AudioContext: FakeContext };
+globalThis.AudioWorkletNode = FakeWorkletNode;
+globalThis.requestAnimationFrame = () => 1;
+globalThis.cancelAnimationFrame = () => {};
+
+function wavBytes() {
+  const samples = 64;
+  const bytes = new ArrayBuffer(44 + samples * 2);
+  const view = new DataView(bytes);
+  const text = (offset, value) => {
+    for (let i = 0; i < value.length; i++) view.setUint8(offset + i, value.charCodeAt(i));
+  };
+  text(0, 'RIFF');
+  view.setUint32(4, bytes.byteLength - 8, true);
+  text(8, 'WAVE');
+  text(12, 'fmt ');
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, 44100, true);
+  view.setUint32(28, 88200, true);
+  view.setUint16(32, 2, true);
+  view.setUint16(34, 16, true);
+  text(36, 'data');
+  view.setUint32(40, samples * 2, true);
+  return new Uint8Array(bytes);
+}
+
+const WAV = wavBytes();
+globalThis.fetch = async (_url, options = {}) => {
+  const range = options.headers?.Range;
+  let start = 0;
+  let end = WAV.length - 1;
+  if (range) {
+    const match = /bytes=(\d+)-(\d+)/.exec(range);
+    if (match) {
+      start = Number(match[1]);
+      end = Math.min(Number(match[2]), end);
+    }
+  }
+  const slice = start <= end ? WAV.slice(start, end + 1) : new Uint8Array();
+  return {
+    ok: true,
+    status: range ? 206 : 200,
+    headers: { get: (name) => name === 'Content-Range' ? `bytes ${start}-${end}/${WAV.length}` : null },
+    arrayBuffer: async () => slice.buffer,
+  };
+};
+
+const { INPUT_COUNT, ZERO_INPUT } = await import('../../static/js/pitchBus.js');
+const { createAudioEngine } = await import('../../static/js/audioEngine.js');
+const { createChunkedAudioEngine } = await import('../../static/js/chunkedAudioEngine.js');
+
+async function verifyEngine(name, create) {
+  const ctx = new FakeContext();
+  const sources = [
+    { ...stem('vocals'), controlName: 'vocals', pitched: true },
+    { ...stem('drums'), controlName: 'original', pitched: true },
+    { ...stem('bass'), controlName: 'original', pitched: true },
+  ];
+  const engine = create(sources, { context: ctx });
+  check(`${name} becomes ready`, await engine.ready);
+
+  const worklet = ctx.nodes.find((node) => node.type === 'worklet');
+  check(
+    `${name} creates one worklet input per semitone`,
+    worklet?.options?.numberOfInputs === INPUT_COUNT,
+    `got ${worklet?.options?.numberOfInputs}`,
+  );
+
+  // A lane's transpose is which input it is wired to, so "what key is this
+  // lane in" is answered by walking the graph, not by reading a parameter.
+  const bus = (index) => ctx.nodes.find((node) =>
+    node.connections.some((edge) => edge.destination === worklet && edge.input === index));
+  const busOf = (node) => {
+    for (let k = 0; k < INPUT_COUNT; k++) {
+      if (node?.connections.some((edge) => edge.destination === bus(k))) return k - ZERO_INPUT;
+    }
+    return null;
+  };
+  check(`${name} exposes the unpitched bus for the metronome`, engine.getMasterNode() === bus(ZERO_INPUT));
+
+  const originalAnalysers = engine.getAnalysers('original');
+  check(`${name} groups all complement analysers under original`, originalAnalysers.length === 2);
+  const drumAnalyser = originalAnalysers[0];
+  const melodicAnalyser = originalAnalysers[1];
+  check(
+    `${name} starts every lane at its own key`,
+    busOf(drumAnalyser) === 0 && busOf(melodicAnalyser) === 0,
+  );
+
+  engine.setGain('original', 0.37);
+  const groupedGains = originalAnalysers.map((analyser) =>
+    ctx.nodes.find((node) => node.type === 'gain'
+      && node.connections.some((edge) => edge.destination === analyser))?.gain.value);
+  check(`${name} applies one mixer control to every complement source`, groupedGains.every((v) => v === 0.37));
+  check(`${name} reports pitch support only after worklet setup`, engine.supportsPitchShift() === true);
+
+  // A lane's key is absolute: it is wired to the input for the number it was
+  // given, with nothing else added in.
+  check(`${name} accepts a lane transpose`, engine.setStemPitch('vocals', -2) === true);
+  const vocalBus = busOf(engine.getAnalysers('vocals')[0]);
+  check(`${name} puts a lane in the key it was given`, vocalBus === -2, `landed on ${vocalBus}`);
+  check(`${name} reports the key it was given`, engine.getStemPitch('vocals') === -2);
+  check(`${name} leaves other lanes where they were`, busOf(melodicAnalyser) === 0);
+
+  // A key past the range the DSP is measured over stops at the edge rather
+  // than landing somewhere unusable.
+  engine.setStemPitch('vocals', 99);
+  check(
+    `${name} clamps a lane to the offered range`,
+    busOf(engine.getAnalysers('vocals')[0]) === 6,
+  );
+
+  // One control drives both sources in the `original` group, and only one of
+  // them is allowed to move. This is the whole reason the unpitched input
+  // exists, and the caller above marked this drum source `pitched: true`.
+  engine.setStemPitch('original', 3);
+  check(
+    `${name} transposes melodic complement sources`,
+    busOf(melodicAnalyser) === 3,
+    `landed on ${busOf(melodicAnalyser)}`,
+  );
+  check(
+    `${name} never moves drums, whatever it is told`,
+    busOf(drumAnalyser) === 0,
+    `landed on ${busOf(drumAnalyser)}`,
+  );
+  check(`${name} reports drums as not pitchable`, engine.isStemPitchable('drums') === false);
+
+  engine.setStemPitch('vocals', 3);
+
+  if (name === 'full-decode engine') {
+    engine.play();
+    const anchoredAt = engine.getCurrentTime();
+    ctx.currentTime += 0.05;
+    check(
+      'the full-decode playhead waits while a changed pitch stage primes',
+      engine.getCurrentTime() === anchoredAt,
+    );
+    ctx.currentTime += 0.20;
+    check('the full-decode playhead advances after DSP priming', engine.getCurrentTime() > anchoredAt);
+    engine.pause();
+    check(
+      'pausing flushes buffered worklet output',
+      worklet.messages.at(-1)?.type === 'reset',
+    );
+  }
+  engine.destroy();
+}
+
+await verifyEngine('full-decode engine', createAudioEngine);
+await verifyEngine('chunked engine', createChunkedAudioEngine);
+
+{
+  const ctx = new FakeContext();
+  ctx.audioWorklet = null;
+  const engine = createAudioEngine([stem('vocals')], { context: ctx });
+  check('full-decode fallback audio still becomes ready', await engine.ready);
+  check('fallback audio reports that pitch shifting is unavailable', engine.supportsPitchShift() === false);
+  // A stepper that moves its own label while the sound never changes is worse
+  // than one that plainly cannot: the engine refuses rather than pretending.
+  check(
+    'fallback audio rejects a misleading pitch change',
+    engine.setStemPitch('vocals', 4) === false && engine.getStemPitch('vocals') === 0,
+  );
+  engine.destroy();
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed ? 1 : 0);

--- a/tests/js/pitch-shift.test.mjs
+++ b/tests/js/pitch-shift.test.mjs
@@ -1,0 +1,657 @@
+// The pitch stage of the SoundTouch worklet (#245).
+//
+// Pitch is the one audio feature where "sounds about right" is not a test: a
+// transpose that lands two cents flat is inaudible and a transpose that lands
+// thirty cents flat is unusable, and nothing in between announces itself. So
+// this measures rather than eyeballs, by driving the processor exactly as an
+// AudioWorklet would (128-frame blocks, k-rate params) and analysing what
+// comes out.
+//
+// Frequency is estimated by autocorrelation, not by an FFT peak. WSOLA splices
+// the signal periodically, which smears a pure tone's spectrum enough that a
+// parabolic FFT peak reports errors of twenty cents on output that is actually
+// correct to two. That false alarm is what motivated using a period estimator.
+//
+// Run:  node tests/js/pitch-shift.test.mjs
+
+import { readFileSync } from 'node:fs';
+
+const SR = 44100;
+const BLOCK = 128;
+
+let pass = 0,
+  fail = 0;
+const check = (name, cond, detail = '') => {
+  if (cond) {
+    pass++;
+    console.log(`PASS  ${name}`);
+  } else {
+    fail++;
+    console.log(`FAIL  ${name}${detail ? '  -- ' + detail : ''}`);
+  }
+};
+
+const SRC = readFileSync(new URL('../../static/vendor/soundtouch-processor.js', import.meta.url), 'utf8');
+
+/** Load the worklet with the AudioWorklet globals shimmed, optionally patched. */
+function load(src = SRC) {
+  let Cls = null;
+  new Function('sampleRate', 'AudioWorkletProcessor', 'registerProcessor', src)(
+    SR,
+    class {
+      constructor() {
+        this.port = { onmessage: null, postMessage: (m) => this.port.sent.push(m), sent: [] };
+      }
+    },
+    (_name, c) => {
+      Cls = c;
+    },
+  );
+  return Cls;
+}
+
+// The processor takes one input per semitone, so "transpose by n" is expressed
+// by which input the signal is fed to. Input ZERO_INPUT is the plain delay line
+// that carries drums and anything already in its own key.
+const INPUT_COUNT = 13;
+const ZERO_INPUT = 6;
+
+/**
+ * Build the `inputs` argument, given a map of semitone -> block.
+ *
+ * Unlisted inputs are handed an empty array, which is exactly what Web Audio
+ * passes for an input nothing is connected to, and is how the processor decides
+ * a chain is needed at all.
+ */
+function inputsFor(blocksBySemitone) {
+  const inputs = [];
+  for (let k = 0; k < INPUT_COUNT; k++) {
+    const block = blocksBySemitone[k - ZERO_INPUT];
+    inputs.push(block ? [block, block] : []);
+  }
+  return inputs;
+}
+
+/**
+ * Collapse [semitone, block] pairs into one block per input.
+ *
+ * At semitone 0 the music and drum buses are the same input, and letting the
+ * later entry win would silently drop the earlier signal -- which reads as a
+ * missing onset rather than as a broken probe.
+ */
+function onBuses(pairs) {
+  const out = {};
+  for (const [semitone, block] of pairs) {
+    if (!out[semitone]) { out[semitone] = block; continue; }
+    const merged = new Float32Array(block.length);
+    for (let i = 0; i < block.length; i++) merged[i] = out[semitone][i] + block[i];
+    out[semitone] = merged;
+  }
+  return out;
+}
+
+/** Feed an existing buffer through the processor; return the output. */
+function driveBuffer(Cls, input, { tempo = 1, pitch = 0 }) {
+  const p = new Cls();
+  const params = { tempo: [tempo] };
+  const blocks = Math.floor(input.length / BLOCK);
+  const out = new Float32Array(blocks * BLOCK);
+  for (let b = 0; b < blocks; b++) {
+    const inL = input.subarray(b * BLOCK, (b + 1) * BLOCK);
+    const oL = new Float32Array(BLOCK);
+    const oR = new Float32Array(BLOCK);
+    p.process(inputsFor({ [pitch]: inL }), [[oL, oR]], params);
+    out.set(oL, b * BLOCK);
+  }
+  return out;
+}
+
+/** Feed a sine through the processor block by block; return the output. */
+function drive(Cls, freq, { tempo = 1, pitch = 0 }, blocks = 500) {
+  const p = new Cls();
+  const params = { tempo: [tempo] };
+  const out = new Float32Array(blocks * BLOCK);
+  const step = (2 * Math.PI * freq) / SR;
+  let phase = 0;
+  for (let b = 0; b < blocks; b++) {
+    const inL = new Float32Array(BLOCK);
+    for (let i = 0; i < BLOCK; i++) {
+      inL[i] = Math.sin(phase);
+      phase += step;
+    }
+    const oL = new Float32Array(BLOCK);
+    const oR = new Float32Array(BLOCK);
+    p.process(inputsFor({ [pitch]: inL }), [[oL, oR]], params);
+    out.set(oL, b * BLOCK);
+  }
+  return out;
+}
+
+/**
+ * Fundamental frequency by autocorrelation, searched within 20% of `expect`.
+ *
+ * The window is deliberately narrow: a wide search locks onto a subharmonic on
+ * WSOLA output and reports a clean -2400 cents, which looks like a catastrophic
+ * bug and is only the estimator picking the wrong lag.
+ */
+function periodNear(x, expect) {
+  const lagMin = Math.floor(SR / (expect * 1.2));
+  const lagMax = Math.ceil(SR / (expect / 1.2));
+  const ac = new Float64Array(lagMax + 2);
+  let best = lagMin,
+    bestV = -Infinity;
+  for (let lag = lagMin; lag <= lagMax; lag++) {
+    let s = 0;
+    for (let i = 0; i < x.length - lag; i++) s += x[i] * x[i + lag];
+    ac[lag] = s / (x.length - lag);
+    if (ac[lag] > bestV) {
+      bestV = ac[lag];
+      best = lag;
+    }
+  }
+  const y0 = ac[best - 1],
+    y1 = ac[best],
+    y2 = ac[best + 1];
+  return SR / (best + (0.5 * (y0 - y2)) / (y0 - 2 * y1 + y2 || 1));
+}
+
+const cents = (a, b) => 1200 * Math.log2(a / b);
+
+/** Energy at `f` via Goertzel, normalised by length. */
+function energyAt(y, f) {
+  const w = (2 * Math.PI * f) / SR;
+  const c = 2 * Math.cos(w);
+  let s1 = 0,
+    s2 = 0;
+  for (let i = 0; i < y.length; i++) {
+    const s0 = y[i] + c * s1 - s2;
+    s2 = s1;
+    s1 = s0;
+  }
+  return (s1 * s1 + s2 * s2 - c * s1 * s2) / y.length;
+}
+
+const Proc = load();
+
+// ── 1. Passthrough must be exact ────────────────────────────────────────────
+// Nobody transposes most of the time, so the common path has to be free of
+// both cost and colour. Not "close": identical.
+{
+  // Compared against the very samples that were fed, not a recomputed sine:
+  // the input is float32 and its phase accumulates, so a float64 reference
+  // disagrees by ~3e-8 even when the processor copied the block verbatim.
+  const step = (2 * Math.PI * 440) / SR;
+  const input = Float32Array.from({ length: 200 * BLOCK }, (_, i) => Math.sin(i * step));
+  const y = driveBuffer(Proc, input, { tempo: 1, pitch: 0 });
+  let maxDiff = 0;
+  for (let i = 0; i < y.length; i++) maxDiff = Math.max(maxDiff, Math.abs(y[i] - input[i]));
+  check('pitch 0 at speed 1 is bit-identical to the input', maxDiff === 0, `max diff ${maxDiff}`);
+}
+
+// ── 2. Every offered semitone lands where it claims ─────────────────────────
+// 5 cents is about the smallest interval a trained ear reliably hears on a
+// sustained tone, so it is the honest ceiling for "in tune".
+{
+  const F = 440;
+  let worst = 0,
+    worstN = 0;
+  let worstTempo = 1;
+  for (const tempo of [0.75, 1]) {
+    for (let n = -6; n <= 6; n++) {
+      if (n === 0) continue;
+      const expect = F * Math.pow(2, n / 12);
+      const y = drive(Proc, F, { tempo, pitch: n }, 900);
+      const err = Math.abs(cents(periodNear(y.subarray(SR), expect), expect));
+      if (err > worst) {
+        worst = err;
+        worstN = n;
+        worstTempo = tempo;
+      }
+    }
+  }
+  check(
+    'every semitone at every offered speed is within 5 cents of target',
+    worst < 5,
+    `worst ${worst.toFixed(2)} cents at ${worstN}, speed ${worstTempo}`,
+  );
+}
+
+// ── 3. The stretcher must not move pitch on its own ─────────────────────────
+// If it did, pitch and speed would interact and the two controls could not be
+// used together, which is the whole point of pairing them.
+{
+  let worst = 0;
+  for (const tempo of [0.75, 1.25, 1.5]) {
+    const y = drive(Proc, 440, { tempo, pitch: 0 }, 700);
+    worst = Math.max(worst, Math.abs(cents(periodNear(y.subarray(SR), 440), 440)));
+  }
+  check('changing speed alone leaves pitch alone', worst < 5, `worst ${worst.toFixed(2)} cents`);
+}
+
+// ── 4. Anti-aliasing actually rejects aliases ───────────────────────────────
+// 17 kHz shifted up six semitones maps past Nyquist and folds back to about
+// 20 kHz. Comparing against the same processor with the filter defeated is the
+// only measurement that means anything: an absolute number cannot tell you
+// whether the filter or the arithmetic is responsible.
+{
+  const Unfiltered = load(SRC.replace('0.47 * sr', '0 * sr'));
+  const ALIAS_HZ = 44100 - 17000 * Math.pow(2, 6 / 12);
+  const on = energyAt(drive(Proc, 17000, { pitch: 6 }, 400).subarray(SR), ALIAS_HZ);
+  const off = energyAt(drive(Unfiltered, 17000, { pitch: 6 }, 400).subarray(SR), ALIAS_HZ);
+  const dB = 10 * Math.log10(off / (on || 1e-30));
+  check('the anti-alias filter rejects at least 20 dB', dB > 20, `only ${dB.toFixed(1)} dB`);
+}
+
+// ── 5. and costs nothing it does not have to ────────────────────────────────
+// The filter sits before the resampler precisely so it does not attenuate
+// content that was going to survive the shift. Placed after, it took 9 dB off
+// this tone for no benefit.
+{
+  const Unfiltered = load(SRC.replace('0.47 * sr', '0 * sr'));
+  const OUT_HZ = 11000 * Math.pow(2, 6 / 12);
+  const on = energyAt(drive(Proc, 11000, { pitch: 6 }, 400).subarray(SR), OUT_HZ);
+  const off = energyAt(drive(Unfiltered, 11000, { pitch: 6 }, 400).subarray(SR), OUT_HZ);
+  const loss = Math.abs(10 * Math.log10(on / off));
+  check('and takes less than 1 dB off content that survives the shift', loss < 1, `${loss.toFixed(2)} dB lost`);
+}
+
+// ── 6. Output stays finite ──────────────────────────────────────────────────
+// A resonant biquad fed a transient can ring into NaN if its state is ever
+// reset inconsistently, and a single NaN silences the whole graph until the
+// page reloads.
+{
+  let bad = 0;
+  for (const n of [-6, -1, 3, 6]) {
+    const y = drive(Proc, 440, { tempo: 0.75, pitch: n }, 300);
+    for (let i = 0; i < y.length; i++) if (!Number.isFinite(y[i]) || Math.abs(y[i]) > 4) bad++;
+  }
+  check('no NaN, no infinity, no runaway samples', bad === 0, `${bad} bad samples`);
+}
+
+// ── 7. Leaving transpose must not replay stale audio ────────────────────────
+// Both stages buffer over a hundred milliseconds. Returning to the bypass path
+// without dropping that would emit it a moment later as a click.
+{
+  const p = new Proc();
+  const step = (2 * Math.PI * 440) / SR;
+  let phase = 0;
+  const feed = (pitch, blocks) => {
+    let last = null;
+    for (let b = 0; b < blocks; b++) {
+      const inL = new Float32Array(BLOCK);
+      for (let i = 0; i < BLOCK; i++) {
+        inL[i] = Math.sin(phase);
+        phase += step;
+      }
+      const oL = new Float32Array(BLOCK);
+      const oR = new Float32Array(BLOCK);
+      p.process(inputsFor({ [pitch]: inL }), [[oL, oR]], { tempo: [1] });
+      last = { inL, oL };
+    }
+    return last;
+  };
+  feed(4, 200);
+  // Leaving a key is a disconnection, so the chain keeps running until it has
+  // played out what it buffered. Nothing should be spliced on the way.
+  const draining = feed(0, 40);
+  let drainStep = 0;
+  for (let i = 1; i < BLOCK; i++) {
+    drainStep = Math.max(drainStep, Math.abs(draining.oL[i] - draining.oL[i - 1]));
+  }
+  check('the chain being left drains without a splice', drainStep < 0.2, `step ${drainStep.toFixed(3)}`);
+
+  // Once it is spent the processor drops it and the bypass path returns, which
+  // is what makes an untransposed track bit-identical rather than merely close.
+  const after = feed(0, 400);
+  let maxDiff = 0;
+  for (let i = 0; i < BLOCK; i++) maxDiff = Math.max(maxDiff, Math.abs(after.oL[i] - after.inL[i]));
+  check('returning to pitch 0 resumes clean passthrough', maxDiff === 0, `max diff ${maxDiff}`);
+}
+
+// ── 8. The engine and the processor agree on the input layout ───────────────
+// A lane's transpose is which input it is connected to, and the two files
+// decide that separately: pitchBus.js picks the index, the processor declares
+// how many exist. If they disagreed, a lane at the edge of the range would be
+// wired to an input that is not there and would simply go silent -- no error,
+// no warning, just a missing instrument.
+{
+  const busSrc = readFileSync(new URL('../../static/js/pitchBus.js', import.meta.url), 'utf8');
+  const num = (src, name) => {
+    const m = src.match(new RegExp(`${name}\\s*=\\s*(-?\\d+)`));
+    return m ? Number(m[1]) : null;
+  };
+  const workletMin = num(SRC, 'PITCH_MIN_SEMITONES');
+  const workletMax = num(SRC, 'PITCH_MAX_SEMITONES');
+  const engineMin = num(busSrc, 'PITCH_MIN');
+  const engineMax = num(busSrc, 'PITCH_MAX');
+  check(
+    'the engine and the processor offer the same semitone range',
+    workletMin === engineMin && workletMax === engineMax,
+    `worklet ${workletMin}..${workletMax}, engine ${engineMin}..${engineMax}`,
+  );
+  check(
+    'that range is the one the UI exposes',
+    workletMin === -6 && workletMax === 6,
+    `${workletMin}..${workletMax}`,
+  );
+
+  // Semitone 0 has to land on the input that does no resampling, or drums
+  // would be handed to a chain.
+  const zero = num(busSrc, 'ZERO_INPUT_FALLBACK');
+  check('semitone 0 maps to the unresampled input', zero === null && engineMin === -6);
+
+  // And the processor must report the buffering the engine uses to place the
+  // playhead. Reading it from a message rather than recomputing it is what
+  // keeps the two from drifting apart.
+  const probe = new Proc();
+  const latency = probe.port.sent.find((m) => m.type === 'latency');
+  check(
+    'the processor reports its own latency to the engine',
+    latency && latency.frames > SR * 0.05 && latency.frames < SR * 0.5,
+    JSON.stringify(latency),
+  );
+}
+
+
+// ── 9. Drums are not transposed ─────────────────────────────────────────────
+// The whole reason the processor takes two inputs. A resampled snare is not
+// the same drum in another key, it is a different drum, so input 1 must come
+// out at the pitch it went in at no matter what the pitch parameter says.
+{
+  const DRUM_HZ = 220;
+  const musicStep = (2 * Math.PI * 440) / SR;
+  const drumStep = (2 * Math.PI * DRUM_HZ) / SR;
+
+  for (const n of [-5, 5]) {
+    const p = new Proc();
+    const params = { tempo: [1] };
+    const blocks = 900;
+    const out = new Float32Array(blocks * BLOCK);
+    let mPhase = 0,
+      dPhase = 0;
+    for (let b = 0; b < blocks; b++) {
+      const m = new Float32Array(BLOCK);
+      const d = new Float32Array(BLOCK);
+      for (let i = 0; i < BLOCK; i++) {
+        m[i] = 0; // silence the pitched bus so only the drum tone is measurable
+        mPhase += musicStep;
+        d[i] = Math.sin(dPhase);
+        dPhase += drumStep;
+      }
+      const oL = new Float32Array(BLOCK);
+      const oR = new Float32Array(BLOCK);
+      p.process(inputsFor({ [n]: m, 0: d }), [[oL, oR]], params);
+      out.set(oL, b * BLOCK);
+    }
+    const got = periodNear(out.subarray(SR), DRUM_HZ);
+    const err = Math.abs(cents(got, DRUM_HZ));
+    check(`drums survive a ${n > 0 ? '+' : ''}${n} semitone transpose unshifted`, err < 5, `moved ${err.toFixed(2)} cents`);
+  }
+}
+
+// ── 10. Drums stay in time with the band ────────────────────────────
+// Test each bus in its own processor. Opposite impulses in one summed output
+// cancel when they are aligned, which can turn a correct result into a false
+// failure or make filter ringing look like a second onset.
+//
+// The marker is a 250 ms tone burst, never a lone impulse. WSOLA relocates an
+// isolated impulse wherever its correlator likes, so an impulse measures the
+// grain search rather than the timing. An earlier revision of this file did
+// exactly that and reported 2 ms, but only because the processor then split
+// attacks out and passed them at unity delay: the probe was reading the
+// bypass, not the pitch chain. Removing the splitter took the same measurement
+// to 38 ms with no change in alignment, which is what a test measuring the
+// wrong signal looks like.
+//
+// Two properties are worth asserting, and they are not the same one:
+//
+//   drift    the buses must not walk apart as a track plays. This is what
+//            ruins a four-minute song, and it is checked a minute in.
+//   offset   a bounded, non-accumulating error is inherent. WSOLA copies a
+//            sequence verbatim and jumps by `outLen * tempo`, so the source
+//            position sawtooths around the mean even though the mean is exact.
+//            `_alignBuses` centres that sawtooth; what is left is its width.
+{
+  const BURST = Math.round(0.25 * SR);
+  const FADE = Math.round(0.002 * SR);
+  const WIN = Math.round(0.002 * SR);
+
+  /** Output time of a single tone burst fed to one bus, in samples. */
+  const onsetAt = (pitch, tempo, bus, at, seconds) => {
+    const p = new Proc();
+    const params = { tempo: [tempo] };
+    const blocks = Math.ceil((seconds * SR) / BLOCK);
+    const silence = new Float32Array(BLOCK);
+    const env = [];
+    const acc = new Float32Array(WIN);
+    let ai = 0;
+    let peak = 0;
+    for (let b = 0; b < blocks; b++) {
+      const sig = new Float32Array(BLOCK);
+      for (let i = 0; i < BLOCK; i++) {
+        const k = b * BLOCK + i - at;
+        if (k < 0 || k >= BURST) continue;
+        const shape = Math.min(1, k / FADE) * Math.min(1, (BURST - k) / FADE);
+        sig[i] = shape * 0.5 * Math.sin((2 * Math.PI * 300 * (b * BLOCK + i)) / SR);
+      }
+      const m = bus === 0 ? sig : silence;
+      const d = bus === 1 ? sig : silence;
+      const oL = new Float32Array(BLOCK);
+      const oR = new Float32Array(BLOCK);
+      p.process(inputsFor(onBuses([[pitch, m], [0, d]])), [[oL, oR]], params);
+      for (let i = 0; i < BLOCK; i++) {
+        acc[ai++] = oL[i];
+        if (ai < WIN) continue;
+        let sum = 0;
+        for (let q = 0; q < WIN; q++) sum += acc[q] * acc[q];
+        const rms = Math.sqrt(sum / WIN);
+        env.push(rms);
+        if (rms > peak) peak = rms;
+        ai = 0;
+      }
+    }
+    if (peak < 0.02) return -1;
+    for (let j = 0; j < env.length; j++) if (env[j] > peak * 0.25) return j * WIN;
+    return -1;
+  };
+
+  const skewMs = (pitch, tempo, at) => {
+    const seconds = (at / SR + 2) / Math.min(1, tempo) + 3;
+    const music = onsetAt(pitch, tempo, 0, at, seconds);
+    const drums = onsetAt(pitch, tempo, 1, at, seconds);
+    if (music < 0 || drums < 0) return NaN;
+    return ((music - drums) / SR) * 1000;
+  };
+
+  // Pitch 0 is a pure bypass on both buses, so it is exact, and saying so
+  // guards the one case a user hears most.
+  let bypassWorst = 0;
+  for (const tempo of [0.75, 1]) {
+    for (const t of [0.7, 2.3, 5.1]) {
+      const s = Math.abs(skewMs(0, tempo, Math.round(t * SR)));
+      if (!(s < Infinity)) { bypassWorst = Infinity; break; }
+      bypassWorst = Math.max(bypassWorst, s);
+    }
+  }
+  check('at pitch 0 the buses are sample-aligned', bypassWorst === 0, `worst ${bypassWorst} ms`);
+
+  // The offset budget. `outLen * (1 - tempo)` is the sawtooth width, 20 ms at
+  // six semitones; the burst is read at 2 ms resolution. 30 ms leaves room for
+  // both without admitting a real desync, which would show as tens of ms at
+  // small intervals or as drift below.
+  let worst = 0;
+  let worstCase = '';
+  for (const tempo of [0.75, 1]) {
+    for (let n = -6; n <= 6; n++) {
+      for (const t of [0.7, 2.3, 5.1]) {
+        const s = Math.abs(skewMs(n, tempo, Math.round(t * SR)));
+        if (!(s <= worst) && !(s > worst)) { worst = Infinity; worstCase = `${n} @ ${tempo}: no onset`; continue; }
+        if (s > worst) {
+          worst = s;
+          worstCase = `${n > 0 ? '+' : ''}${n}, speed ${tempo}, onset ${t.toFixed(2)}s`;
+        }
+      }
+    }
+  }
+  check(
+    'drums stay within a grain of the band for every pitch and offered speed',
+    worst <= 30,
+    `worst ${Number.isFinite(worst) ? worst.toFixed(2) + ' ms' : 'missing onset'} at ${worstCase}`,
+  );
+
+  // The one that matters over a whole track. A chain whose rates are even
+  // slightly unequal looks fine in the first bar and is a beat out by the last.
+  let worstDrift = 0;
+  let driftCase = '';
+  for (const tempo of [0.75, 1]) {
+    for (const n of [-6, -2, 2, 6]) {
+      const early = skewMs(n, tempo, Math.round(1 * SR));
+      const late = skewMs(n, tempo, Math.round(60 * SR));
+      const drift = Math.abs(late - early);
+      if (!(drift <= worstDrift) && !(drift > worstDrift)) { worstDrift = Infinity; driftCase = `${n} @ ${tempo}: no onset`; continue; }
+      if (drift > worstDrift) {
+        worstDrift = drift;
+        driftCase = `${n > 0 ? '+' : ''}${n}, speed ${tempo}`;
+      }
+    }
+  }
+  check(
+    'the buses do not drift apart over a minute of playback',
+    worstDrift <= 30,
+    `worst ${Number.isFinite(worstDrift) ? worstDrift.toFixed(2) + ' ms' : 'missing onset'} at ${driftCase}`,
+  );
+}
+
+// ── 11. No clicks, pops or dropouts while transposing ───────────────
+// The reported symptom (#245 follow-up) was "choppy, static for
+// microseconds" while transposed. Both causes were structural, and both are
+// invisible to a test that only measures pitch:
+//
+//   1. attacks were split out of the music bus and passed at unity while the
+//      tonal half went through the ~120 ms pitch chain. The two halves cannot
+//      sum back to the input, so every onset punched a step into the output.
+//      Measured 0.64 full scale against a source whose own largest step was
+//      0.10, five times anything present in the input.
+//   2. the pitch chain produced exactly one quantum per quantum with no
+//      slack, so a quantum occasionally came up a few samples short and was
+//      emitted as a partial block, zero-padded. A hard edge to zero in the
+//      middle of a block is a click.
+//
+// So this measures the output the way an ear does: the largest sample-to-
+// sample step, against the same measure taken on the bypass path. Anything
+// the DSP adds beyond what the source already contains is an artefact.
+{
+  const chord = (n) => {
+    const a = new Float32Array(n);
+    for (let i = 0; i < n; i++) {
+      const t = i / SR;
+      a[i] = 0.2 * Math.sin(2 * Math.PI * 220 * t)
+        + 0.15 * Math.sin(2 * Math.PI * 277.18 * t)
+        + 0.15 * Math.sin(2 * Math.PI * 329.63 * t);
+      // An attack every 500 ms: this is what triggered the splitter, and any
+      // real mix has them several times a second.
+      const phase = i % Math.round(SR * 0.5);
+      if (phase < SR * 0.02) {
+        a[i] += 0.5 * Math.exp(-phase / (SR * 0.004)) * Math.sin(2 * Math.PI * 1200 * t);
+      }
+    }
+    return a;
+  };
+
+  /** Largest step, and any block emitted short and zero-padded. */
+  const artefacts = (Cls, pitch, tempo, blocks = 1200) => {
+    const p = new Cls();
+    const params = { tempo: [tempo] };
+    const src = chord(blocks * BLOCK);
+    const out = new Float32Array(blocks * BLOCK);
+    let partial = 0;
+    for (let b = 0; b < blocks; b++) {
+      const inL = src.subarray(b * BLOCK, (b + 1) * BLOCK);
+      const oL = new Float32Array(BLOCK);
+      const oR = new Float32Array(BLOCK);
+      p.process(inputsFor({ [pitch]: inL }), [[oL, oR]], params);
+      out.set(oL, b * BLOCK);
+      let zeros = 0;
+      for (let i = BLOCK - 1; i >= 0 && oL[i] === 0; i--) zeros++;
+      if (zeros > 0 && zeros < BLOCK) partial++;
+    }
+    let step = 0;
+    for (let i = Math.round(SR * 0.6) + 1; i < out.length; i++) {
+      const d = Math.abs(out[i] - out[i - 1]);
+      if (d > step) step = d;
+    }
+    return { step, partial };
+  };
+
+  const Proc11 = load();
+  const baseline = artefacts(Proc11, 0, 1).step;
+
+  let worstStep = 0;
+  let worstStepCase = '';
+  let partials = 0;
+  let partialCase = '';
+  for (const [pitch, tempo] of [[2, 1], [-2, 1], [5, 1], [-5, 1], [6, 1], [-6, 1], [2, 0.75], [-5, 0.75]]) {
+    const a = artefacts(Proc11, pitch, tempo);
+    if (a.step > worstStep) {
+      worstStep = a.step;
+      worstStepCase = `${pitch > 0 ? '+' : ''}${pitch}, speed ${tempo}`;
+    }
+    if (a.partial > 0 && !partialCase) partialCase = `${pitch > 0 ? '+' : ''}${pitch}, speed ${tempo}`;
+    partials += a.partial;
+  }
+
+  check(
+    'no quantum is emitted short and zero-padded',
+    partials === 0,
+    `${partials} partial blocks, first at ${partialCase}`,
+  );
+  // Pitching up resamples, which steepens every slope by the shift ratio, so
+  // some headroom over the bypass is correct. 2x covers the 1.41x at six
+  // semitones; the splitter bug sat at 6x and could not hide under this.
+  check(
+    'transposing adds no step the source did not already contain',
+    worstStep < baseline * 2,
+    `worst ${worstStep.toFixed(3)} at ${worstStepCase} vs ${baseline.toFixed(3)} on bypass`,
+  );
+
+  // Prove the gate above can actually see the regression it exists for: with
+  // the input cushion removed, the chain runs at zero slack again and starves.
+  const starved = load(SRC
+    .replace('const PRIME_CUSHION = 512;', 'const PRIME_CUSHION = 0;')
+    .replace('const OUTPUT_RESERVE = 512;', 'const OUTPUT_RESERVE = 0;')
+    .replace('this._commonPrime = this._tempo.needed + PRIME_CUSHION;', 'this._commonPrime = 0;'));
+  let starvedPartials = 0;
+  for (const [pitch, tempo] of [[2, 1], [-2, 1], [5, 1], [-5, 1]]) {
+    starvedPartials += artefacts(starved, pitch, tempo).partial;
+  }
+  check(
+    'and that gate fails when the input cushion is removed',
+    starvedPartials > 0,
+    `saw ${starvedPartials} partial blocks with the cushion gone`,
+  );
+}
+
+// A transport restart keeps the same parameters, so parameter-change flushing
+// cannot protect it. The explicit message must clear all buffered audio.
+{
+  const p = new Proc();
+  const params = { tempo: [0.75] };
+  const silence = new Float32Array(BLOCK);
+  const impulse = new Float32Array(BLOCK);
+  impulse[0] = 1;
+  p.process(inputsFor({ 4: impulse }), [[new Float32Array(BLOCK), new Float32Array(BLOCK)]], params);
+  for (let i = 0; i < 80; i++) {
+    p.process(inputsFor({ 4: silence }), [[new Float32Array(BLOCK), new Float32Array(BLOCK)]], params);
+  }
+  p.port.onmessage?.({ data: { type: 'reset' } });
+  let peak = 0;
+  for (let i = 0; i < 100; i++) {
+    const out = new Float32Array(BLOCK);
+    p.process(inputsFor({ 4: silence }), [[out, new Float32Array(BLOCK)]], params);
+    for (const sample of out) peak = Math.max(peak, Math.abs(sample));
+  }
+  check('an explicit transport reset cannot emit stale buffered audio', peak === 0, `peak ${peak}`);
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/tests/js/vu-scale.test.mjs
+++ b/tests/js/vu-scale.test.mjs
@@ -1,0 +1,146 @@
+// How much of a lane meter a real stem actually lights.
+//
+// The bug this exists to prevent came back as a complaint, not a failure: the
+// meters worked, moved with the audio and were simply unreadable, because they
+// were linear in amplitude. Nothing could catch that, because nothing asserted
+// what fraction of the bar normal playback uses.
+//
+// So this measures exactly that, against the levels separated stems really sit
+// at, and keeps the old linear formula around as the control. A scale that
+// leaves the median lane in the bottom tenth of its meter fails here.
+//
+// Run:  node tests/js/vu-scale.test.mjs
+
+import { VU_FLOOR_DB, vuLevel } from "../../static/js/vuScale.js";
+
+let pass = 0;
+let fail = 0;
+const check = (name, cond, detail = "") => {
+  if (cond) {
+    pass++;
+    console.log(`PASS  ${name}`);
+  } else {
+    fail++;
+    console.log(`FAIL  ${name}${detail ? "  -- " + detail : ""}`);
+  }
+};
+
+const dbToRms = (db) => Math.pow(10, db / 20);
+const pct = (rms) => vuLevel(rms) * 100;
+
+// The linear scale this replaced, kept as the control so the comparison below
+// is a measurement rather than an assertion about the past.
+const linear = (rms) => Math.min(1, rms * 2.5) * 100;
+
+// ── 1. The ends behave ──────────────────────────────────────────────────────
+{
+  check("silence reads empty", vuLevel(0) === 0);
+  check("a negative or bogus level reads empty", vuLevel(-1) === 0 && vuLevel(NaN) === 0);
+  check("full scale fills the bar", vuLevel(1) === 1);
+  check("anything above full scale is clamped, not overflowed", vuLevel(4) === 1);
+  check(
+    "the floor is the zero point",
+    Math.abs(vuLevel(dbToRms(VU_FLOOR_DB))) < 1e-9,
+    `${pct(dbToRms(VU_FLOOR_DB)).toFixed(3)}%`,
+  );
+  check("below the floor stays empty", vuLevel(dbToRms(VU_FLOOR_DB - 20)) === 0);
+}
+
+// ── 2. It is monotonic ──────────────────────────────────────────────────────
+// A meter that ever goes down as the audio gets louder is worse than no meter.
+{
+  let ok = true;
+  let previous = -1;
+  for (let db = VU_FLOOR_DB; db <= 0; db += 0.25) {
+    const level = vuLevel(dbToRms(db));
+    if (level < previous) ok = false;
+    previous = level;
+  }
+  check("louder never draws shorter", ok);
+}
+
+// ── 3. Real stems use the bar ───────────────────────────────────────────────
+// These are median RMS levels measured from a real StemDeck library: four
+// tracks, the vocals, drums, bass and "other" stems of each. They are the
+// levels the meter spends its time at, so they are the levels worth testing.
+{
+  const MEASURED = [
+    ["drums, quiet mix", 0.0068],
+    ["other, quiet mix", 0.0064],
+    ["vocals, quiet mix", 0.02],
+    ["bass, quiet mix", 0.021],
+    ["vocals, loud mix", 0.082],
+    ["drums, loud mix", 0.034],
+    ["bass, loud mix", 0.136],
+  ];
+
+  let worstNew = 100;
+  let worstOld = 100;
+  let worstCase = "";
+  for (const [label, rms] of MEASURED) {
+    if (pct(rms) < worstNew) {
+      worstNew = pct(rms);
+      worstCase = label;
+    }
+    worstOld = Math.min(worstOld, linear(rms));
+  }
+
+  // The complaint was "less than 15% of the bar", and the old scale earned it.
+  check(
+    "the scale this replaced really did waste the bar",
+    worstOld < 15,
+    `quietest measured stem lit ${worstOld.toFixed(1)}% under the linear scale`,
+  );
+  check(
+    "every measured stem now lights at least a quarter of its meter",
+    worstNew >= 25,
+    `${worstCase} lights ${worstNew.toFixed(1)}%`,
+  );
+
+  const median = MEASURED.map(([, rms]) => pct(rms)).sort((a, b) => a - b)[
+    Math.floor(MEASURED.length / 2)
+  ];
+  check(
+    "the median stem sits in the middle of the bar, not the bottom",
+    median > 40 && median < 80,
+    `${median.toFixed(1)}%`,
+  );
+}
+
+// ── 4. It still leaves headroom ─────────────────────────────────────────────
+// A scale that fixes "always empty" by always being full is no better. Normal
+// material must not sit pinned at the top, and the loudest thing a stem can be
+// must still be distinguishable from merely loud.
+{
+  check(
+    "ordinary programme material leaves room above it",
+    pct(0.1) < 80,
+    `${pct(0.1).toFixed(1)}% at -20 dBFS`,
+  );
+  check(
+    "a hot stem and a full-scale one are told apart",
+    pct(1) - pct(0.35) > 10,
+    `${pct(0.35).toFixed(1)}% vs ${pct(1).toFixed(1)}%`,
+  );
+  check(
+    "nothing normal is clipped to full",
+    pct(0.5) < 100,
+    `${pct(0.5).toFixed(1)}% at -6 dBFS`,
+  );
+}
+
+// ── 5. Quiet is still visibly quiet ─────────────────────────────────────────
+// The point is a readable meter, not a flattering one: a stem 20 dB down on
+// another has to look 20 dB down.
+{
+  const loud = pct(0.1);
+  const quiet = pct(0.01);
+  check(
+    "a stem 20 dB down reads clearly lower",
+    loud - quiet > 25,
+    `${quiet.toFixed(1)}% vs ${loud.toFixed(1)}%`,
+  );
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Transposition, per-lane and global, plus two things found on the way.

Closes #245
Closes #476
Closes #477
Closes #478

## Transpose (#245, #476)

A semitone control in the transport bar moves the whole track. One on
every mixer lane moves that instrument alone, so a harmony line can be
practised against the original melody rather than instead of it.

**Drums are never transposed**, and that is enforced in three places
because there are three ways in: the UI never offers it, the engine
ignores it if a caller asks anyway, and the worklet's unpitched input is
where drums are wired regardless. It also covers drums you cannot see.
A stem deselected at import is folded into `original.wav`, so
`playbackStems.js` rebuilds that lane from the retained raw stems and
routes its drums out. A job too old to rebuild keeps the whole lane
unpitched rather than risk resampling a kit mixed into it.

### One clock, not one shifter per lane

The obvious build does not work. WSOLA latency moves with the shift, so
independently clocked chains put lanes up to 144 ms apart:

```
pitch  0, tempo 1       0 ms   (bypass)
pitch +2, tempo 1     115 ms
pitch -5, tempo 1     144 ms
pitch  0, tempo 0.75  437 ms
```

So the worklet takes one input per semitone, each a pitch chain, summed
into a single tempo stage. A lane's key is *which input it is connected
to*, not a parameter. Measured with five chains live at once:

| | |
|---|---|
| Worst pitch error | 0.35 cents |
| Worst skew between buses | 12 ms |
| Drift over 60 s | 0.0 ms |
| Semitone 0 | bit-identical bypass |

Changing a lane mid-playback neither restarts nor flushes. Every bus is
primed with the same silence, so the old chain plays out what it
buffered while the new one takes over as it runs dry. A short duck, not
a gap.

### Absolute lane keys

A lane shows the key it is actually in, and the global control applies
its *change* rather than its value. So a lane deliberately put a third
above the rest stays a third above the rest when the track moves, and
there is never a second number to add in your head. Reset returns the
global key and every lane at once, which stepping the global back to
zero cannot do once lanes have moved individually.

### Three things the measurements changed

- An earlier revision split attacks out of the music bus and passed them
  at unity while the rest went through the pitch chain. A delayed copy
  plus an undelayed copy cannot sum back to the input: it put a 0.64
  full-scale step into the output at every onset, against a source whose
  own largest step was 0.10. Heard as static. Removed.
- The chain produced exactly one quantum per quantum with no slack, so a
  quantum occasionally came up short and was emitted zero-padded. A hard
  edge to zero mid-block is a click. Fixed with an output reserve and an
  input cushion banked during priming.
- The old alignment test reported 2 ms, but only because the attack
  splitter was passing its probe through the bypass. Real alignment was
  18 ms and one-sided, being the WSOLA sequence sawtooth. Predictable,
  so now cancelled rather than tolerated.

## Lane meters (#477)

They were linear in amplitude. Loudness is logarithmic and a separated
stem sits around -20 to -30 dBFS, so normal playback lived in the bottom
tenth of the bar. Measured median across a real library: **10.4%**, with
drums and "other" under 2%.

Now dB-scaled with a -60 dBFS floor:

| stem (median) | before | after |
|---|---|---|
| drums, quiet mix | 1.7% | 27.8% |
| other, quiet mix | 1.6% | 26.9% |
| vocals | 5.0% | 43.4% |
| bass | 34.1% | 71.1% |

This forced the meters off `getByteTimeDomainData`: its quantisation
step, one part in 128, is -42 dBFS, which on a dB scale would light
every meter to a third of full over silence.

## Windows test harness (#478)

`tests/e2e/serve.sh` is stored LF with no `.gitattributes`, so a
Windows checkout wrote it CRLF and bash could not run a single line of
it. The browser suite was unrunnable on the primary desktop development
platform, and CI never saw it because CI is Linux.

## Testing

| suite | |
|---|---|
| Browser (Playwright) | 66 pass |
| DSP | 21 pass |
| Engine routing | 43 pass |
| VU scale | 14 pass |
| Other JS suites | pass |
| i18n coverage and duplicates | clean, 9 tables plus the ptPT variant |

Two of these deserve a note. `tests/js/pitch-shift.test.mjs` includes a
control that rebuilds the worklet with the input cushion removed and
confirms the click gate *fails*, so it can actually catch the regression
it exists for. `tests/js/vu-scale.test.mjs` asserts what fraction of the
bar real measured stem levels light and keeps the old linear formula as
a control, so the comparison is a measurement rather than a claim.

## Not covered here

`tests/e2e/serve.sh` runs `uv run`, which resynced a project environment
on a GPU box, uninstalled seven packages and tried to replace a
hand-installed `torch 2.6.0+cu124` with the plain wheel. It failed
partway on a locked DLL and rolled back, so nothing was lost. Noted in
#478 as worth its own issue; not fixed here.

No Python dependencies changed, so the desktop in-app updater is
unaffected.

Before merging: the Unraid template pin in `templates/stemdeck.xml` is
still `0.15.2` and is a separate decision.
