### PR TITLE
Pin the Unraid template to 0.17.1

### DIFF
--- a/templates/stemdeck.xml
+++ b/templates/stemdeck.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>StemDeck</Name>
-  <Repository>ghcr.io/stemdeckapp/stemdeck:0.16.1</Repository>
+  <Repository>ghcr.io/stemdeckapp/stemdeck:0.17.1</Repository>
   <Registry>https://github.com/stemdeckapp/stemdeck/pkgs/container/stemdeck</Registry>
   <Network>bridge</Network>
   <Shell>sh</Shell>


### PR DESCRIPTION
Closes #597

Unraid pulls exactly the tag in `<Repository>`, so the template was still installing **0.16.1** while 0.17.0 is the current Latest. Everything shipped since 0.16.1 has been invisible on that platform.

One line changed. I checked there are no other `0.16.1` references in the file and that it still parses as XML.

## Do not merge this before v0.17.1 is published

`v0.17.1` is currently a **draft** (`published: null`). The image is built by `docker-publish.yml` on the release `published` event, so `ghcr.io/stemdeckapp/stemdeck:0.17.1` **does not exist yet**.

Merging this first would point every Unraid install at a tag that 404s, which is worse than being a version behind. The order has to be: publish the release, confirm the image is in GHCR, then merge this.

I could not verify the image directly from here -- an anonymous GHCR manifest probe 404s even for `0.16.1`, the tag currently pinned and known good, so the probe is unreliable rather than informative. Worth a manual check against the package listing before merging.