### PR TITLE
fix(macos): stop shipping AppleDouble files that break song sections, and give warmup the bundled FFmpeg

### DIFF
--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -1414,6 +1414,9 @@ fn warmup_models(state: tauri::State<BackendState>) -> Result<ModelWarmupStatus,
         .env("TORCH_HOME", data_dir.join("models").join("torch"))
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    // The vocal-split model's downloader probes for `ffmpeg` on PATH before it
+    // will load anything (#505).
+    apply_ffmpeg_path(&mut command, &data_dir)?;
 
     let child = command
         .spawn()
@@ -1566,13 +1569,7 @@ fn start_backend(
             .stdout(stdout)
             .stderr(stderr);
 
-        if let Some(ffmpeg_dir) = ffmpeg_dir_if_present(&data_dir) {
-            let existing = env::var_os("PATH").unwrap_or_default();
-            let mut paths = vec![ffmpeg_dir];
-            paths.extend(env::split_paths(&existing));
-            let joined = env::join_paths(paths).map_err(|e| e.to_string())?;
-            cmd.env("PATH", joined);
-        }
+        apply_ffmpeg_path(&mut cmd, &data_dir)?;
 
         #[cfg(windows)]
         {
@@ -3378,6 +3375,27 @@ fn resolve_existing_ffmpeg(data_dir: &Path) -> Option<PathBuf> {
 fn ffmpeg_dir_if_present(data_dir: &Path) -> Option<PathBuf> {
     let path = resolve_existing_ffmpeg(data_dir)?;
     path.parent().map(Path::to_path_buf)
+}
+
+/// Prepend the bundled FFmpeg directory to `cmd`'s PATH.
+///
+/// Every child process that may shell out to `ffmpeg`/`ffprobe` needs this, not
+/// just the backend: a Finder-launched `.app` inherits a bare
+/// `/usr/bin:/bin:/usr/sbin:/sbin`, so an FFmpeg we downloaded into the data
+/// directory is invisible to anything we spawn unless we put it there
+/// ourselves. Warmup grew its own command without this and silently lost the
+/// karaoke vocal-split model to `FileNotFoundError` (#505), so it lives in one
+/// place now.
+fn apply_ffmpeg_path(cmd: &mut Command, data_dir: &Path) -> Result<(), String> {
+    let Some(ffmpeg_dir) = ffmpeg_dir_if_present(data_dir) else {
+        return Ok(());
+    };
+    let existing = env::var_os("PATH").unwrap_or_default();
+    let mut paths = vec![ffmpeg_dir];
+    paths.extend(env::split_paths(&existing));
+    let joined = env::join_paths(paths).map_err(|e| e.to_string())?;
+    cmd.env("PATH", joined);
+    Ok(())
 }
 
 /// Claim `host:port` without serving on it, and report the port that was

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -3172,6 +3172,47 @@ fn sha256_file(path: &Path) -> Result<String, String> {
     Ok(format!("{:x}", hasher.finalize()))
 }
 
+/// True for AppleDouble sidecars -- the `._name` files macOS `tar` emits to
+/// carry a file's extended attributes (#505).
+///
+/// The runtime pack is built on macOS, where `ditto` preserves xattrs and `tar`
+/// may encode them as these sidecar members. This crate has no AppleDouble
+/// support, so unpacking them writes 30k binary stubs into `site-packages` --
+/// and `matplotlib`'s `*.mplstyle` glob then matches `._seaborn-v0_8-bright
+/// .mplstyle` and dies decoding its header, which takes down `matplotlib
+/// .pyplot`, `allin1_infer`, and automatic song sections with it.
+///
+/// The pack script strips them at build time and fails if any survive, so this
+/// exists for the packs already published without that guard.
+fn is_apple_double(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.starts_with("._"))
+}
+
+fn unpack_without_apple_double<R: Read>(
+    mut archive: Archive<R>,
+    destination: &Path,
+) -> Result<(), String> {
+    let entries = archive
+        .entries()
+        .map_err(|e| format!("failed to read runtime pack: {e}"))?;
+    for entry in entries {
+        let mut entry = entry.map_err(|e| format!("failed to read runtime pack: {e}"))?;
+        let path = entry
+            .path()
+            .map_err(|e| format!("failed to read runtime pack: {e}"))?
+            .into_owned();
+        if is_apple_double(&path) {
+            continue;
+        }
+        entry
+            .unpack_in(destination)
+            .map_err(|e| format!("failed to extract runtime pack: {e}"))?;
+    }
+    Ok(())
+}
+
 fn extract_tar_archive(archive: &Path, destination: &Path) -> Result<(), String> {
     let file = fs::File::open(archive)
         .map_err(|e| format!("failed to open archive {}: {e}", archive.display()))?;
@@ -3181,14 +3222,10 @@ fn extract_tar_archive(archive: &Path, destination: &Path) -> Result<(), String>
     if is_zst {
         let decoder =
             zstd::Decoder::new(file).map_err(|e| format!("failed to init zstd decoder: {e}"))?;
-        Archive::new(decoder)
-            .unpack(destination)
-            .map_err(|e| format!("failed to extract runtime pack: {e}"))
+        unpack_without_apple_double(Archive::new(decoder), destination)
     } else {
         let decoder = GzDecoder::new(file);
-        Archive::new(decoder)
-            .unpack(destination)
-            .map_err(|e| format!("failed to extract runtime pack: {e}"))
+        unpack_without_apple_double(Archive::new(decoder), destination)
     }
 }
 
@@ -4374,6 +4411,52 @@ mod tests {
 
     fn make_tmp() -> TempDir {
         tempfile::tempdir().expect("failed to create temp dir")
+    }
+
+    #[test]
+    fn extract_tar_archive_drops_apple_double_sidecars() {
+        // A macOS-built runtime pack can carry `._name` AppleDouble members
+        // alongside the real files. Unpacked verbatim, the one beside
+        // matplotlib's stylelib matches its `*.mplstyle` glob and kills every
+        // import of matplotlib.pyplot -- and with it automatic song sections
+        // (#505).
+        let source = make_tmp();
+        let stylelib = source.path().join("runtime/stylelib");
+        fs::create_dir_all(&stylelib).unwrap();
+        fs::write(
+            stylelib.join("seaborn-v0_8-bright.mplstyle"),
+            b"axes.grid: True",
+        )
+        .unwrap();
+        fs::write(
+            stylelib.join("._seaborn-v0_8-bright.mplstyle"),
+            b"\x00\x05\x16\x07\xa3binary AppleDouble header",
+        )
+        .unwrap();
+
+        // Must be .tar.zst: that is the shape the macOS runtime pack ships in,
+        // and the only one extract_tar_archive routes away from gzip.
+        let archive_dir = make_tmp();
+        let archive = archive_dir.path().join("runtime.tar.zst");
+        let encoder = zstd::Encoder::new(fs::File::create(&archive).unwrap(), 0).unwrap();
+        let mut builder = tar::Builder::new(encoder);
+        builder
+            .append_dir_all("runtime", source.path().join("runtime"))
+            .unwrap();
+        builder.into_inner().unwrap().finish().unwrap();
+
+        let destination = make_tmp();
+        super::extract_tar_archive(&archive, destination.path()).unwrap();
+
+        let unpacked = destination.path().join("runtime/stylelib");
+        assert!(
+            unpacked.join("seaborn-v0_8-bright.mplstyle").is_file(),
+            "real files must still be extracted"
+        );
+        assert!(
+            !unpacked.join("._seaborn-v0_8-bright.mplstyle").exists(),
+            "AppleDouble sidecar must not be written to disk"
+        );
     }
 
     #[test]

--- a/scripts/macos/make-runtime-pack.sh
+++ b/scripts/macos/make-runtime-pack.sh
@@ -214,6 +214,20 @@ echo "==> Stripping Python caches"
 find "$PYTHON_DIR" -type d -name "__pycache__" -prune -exec rm -rf {} + 2>/dev/null || true
 find "$PYTHON_DIR" -type f \( -name "*.pyc" -o -name "*.pyo" \) -delete
 
+# The ditto above preserves extended attributes on every copied file (#505).
+# macOS tar then serializes those xattrs as AppleDouble "._name" members, and
+# the Rust tar crate that unpacks this archive on the user's machine knows
+# nothing about AppleDouble, so it writes them out as literal files. One of
+# them lands in matplotlib's style directory, where the "*.mplstyle" glob picks
+# it up and chokes on the binary header -- taking down every import of
+# matplotlib.pyplot, and with it allin1_infer and automatic song sections.
+# Strip the xattrs, delete any sidecars already on disk, and tell tar not to
+# regenerate them.
+echo "==> Stripping extended attributes and AppleDouble sidecars"
+xattr -cr "$STAGING" 2>/dev/null || true
+find "$STAGING" -name "._*" -delete
+
+export COPYFILE_DISABLE=1
 ARCHIVE_NAME="StemDeck-runtime-macOS-${ARCH}.tar.zst"
 ARCHIVE_PATH="${BUILD_DIR}/${ARCHIVE_NAME}"
 if command -v zstd >/dev/null 2>&1; then
@@ -222,6 +236,38 @@ else
   ARCHIVE_NAME="StemDeck-runtime-macOS-${ARCH}.tar.gz"
   ARCHIVE_PATH="${BUILD_DIR}/${ARCHIVE_NAME}"
   tar -czf "$ARCHIVE_PATH" -C "$STAGING" runtime
+fi
+
+# The three guards above are all environment-dependent -- whether macOS tar
+# emits AppleDouble members at all varies by OS version -- so verify the actual
+# archive rather than trusting them. A pack that ships even one sidecar is a
+# broken pack.
+#
+# `tar -tf` cannot do this audit: macOS tar folds "._name" members back into
+# their sibling's metadata while listing, exactly as it does while creating, so
+# it reports a clean archive whether or not one is clean. Stream the members
+# through Python's tarfile instead, which has no AppleDouble handling at all.
+echo "==> Verifying archive carries no AppleDouble entries"
+if [[ "$ARCHIVE_PATH" == *.zst ]]; then
+  DECOMPRESS=(zstd -dc "$ARCHIVE_PATH")
+else
+  DECOMPRESS=(gzip -dc "$ARCHIVE_PATH")
+fi
+APPLE_DOUBLE="$("${DECOMPRESS[@]}" | "$PYTHON_BIN" -c '
+import posixpath, sys, tarfile
+
+found = [
+  member.name
+  for member in tarfile.open(fileobj=sys.stdin.buffer, mode="r|")
+  if posixpath.basename(member.name).startswith("._")
+]
+print("\n".join(found[:5]))
+print(f"({len(found)} total)" if found else "", end="")
+')"
+if [[ -n "$APPLE_DOUBLE" ]]; then
+  echo "ERROR: archive contains AppleDouble ._ entries (see #505)" >&2
+  echo "$APPLE_DOUBLE" >&2
+  exit 1
 fi
 
 SIZE="$(stat -f%z "$ARCHIVE_PATH")"

--- a/templates/stemdeck.xml
+++ b/templates/stemdeck.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>StemDeck</Name>
-  <Repository>ghcr.io/stemdeckapp/stemdeck:0.15.2</Repository>
+  <Repository>ghcr.io/stemdeckapp/stemdeck:0.16.0</Repository>
   <Registry>https://github.com/stemdeckapp/stemdeck/pkgs/container/stemdeck</Registry>
   <Network>bridge</Network>
   <Shell>sh</Shell>


### PR DESCRIPTION
Fixes #505.

Two macOS desktop defects, both surfacing as warmup failures in `setup.log`. The first one is not really a warmup problem.

## 1. AppleDouble sidecars break automatic song sections

`make-runtime-pack.sh` copies Python with `ditto`, which preserves extended attributes on every file, then tars the staging tree without disabling copyfile. macOS tar serializes those xattrs as AppleDouble `._name` members, and the Rust tar crate that unpacks the pack on the user's machine has no AppleDouble support, so it writes them out as literal files. A 0.16.0 install carries 30,239 of them.

One lands in matplotlib's style directory. matplotlib globs `*.mplstyle` at import time, matches `._seaborn-v0_8-bright.mplstyle`, and dies on byte 45 of the AppleDouble header:

```
matplotlib/style/__init__.py:209  styles[path.stem] = rc_params_from_file(path, ...)
matplotlib/__init__.py:902        for line_no, line in enumerate(fd, 1)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa3 in position 45: invalid start byte
```

matplotlib logs `Cannot decode configuration file ... as utf-8.` and re-raises, so `import matplotlib.pyplot` fails, which fails `allin1_infer/__init__.py -> .analyze -> .visualize`, which fails every importer of `allin1_infer`.

**That includes `app/pipeline/section_worker.py`.** Automatic song section detection was broken outright on macOS 0.16.0, not merely un-prewarmed. Linux and Docker are unaffected: this is a macOS archive artifact.

Fixed on both ends:

- **Build:** strip xattrs and any sidecars from the staging tree, and set `COPYFILE_DISABLE=1` before tarring.
- **Runtime:** `extract_tar_archive` skips `._` entries, so the packs already published are handled without waiting for a rebuild.

The pack script also verifies the finished archive and fails the build if a sidecar survives. That check deliberately does **not** use `tar -tf`: macOS tar folds `._name` members back into their sibling's metadata while listing exactly as it does while creating, so it reports a clean archive whether or not one is clean. It streams members through Python's `tarfile` instead, which has no AppleDouble handling.

## 2. Warmup did not put the bundled FFmpeg on PATH

`warmup_models` built its Python command without the PATH block `start_backend` has, so the FFmpeg we downloaded into the data directory was invisible to it. A Finder-launched `.app` inherits a bare `/usr/bin:/bin:/usr/sbin:/sbin`, and `audio_separator` probes for `ffmpeg` before loading anything:

```
WARMUP_FAILED vocal_split [Errno 2] No such file or directory: 'ffmpeg'
```

Smaller blast radius: the real backend does get the right PATH, so the on-demand karaoke split still worked, it just paid the model download mid-job. Recurring on every launch in `setup.log` since timestamp 1787336901.

The two spawn sites had drifted because each carried its own copy of the PATH logic, so it is extracted into `apply_ffmpeg_path` and called from both.

## Verification

- Reproduced both failures against the real installed 0.16.0 runtime, the second under `env -i PATH=/usr/bin:/bin:/usr/sbin:/sbin` to mimic a Finder launch.
- Deleting the sidecars from the installed runtime makes `allin1_infer` and the full `section_worker` import set succeed; adding the FFmpeg dir to PATH makes `Separator` construct.
- New regression test `extract_tar_archive_drops_apple_double_sidecars` builds a `.tar.zst` containing a sidecar and asserts it is dropped while the real file is kept. Confirmed it fails without the fix.
- `cargo test` 58 passed, `cargo fmt --check` and `cargo clippy` clean.
- Exercised the pack script's strip-and-verify logic on a synthetic staging tree in both directions: clean archive passes, archive with nested and top-level sidecars is caught.

## Note for the release

The `extract_tar_archive` guard only runs on a fresh runtime install. Anyone already on 0.16.0 keeps their 30k sidecars until the runtime is re-fetched, so this needs a runtime version bump to reach existing macOS installs.
