### PR TITLE
fix(setup): drain child pipes while the child runs, not after it exits

### DIFF
--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -4410,34 +4410,65 @@ fn update_setup_config<const N: usize>(
 /// Polls an already-spawned child until it exits or the timeout elapses.
 /// Mirrors command_output_with_timeout but accepts a pre-spawned Child so the
 /// caller can record the PID before waiting (e.g. to kill on window close).
+/// Wait for `child`, draining its pipes while it runs.
+///
+/// The draining is the point. Reading only after `try_wait()` reports an exit
+/// deadlocks any child that outruns the OS pipe buffer: it blocks in `write()`
+/// with nobody reading, so it never exits, so `try_wait()` never reports an
+/// exit, and the whole thing ends at the timeout instead. `warmup_models`
+/// pipes both streams and its model downloads emit tqdm progress to stderr in
+/// proportion to how long they take -- so the failure lands on slow
+/// connections, the users warmup exists to help (#516).
+///
+/// Each stream gets its own thread because both must drain concurrently;
+/// draining one and then the other reintroduces the deadlock on whichever is
+/// second.
 fn child_output_with_timeout(
     mut child: Child,
     timeout: Duration,
     label: &str,
 ) -> Result<Output, String> {
+    let stdout_reader = child.stdout.take().map(|mut pipe| {
+        thread::spawn(move || {
+            let mut buf = Vec::new();
+            let _ = pipe.read_to_end(&mut buf);
+            buf
+        })
+    });
+    let stderr_reader = child.stderr.take().map(|mut pipe| {
+        thread::spawn(move || {
+            let mut buf = Vec::new();
+            let _ = pipe.read_to_end(&mut buf);
+            buf
+        })
+    });
+
+    let collect = |reader: Option<thread::JoinHandle<Vec<u8>>>| {
+        reader.and_then(|h| h.join().ok()).unwrap_or_default()
+    };
+
     let deadline = Instant::now() + timeout;
     loop {
         if let Some(status) = child
             .try_wait()
             .map_err(|e| format!("failed to wait for {label}: {e}"))?
         {
-            let mut stdout = Vec::new();
-            if let Some(mut pipe) = child.stdout.take() {
-                let _ = pipe.read_to_end(&mut stdout);
-            }
-            let mut stderr = Vec::new();
-            if let Some(mut pipe) = child.stderr.take() {
-                let _ = pipe.read_to_end(&mut stderr);
-            }
+            // The child is gone, so both pipes are at EOF and these joins
+            // return promptly.
             return Ok(Output {
                 status,
-                stdout,
-                stderr,
+                stdout: collect(stdout_reader),
+                stderr: collect(stderr_reader),
             });
         }
         if Instant::now() >= deadline {
             let _ = child.kill();
             let _ = child.wait();
+            // Joined rather than detached: killing the child closes its ends,
+            // so the readers finish, and dropping the handles without joining
+            // would leak two threads per timeout.
+            let _ = collect(stdout_reader);
+            let _ = collect(stderr_reader);
             return Err(format!(
                 "{label} timed out after {} seconds",
                 timeout.as_secs()
@@ -4452,44 +4483,12 @@ fn command_output_with_timeout(
     timeout: Duration,
     label: &str,
 ) -> Result<Output, String> {
-    let mut child = command
+    let child = command
         .spawn()
         .map_err(|e| format!("failed to start {label}: {e}"))?;
-    let deadline = Instant::now() + timeout;
-
-    loop {
-        if let Some(status) = child
-            .try_wait()
-            .map_err(|e| format!("failed to wait for {label}: {e}"))?
-        {
-            let mut stdout = Vec::new();
-            if let Some(mut pipe) = child.stdout.take() {
-                let _ = pipe.read_to_end(&mut stdout);
-            }
-
-            let mut stderr = Vec::new();
-            if let Some(mut pipe) = child.stderr.take() {
-                let _ = pipe.read_to_end(&mut stderr);
-            }
-
-            return Ok(Output {
-                status,
-                stdout,
-                stderr,
-            });
-        }
-
-        if Instant::now() >= deadline {
-            let _ = child.kill();
-            let _ = child.wait();
-            return Err(format!(
-                "{label} timed out after {} seconds",
-                timeout.as_secs()
-            ));
-        }
-
-        thread::sleep(Duration::from_millis(100));
-    }
+    // Same pipe-draining requirement as child_output_with_timeout; sharing it
+    // keeps the two from drifting apart again (#516).
+    child_output_with_timeout(child, timeout, label)
 }
 
 #[cfg(windows)]
@@ -4647,6 +4646,44 @@ mod tests {
                 "should reject {bad}"
             );
         }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_chatty_child_is_drained_rather_than_deadlocked() {
+        // Reading the pipes only after try_wait() reports an exit deadlocks any
+        // child that outruns the OS pipe buffer (64 KiB on Linux, smaller on
+        // macOS): it blocks in write() with nobody reading, so it never exits.
+        // warmup_models pipes both streams and its downloads emit tqdm progress
+        // to stderr in proportion to how long they take, so the old code failed
+        // for users on slow connections after burning the full 30-minute
+        // timeout (#516).
+        //
+        // 512 KiB on each stream is comfortably past any pipe buffer. A short
+        // timeout keeps the failure mode obvious: without concurrent draining
+        // this returns Err(timed out) instead of the output.
+        let mut command = Command::new("sh");
+        command
+            .arg("-c")
+            .arg("yes stdoutstdoutstdout | head -c 524288; yes errerrerr | head -c 524288 >&2")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let output =
+            super::command_output_with_timeout(command, Duration::from_secs(20), "chatty child")
+                .expect("a child that fills its pipes must still be collected");
+
+        assert!(output.status.success());
+        assert_eq!(
+            output.stdout.len(),
+            524_288,
+            "stdout must be drained in full"
+        );
+        assert_eq!(
+            output.stderr.len(),
+            524_288,
+            "stderr must be drained in full"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #516. **Targets `fix/510-updater-url-allowlist`** -- both touch `main.rs` and the plan sequences the Rust changes. Merge #528 first.

## The problem

`child_output_with_timeout` read the pipes only after `try_wait()` reported an exit:

```rust
loop {
    if let Some(status) = child.try_wait()? {
        // read_to_end on stdout/stderr -- only reachable once the child is gone
    }
    thread::sleep(Duration::from_millis(100));
}
```

A child that outruns the OS pipe buffer blocks in `write()` with nobody reading, so it never exits, so `try_wait()` never reports an exit. The call ends at the timeout with no output.

`warmup_models` pipes both streams (`main.rs:1414-1415`) and its model downloads emit tqdm progress to stderr in proportion to how **long** they take, not how large they are. The failure therefore lands on slow connections -- exactly the users warmup exists to spare a mid-pipeline download.

## Change

Each stream drains on its own thread. Both are required: draining one then the other reintroduces the deadlock on whichever is second. Readers are joined rather than detached on the timeout path, since killing the child closes its ends and dropping the handles would leak two threads per timeout.

`command_output_with_timeout` had the identical shape and now delegates, so the two cannot drift apart again.

## Verification -- the deadlock is reproduced, not assumed

New test `a_chatty_child_is_drained_rather_than_deadlocked` writes 512 KiB to each stream.

| implementation | result |
|---|---|
| read-after-exit (old) | **FAILED** -- `"chatty child timed out after 20 seconds"`, took 20.09s |
| concurrent draining (this PR) | passed in 0.11s |

Worth recording: when I filed #516 I measured a real cold-cache warmup on a fast connection and found only **8,360 bytes** of stderr -- under the buffer. That is why this had not been hit in practice, not why it could not happen. The test settles it.

```
cargo fmt --check   OK
cargo clippy        0 errors
cargo test          59 passed, 1 failed
```

The 1 failure is `tests::a_free_port_is_granted_as_asked`, the known parallel-execution flake, failing 3/3 on the base branch without this change.

## One thing to check in review

While rewriting `command_output_with_timeout` I initially sliced out the `#[cfg(windows)]` attribute above `hide_console_window`, which `cargo check` caught immediately. Restored, and both `hide_console_window` definitions keep their cfg guards -- worth a glance since a Linux/macOS-only compile would not exercise the Windows one.
