### PR TITLE
Pin the Unraid template to 0.16.1

### DIFF
--- a/templates/stemdeck.xml
+++ b/templates/stemdeck.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>StemDeck</Name>
-  <Repository>ghcr.io/stemdeckapp/stemdeck:0.16.0</Repository>
+  <Repository>ghcr.io/stemdeckapp/stemdeck:0.16.1</Repository>
   <Registry>https://github.com/stemdeckapp/stemdeck/pkgs/container/stemdeck</Registry>
   <Network>bridge</Network>
   <Shell>sh</Shell>


### PR DESCRIPTION
Closes #553

One line. `templates/stemdeck.xml` pins an exact image and Unraid users pull exactly that, so while it said `0.16.0` a Community Applications install got 0.16.0 and an existing one was never offered anything newer.

```diff
-  <Repository>ghcr.io/stemdeckapp/stemdeck:0.16.0</Repository>
+  <Repository>ghcr.io/stemdeckapp/stemdeck:0.16.1</Repository>
```

The tag exists. `Docker Publish` ran on the release and pushed `ghcr.io/stemdeckapp/stemdeck:0.16.1` and `:latest`, and v0.16.1 is promoted, so this points at a published image rather than one still building.

That ordering is the point. Bumping this at merge time would have pointed the template at a tag nobody had pushed, and a template that fails to pull is worse than one a release behind.

Nothing else in the file changes. The template tracks the latest published release and only the `<Repository>` line carries the version.