### PR TITLE
Compile the Linux shell, and keep compiling it

### DIFF
--- a/.github/workflows/linux-check.yml
+++ b/.github/workflows/linux-check.yml
@@ -1,0 +1,72 @@
+name: Linux Rust Check
+
+# ci.yml runs on every PR and is entirely ubuntu-latest, which made Linux look
+# covered. It is not: ci.yml never invokes cargo. Linux Rust was compiled only
+# by linux-release.yml, on release publish, so a Linux-only cfg block first met
+# a compiler after the tag existed and after the other platforms had begun
+# uploading assets (#531).
+#
+# That is not hypothetical. #518 added a call inside
+# #[cfg(all(unix, not(target_os = "macos")))] to a function gated
+# #[cfg(target_os = "macos")]. It was reviewed, merged and released to main
+# without compiling once (#550).
+#
+# Unlike macos-check.yml and windows-check.yml, this needs no self-hosted
+# runner, so there is no cost argument for making it manual. It runs on every
+# PR that touches the Rust.
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "desktop/src-tauri/**"
+      - ".github/workflows/linux-check.yml"
+  push:
+    branches: [main]
+    paths:
+      - "desktop/src-tauri/**"
+      - ".github/workflows/linux-check.yml"
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    # GitHub-hosted and disposable, so a fork's build.rs or test body runs in a
+    # container that is thrown away and holds no signing material. The fork
+    # guard the other two check workflows carry exists because those run on the
+    # machine that builds releases; it would buy nothing here.
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: desktop/src-tauri
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      # The same set scripts/linux/make-portable.sh needs to build the shell.
+      # Without them the glib/gtk/webkit sys crates fail in their build scripts,
+      # which is also why this cannot be cross-compiled from another platform.
+      - name: Install Tauri system dependencies
+        working-directory: .
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
+      - name: cargo fmt --check
+        run: cargo fmt --check
+
+      - name: cargo build
+        run: cargo build --tests
+
+      - name: cargo clippy
+        run: cargo clippy --tests -- -D warnings
+
+      - name: cargo test
+        run: cargo test

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -3910,7 +3910,12 @@ fn override_sha256(env_var: &str) -> Option<String> {
 // Verify a freshly downloaded archive against an expected SHA256 before it is
 // extracted or made executable (#172). On mismatch the file is removed so a
 // corrupt or tampered binary is never run. `None` means no hash to enforce.
-#[cfg(target_os = "macos")]
+//
+// Unix rather than macOS: the Linux FFmpeg download calls this too (#518).
+// While the gate said macOS the Linux caller referred to a function that was
+// configured out, and nothing noticed because nothing compiles the Linux shell
+// until a release builds it (#531).
+#[cfg(unix)]
 fn verify_pinned_sha256(path: &Path, expected: Option<&str>, label: &str) -> Result<(), String> {
     let Some(expected) = expected else {
         return Ok(());
@@ -5152,9 +5157,9 @@ mod tests {
         }
     }
 
-    // --- macOS FFmpeg checksum verification (#172) ---
+    // --- FFmpeg checksum verification (#172), macOS and Linux ---
 
-    #[cfg(target_os = "macos")]
+    #[cfg(unix)]
     #[test]
     fn verify_pinned_sha256_accepts_matching_hash() {
         let dir = make_tmp();
@@ -5166,7 +5171,7 @@ mod tests {
         assert!(f.exists(), "a valid download must be kept");
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(unix)]
     #[test]
     fn verify_pinned_sha256_rejects_and_removes_on_mismatch() {
         let dir = make_tmp();
@@ -5177,7 +5182,7 @@ mod tests {
         assert!(!f.exists(), "a tampered/corrupt download must be removed");
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(unix)]
     #[test]
     fn verify_pinned_sha256_none_skips() {
         let dir = make_tmp();


### PR DESCRIPTION
Closes #550
Closes #531

`cargo check` has been failing on Linux on `main`. Found by building the shell in WSL against the real cfg gates.

## The break

```
error[E0425]: cannot find function `verify_pinned_sha256` in this scope
    --> src/main.rs:3838:9
note: found an item that was configured out
    --> src/main.rs:3914:4
     | #[cfg(target_os = "macos")]
```

`download_linux_ffmpeg` verifies its download against a pinned SHA256, which is the whole point of #518. The function it calls was macOS-gated, so on Linux the call referred to something that did not exist.

The Linux release build would have failed **after the tag existed**, and after the macOS and Windows jobs may already have uploaded their assets, because `linux-release.yml` is the only thing that compiles this code.

The gate belongs on `unix`. Both callers are Unix, Windows takes a different path, and widening further would only add a dead-code warning there.

## The tests were dark too

The three `verify_pinned_sha256` tests were `#[cfg(target_os = "macos")]` as well, so Linux depended on a function it had never once tested. They move with it.

The Linux suite goes from 57 to 63. Three of those six are these.

## Keeping it compiled

Fixing the gate alone leaves the hole open, which is #531. Whatever lands next inside a Linux cfg block has the same nothing waiting to catch it.

`linux-check.yml` mirrors the other two check workflows with one deliberate difference: it runs on **every PR** that touches `desktop/src-tauri`, not on manual dispatch. `macos-check.yml` and `windows-check.yml` are manual because they occupy the self-hosted machine that builds releases. This one is GitHub-hosted and disposable, so there is no cost argument, and no reason for the fork guard the other two carry either.

It installs the same GTK and WebKit packages `scripts/linux/make-portable.sh` needs, then runs `cargo fmt --check`, `cargo build --tests`, `cargo clippy --tests -- -D warnings` and `cargo test`.

`ci.yml` running entirely on `ubuntu-latest` is what made Linux look covered. It never invokes cargo.

## Verification

Ubuntu 24.04, WSL:

```
cargo fmt --check                        clean
cargo clippy --all-targets -- -D warnings  clean
cargo test                               63 passed
```

Windows, unchanged by the gate move:

```
cargo clippy --all-targets  clean
cargo test                  57 passed
```

No clippy allowances were needed on Linux. Unlike the Windows check's first run, this target came up clean.

## Note on 0.16.1

This is not in the 0.16.1 merge that just landed on `main`. Tagging before this lands means the Linux release build fails.