### PR TITLE
Cover the streaming render path, which was never broken

### DIFF
--- a/tests/e2e/zoom.spec.mjs
+++ b/tests/e2e/zoom.spec.mjs
@@ -65,6 +65,27 @@ const loopBounds = (page) =>
     };
   });
 
+// Every canvas WaveSurfer has drawn, reached through the shadow roots it renders
+// into. `#multitrack-container.querySelectorAll("canvas")` returns nothing --
+// not because the streaming path draws nothing, but because querySelectorAll
+// does not cross a shadow boundary. That blind spot is the reason this path
+// looked broken and went uncovered.
+const waveSurferCanvases = (page) =>
+  page.evaluate(() => {
+    const out = [];
+    const walk = (root) => {
+      for (const el of root.querySelectorAll("*")) {
+        if (!el.shadowRoot) continue;
+        for (const c of el.shadowRoot.querySelectorAll("canvas")) {
+          out.push({ backing: c.width, css: Math.round(c.getBoundingClientRect().width) });
+        }
+        walk(el.shadowRoot);
+      }
+    };
+    walk(document.querySelector("#multitrack-container"));
+    return out;
+  });
+
 // Deliberately wide: the bar-count maths only has room to prove itself when the
 // panel can hold a few hundred bars.
 test.use({ viewport: { width: 1600, height: 900 } });
@@ -268,6 +289,54 @@ test.describe("waveform zoom", () => {
 
     expect(panned.content).toBe(zoomed.content);
     expect(panned.scrollLeft).not.toBe(zoomed.scrollLeft);
+  });
+
+  // The SVG overview is only the visible waveform when the Web Audio engine owns
+  // playback. On the streaming path WaveSurfer draws the lanes into canvases
+  // instead and gets its own zoom call, so the "bars keep their width" promise
+  // rests on a completely different mechanism there: its bars are configured in
+  // pixels (barWidth 3, barGap 2), which holds only if it re-renders rather than
+  // letting a fixed-size canvas stretch.
+  test("the streaming path re-renders its canvases instead of stretching them", async ({ page }) => {
+    await page.addInitScript(() => window.localStorage.setItem("stemdeck.audioEngine", "0"));
+    await openStudio(page, { tauri: true });
+    await page.waitForFunction(
+      () => {
+        let n = 0;
+        const walk = (root) => {
+          for (const el of root.querySelectorAll("*")) {
+            if (!el.shadowRoot) continue;
+            n += el.shadowRoot.querySelectorAll("canvas").length;
+            walk(el.shadowRoot);
+          }
+        };
+        walk(document.querySelector("#multitrack-container"));
+        return n > 0;
+      },
+      null,
+      { timeout: 20000 },
+    );
+
+    const before = await zoomState(page);
+    const canvasesBefore = await waveSurferCanvases(page);
+    expect(canvasesBefore.length).toBeGreaterThan(0);
+
+    for (let i = 0; i < 40; i++) await wheel(page, -240);
+    await page.waitForTimeout(1200);
+
+    const after = await zoomState(page);
+    const canvasesAfter = await waveSurferCanvases(page);
+    expect(after.content).toBeGreaterThan(before.content * 4);
+
+    // A canvas whose backing store matches its CSS width was drawn at that
+    // width. A stretched one keeps its original pixel width while its box grows,
+    // which is the failure the SVG path had to be fixed for.
+    for (const c of canvasesAfter) expect(c.backing).toBe(c.css);
+    // And something actually got wider, rather than the lanes being re-cut into
+    // more canvases of the same size. WaveSurfer chunks at 4000px, so the widest
+    // is the one to look at.
+    const widest = (list) => Math.max(...list.map((c) => c.backing));
+    expect(widest(canvasesAfter)).toBeGreaterThan(widest(canvasesBefore) * 2);
   });
 
   test("opening another track returns to the fitted view", async ({ page }) => {


### PR DESCRIPTION
Closes #494

I claimed in #493 that the streaming render path was reasoned about rather than
measured, because looking for its canvases found none. That claim was wrong, and
this corrects it.

## The false negative

```js
document.querySelector("#multitrack-container").querySelectorAll("canvas").length
// 0
```

Zero after eight seconds, with the loading overlay cleared, `canplay` fired, no
failed requests, and the same result against `main`. Every signal said the
streaming path renders nothing.

It renders nine canvases. **WaveSurfer draws into shadow roots**, and
`querySelectorAll` does not cross a shadow boundary. Walking the roots finds them
all, correctly sized.

That is worth more than the coverage it cost: the obvious way to look at this
path returns a convincing wrong answer, so the first person to check concludes it
is broken. The helper that walks the roots carries that warning next to it.

## What the test asserts

The zoom promise rests on a different mechanism here than on the SVG path.
WaveSurfer bars are configured in pixels (`barWidth 3`, `barGap 2`), so they keep
their width across a zoom **only if it re-renders** rather than letting a
fixed-size canvas stretch.

Backing store width against CSS width is what separates the two, and it is now
measured:

| | 1x | 5x |
|---|---|---|
| Content width | 910 px | 4550 px |
| Canvases per lane | 1 x 910 | 4000 + 550 |
| Backing == CSS | yes | yes |

WaveSurfer chunks at 4000 px, which is why a zoomed lane is two canvases rather
than one wide one. A stretched canvas would keep its 910 px backing store while
its box grew, and fails the assertion.

## Verification

12 zoom tests pass, 78 browser tests overall. No production code changed: this is
coverage for behaviour that was already correct.
