### PR TITLE
ci: stop fork pull requests running on the self-hosted runners

### DIFF
--- a/.github/workflows/macos-check.yml
+++ b/.github/workflows/macos-check.yml
@@ -26,6 +26,20 @@ concurrency:
 
 jobs:
   check:
+    # Never run a fork's code on the self-hosted runner. cargo build/clippy/test
+    # all execute whatever the PR supplies -- build.rs, proc-macro crates, a
+    # swapped Cargo.toml dependency, the test bodies themselves -- and this
+    # runner is the same machine that builds, signs and uploads every macOS
+    # release. Nothing here cleans the workspace, so an implant in ~/.cargo,
+    # ~/.rustup or the persistent _work tree would survive into the next
+    # release. permissions: {} limits the token, not code execution.
+    #
+    # GitHub's public-repo default only gates *first-time* contributors, so one
+    # trivial merged PR is enough to unlock this for a later one. Fork PRs get a
+    # maintainer-triggered workflow_dispatch run instead.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     # Runner must be darwin/arm64 with Xcode CLT and rustup (same requirements
     # as macos-release.yml, which this intentionally does not replace -- this
     # only builds/checks, never signs, packages, or uploads anything).

--- a/.github/workflows/windows-check.yml
+++ b/.github/workflows/windows-check.yml
@@ -27,6 +27,15 @@ concurrency:
 
 jobs:
   check:
+    # Never run a fork's code on the self-hosted runner -- see the same guard in
+    # macos-check.yml. cargo build/clippy/test execute whatever the PR supplies
+    # (build.rs, proc-macro crates, a swapped Cargo.toml dependency, the test
+    # bodies), nothing here cleans the workspace, and this runner also builds
+    # the Windows release. Fork PRs get a maintainer-triggered
+    # workflow_dispatch run instead.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     # Runner must have rustup and the MSVC toolchain (same requirements as
     # windows-release.yml, which this intentionally does not replace -- this
     # only builds/checks, never packages or uploads anything).


### PR DESCRIPTION
Fixes #511.

`macos-check.yml` and `windows-check.yml` trigger on `pull_request` and run on `[self-hosted, macOS, ARM64]` / `[self-hosted, windows, x64]` with no fork guard, on a public repository.

`cargo fmt`, `cargo build` and `cargo clippy` all execute code the PR supplies: `build.rs`, proc-macro crates, a swapped `Cargo.toml` dependency or `[patch]`, and the test bodies. `permissions: {}` limits the token, not code execution.

That runner is the same machine that builds, signs and uploads every macOS DMG and runtime pack. Neither check workflow cleans its workspace, and the release workflows only `rm -rf .build dist` -- so an implant in `~/.cargo`, `~/.npm`, `~/.rustup` or the persistent `_work` tree survives into the next release. GitHub's public-repo default only gates *first-time* contributors, so one trivial merged PR unlocks this for a later one.

## Change

Both jobs gain:

```yaml
if: >-
  github.event_name != 'pull_request' ||
  github.event.pull_request.head.repo.full_name == github.repository
```

## Why not move to GitHub-hosted runners

That would lose the reason the trigger exists. `ci.yml` is entirely `ubuntu-latest`, and a Linux runner cannot type-check code behind `#[cfg(target_os = "macos")]` or `#[cfg(windows)]` at all -- it is stripped before semantic analysis. #421 added ~600 lines of mostly cfg-gated Rust and every CI check passed without compiling any of it.

`workflow_dispatch` is unaffected, so a fork's Rust change can still get a real compiler pass when a maintainer triggers one.

## Verification

Both files parse and the guard resolves as intended:

```
macos-check.yml   if: github.event_name != 'pull_request' || ...head.repo.full_name == github.repository
windows-check.yml if: github.event_name != 'pull_request' || ...head.repo.full_name == github.repository
```

Behaviour: `workflow_dispatch` runs (first clause), same-repo PRs run (second clause), fork PRs are skipped.

Worth pairing later with a workspace clean at the start of the release workflows, so a compromised check run cannot persist into a build. Not done here to keep this change minimal.
