### PR TITLE
Keep audio alive in a hidden tab, and stop trusting downloads that never finished

### DIFF
--- a/app/core/model_cache.py
+++ b/app/core/model_cache.py
@@ -34,6 +34,11 @@ from typing import TypeVar
 
 logger = logging.getLogger("stemdeck.modelcache")
 
+# Artifacts already discarded once in this process. Healing is for a file that
+# arrived damaged, which a single re-fetch settles either way; repeating it
+# turns a permanently failing load into a ~100 MB download on every attempt.
+_healed: set[Path] = set()
+
 T = TypeVar("T")
 
 
@@ -74,10 +79,20 @@ def load_or_heal(load: Callable[[], T], stale: Callable[[], Iterable[Path]]) -> 
         raise
     except Exception as first:
         try:
-            removed = [p for p in stale() if _remove(p)]
+            paths = list(stale())
         except Exception:
             logger.warning("could not resolve model cache paths", exc_info=True)
             raise first from None
+        # Once per artifact per process. beat_this collapses every failure into
+        # one ValueError, so a load that is broken for some reason a fresh copy
+        # cannot fix looks exactly like a truncated one, and without this it
+        # would delete and re-fetch ~100 MB on every attempt for as long as the
+        # process lives.
+        fresh = [p for p in paths if p not in _healed]
+        if not fresh:
+            raise
+        removed = [p for p in fresh if _remove(p)]
+        _healed.update(fresh)
         if not removed:
             raise
         logger.warning(
@@ -102,11 +117,18 @@ def beat_this_artifacts(checkpoint: str) -> list[Path]:
 
 
 def vocal_split_artifacts(models_dir: Path, model_file: str) -> list[Path]:
-    """The audio-separator model file, and the metadata index that names it.
+    """The audio-separator model file, and the metadata indexes that name it.
 
-    The index is listed too because audio-separator reports a truncated model
-    as an unknown MD5, which is a lookup against that index rather than against
-    the file itself.
+    The indexes are listed too because audio-separator reports a truncated
+    model as an unknown MD5, and that is a lookup against them rather than
+    against the file itself. There are two, one per architecture family, and
+    they are the names audio-separator actually writes: a single
+    "model_data.json" is not one of them, so listing that instead heals the
+    checkpoint and leaves the index that produced the error in place.
     """
     root = models_dir / "audio-separator"
-    return [root / model_file, root / "model_data.json"]
+    return [
+        root / model_file,
+        root / "vr_model_data.json",
+        root / "mdx_model_data.json",
+    ]

--- a/app/core/model_cache.py
+++ b/app/core/model_cache.py
@@ -1,0 +1,112 @@
+"""Recovery for model checkpoints that were cached incompletely.
+
+Both model loaders StemDeck depends on treat a cached file's *existence* as
+proof that it is usable, and neither checks that what landed is what was sent.
+
+torch.hub, which is what beat_this loads through::
+
+    if not os.path.exists(cached_file):
+        download_url_to_file(url, cached_file, hash_prefix, progress=progress)
+
+and `download_url_to_file` reads until the body ends, then moves the result
+into place with no comparison against Content-Length. `check_hash` defaults to
+False and beat_this does not pass it. audio-separator has the same shape, which
+is why a bad file there surfaces as an MD5 that matches nothing.
+
+So a connection that drops mid-body and closes cleanly is promoted to a
+complete checkpoint, and every later run finds the file present and stops
+there. The failure never heals on its own, and it is silent: beat detection
+falls back to librosa (see app/pipeline/beat_detect.py) and the karaoke split
+just reports itself unavailable. A user gets a permanently worse beat grid and
+no reason to suspect why (#502).
+
+The fix is to stop trusting existence. If a load fails and there was a cached
+artifact to blame, remove it and try once.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from collections.abc import Callable, Iterable
+from pathlib import Path
+from typing import TypeVar
+
+logger = logging.getLogger("stemdeck.modelcache")
+
+T = TypeVar("T")
+
+
+def _remove(path: Path) -> bool:
+    """Delete one cached artifact. True if something was actually removed."""
+    try:
+        if path.is_dir():
+            shutil.rmtree(path, ignore_errors=True)
+            return not path.exists()
+        if path.exists():
+            path.unlink()
+            return True
+    except OSError:
+        # A file held open by another process, or a read-only cache dir. Not
+        # worth failing the load over: the caller's own error is the real one.
+        logger.warning("could not remove cached model artifact %s", path, exc_info=True)
+    return False
+
+
+def load_or_heal(load: Callable[[], T], stale: Callable[[], Iterable[Path]]) -> T:
+    """Call ``load``; on failure drop the cached artifacts and call it once more.
+
+    ``stale`` is a callable so that working out where the cache lives (which
+    for torch means importing torch) only happens on the failure path.
+
+    The retry is conditional on having actually removed something, and that is
+    the point rather than an optimisation. If nothing was cached, the load
+    failed for some other reason -- offline, missing dependency, no disk -- and
+    a second attempt just pays the same network timeout again for the same
+    answer. Only a cache we have now invalidated earns another try.
+
+    An ImportError is never treated as a cache problem. The package is missing,
+    and deleting model files would not help.
+    """
+    try:
+        return load()
+    except ImportError:
+        raise
+    except Exception as first:
+        try:
+            removed = [p for p in stale() if _remove(p)]
+        except Exception:
+            logger.warning("could not resolve model cache paths", exc_info=True)
+            raise first from None
+        if not removed:
+            raise
+        logger.warning(
+            "model load failed (%s); discarded %s and retrying once",
+            first,
+            ", ".join(str(p) for p in removed),
+        )
+        return load()
+
+
+def beat_this_artifacts(checkpoint: str) -> list[Path]:
+    """Where torch.hub keeps the beat_this checkpoint.
+
+    Mirrors beat_this.inference.load_checkpoint, which asks torch.hub for
+    ``beat_this-<name>.ckpt``. Kept next to the healing logic because the two
+    have to agree: pointed at the wrong path this silently never heals
+    anything.
+    """
+    import torch
+
+    return [Path(torch.hub.get_dir()) / "checkpoints" / f"beat_this-{checkpoint}.ckpt"]
+
+
+def vocal_split_artifacts(models_dir: Path, model_file: str) -> list[Path]:
+    """The audio-separator model file, and the metadata index that names it.
+
+    The index is listed too because audio-separator reports a truncated model
+    as an unknown MD5, which is a lookup against that index rather than against
+    the file itself.
+    """
+    root = models_dir / "audio-separator"
+    return [root / model_file, root / "model_data.json"]

--- a/app/pipeline/beat_detect.py
+++ b/app/pipeline/beat_detect.py
@@ -62,7 +62,17 @@ def _get_model():
         try:
             from beat_this.inference import Audio2Beats
 
-            _model = Audio2Beats(checkpoint_path=BEAT_MODEL_CHECKPOINT, device="cpu", dbn=False)
+            from app.core.model_cache import beat_this_artifacts, load_or_heal
+
+            # A checkpoint that downloaded incompletely is still a file on
+            # disk, and torch.hub will keep handing it back forever. Without
+            # this, one dropped connection costs the user the neural beat grid
+            # permanently and silently, because the librosa fallback below
+            # looks exactly like a machine that never had the model (#502).
+            _model = load_or_heal(
+                lambda: Audio2Beats(checkpoint_path=BEAT_MODEL_CHECKPOINT, device="cpu", dbn=False),
+                lambda: beat_this_artifacts(BEAT_MODEL_CHECKPOINT),
+            )
             logger.info("beat model loaded (checkpoint=%s)", BEAT_MODEL_CHECKPOINT)
         except ImportError:
             logger.info("beat_this not installed -- using librosa beat tracking")

--- a/app/pipeline/vocal_split_worker.py
+++ b/app/pipeline/vocal_split_worker.py
@@ -38,6 +38,7 @@ def _run(device: str, vocals_path: str, out_dir: str) -> None:
     from audio_separator.separator import Separator
 
     from app.core.config import MODELS_DIR
+    from app.core.model_cache import load_or_heal, vocal_split_artifacts
 
     separator = Separator(
         log_level=40,  # logging.ERROR -- only the lines we emit ourselves matter
@@ -45,7 +46,14 @@ def _run(device: str, vocals_path: str, out_dir: str) -> None:
         output_dir=out_dir,
         output_format="WAV",
     )
-    separator.load_model(model_filename=VOCAL_SPLIT_MODEL)
+    # This is the only path Docker ever takes: there is no warmup step there, so
+    # the model is fetched here on first use. A download cut short leaves a file
+    # that audio-separator will keep accepting as present and keep failing to
+    # load, which is #502 with no setup step to have caught it earlier.
+    load_or_heal(
+        lambda: separator.load_model(model_filename=VOCAL_SPLIT_MODEL),
+        lambda: vocal_split_artifacts(MODELS_DIR, VOCAL_SPLIT_MODEL),
+    )
     # Karaoke-family models label their two outputs "Vocals" (the lead vocal
     # that survived a second isolation pass) and "Instrumental" (everything in
     # the input that wasn't lead vocal -- since the input here is already an

--- a/app/pipeline/warmup.py
+++ b/app/pipeline/warmup.py
@@ -17,9 +17,16 @@ download later) rather than blocking the app from starting.
 
 "Until it can download later" depends on the cache being empty rather than
 wrong. A checkpoint truncated by a dropped connection is still a file, and
-both loaders here take a file's existence as proof it is good, so the retry
-never fires and the feature stays dead. Every load below therefore goes
-through app/core/model_cache.load_or_heal (#502).
+the loader takes a file's existence as proof it is good, so the retry never
+fires and the feature stays dead (#502).
+
+The two that reported that failure in the wild, beat_this and the vocal-split
+model, therefore load through app/core/model_cache.load_or_heal. Demucs and
+the section model do not: they cache through their own libraries rather than
+torch.hub, and neither has been seen to poison itself this way. Adding them
+would mean naming their cache layouts here and keeping those names correct
+from a distance, which is the mistake that made the first version of
+vocal_split_artifacts point at a file audio-separator never writes.
 """
 
 from __future__ import annotations

--- a/app/pipeline/warmup.py
+++ b/app/pipeline/warmup.py
@@ -14,6 +14,12 @@ failure. A model failing to download here is never fatal to setup -- exactly
 like the lazy path it replaces, a missing model degrades only that one
 feature (e.g. no beat grid, or the karaoke split unavailable until it can
 download later) rather than blocking the app from starting.
+
+"Until it can download later" depends on the cache being empty rather than
+wrong. A checkpoint truncated by a dropped connection is still a file, and
+both loaders here take a file's existence as proof it is good, so the retry
+never fires and the feature stays dead. Every load below therefore goes
+through app/core/model_cache.load_or_heal (#502).
 """
 
 from __future__ import annotations
@@ -39,17 +45,27 @@ def _warm_demucs() -> None:
 def _warm_beat_this() -> None:
     from beat_this.inference import Audio2Beats
 
-    Audio2Beats(checkpoint_path=BEAT_MODEL_CHECKPOINT, device="cpu", dbn=False)
+    from app.core.model_cache import beat_this_artifacts, load_or_heal
+
+    load_or_heal(
+        lambda: Audio2Beats(checkpoint_path=BEAT_MODEL_CHECKPOINT, device="cpu", dbn=False),
+        lambda: beat_this_artifacts(BEAT_MODEL_CHECKPOINT),
+    )
 
 
 def _warm_vocal_split() -> None:
     from audio_separator.separator import Separator
 
-    separator = Separator(
-        log_level=40,  # logging.ERROR -- this is a one-shot download, not a job
-        model_file_dir=str(MODELS_DIR / "audio-separator"),
-    )
-    separator.load_model(model_filename=VOCAL_SPLIT_MODEL)
+    from app.core.model_cache import load_or_heal, vocal_split_artifacts
+
+    def load() -> None:
+        separator = Separator(
+            log_level=40,  # logging.ERROR -- this is a one-shot download, not a job
+            model_file_dir=str(MODELS_DIR / "audio-separator"),
+        )
+        separator.load_model(model_filename=VOCAL_SPLIT_MODEL)
+
+    load_or_heal(load, lambda: vocal_split_artifacts(MODELS_DIR, VOCAL_SPLIT_MODEL))
 
 
 def _warm_sections() -> None:

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -2631,8 +2631,9 @@ fn pip_line_reporter(app: tauri::AppHandle, label: String) -> impl FnMut(&str) +
 }
 
 /// Runs `python -m pip install <args>`, tracking the pip PID so stop_backend can
-/// kill it if the window is closed mid-install (#140), bounding it at 20 minutes,
-/// and logging raw stderr to setup.log before mapping it to a user-facing message.
+/// kill it if the window is closed mid-install (#140), giving up once it has
+/// been silent for PIP_STALL_TIMEOUT rather than after a fixed time (#502), and
+/// logging raw stderr to setup.log before mapping it to a user-facing message.
 #[cfg(not(target_os = "macos"))]
 fn run_pip_install(
     python: &Path,
@@ -2698,6 +2699,17 @@ const PIP_STALL_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 #[cfg(not(target_os = "macos"))]
 const PIP_HARD_CAP: Duration = Duration::from_secs(4 * 60 * 60);
 
+/// The budget for a pip that cannot report progress at all.
+///
+/// pip before 24.1 has no `--progress-bar raw`, and the retry that drops the
+/// flag writes nothing to a pipe until it finishes. There is no activity to
+/// measure, so this is a plain deadline. Generous, because the thing it is
+/// bounding is the same 3 GB download, and a fixed budget on a download is
+/// exactly what #502 was about: it only exists here because that path gives us
+/// nothing better to go on.
+#[cfg(not(target_os = "macos"))]
+const PIP_SILENT_TIMEOUT: Duration = Duration::from_secs(90 * 60);
+
 /// One `python -m pip install` run, streamed. Split out of `run_pip_install`
 /// only so the progress flag can be dropped and the whole thing retried.
 #[cfg(not(target_os = "macos"))]
@@ -2709,6 +2721,17 @@ fn spawn_pip(
     app: &tauri::AppHandle,
     label: &str,
 ) -> Result<Output, String> {
+    // A stall budget only means anything when the child says something while it
+    // works. Without `--progress-bar raw` pip writes nothing to a pipe for the
+    // whole download, so silence is its normal state and PIP_STALL_TIMEOUT
+    // would kill a perfectly healthy 3 GB transfer five minutes in -- worse
+    // than the fixed cap this replaced. On that path the stall budget is set to
+    // the cap, which makes it a plain deadline again.
+    let stall = if progress_args.is_empty() {
+        PIP_SILENT_TIMEOUT
+    } else {
+        PIP_STALL_TIMEOUT
+    };
     let mut command = Command::new(python);
     command
         .args(["-m", "pip", "install"])
@@ -2727,7 +2750,7 @@ fn spawn_pip(
     }
     let output = child_output_streaming(
         child,
-        PIP_STALL_TIMEOUT,
+        stall,
         PIP_HARD_CAP,
         label,
         pip_line_reporter(app.clone(), label.to_string()),

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -14,7 +14,7 @@ use std::{
     process::{Child, Command, Output, Stdio},
     sync::{
         atomic::{AtomicU64, Ordering},
-        Mutex,
+        Arc, Mutex,
     },
     thread,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
@@ -1887,6 +1887,12 @@ fn ensure_torch_device(
                 // #502, where cu128 was the only thing ever offered.
                 let candidates = wheel_candidates(compute_cap.as_deref(), &cuda_version);
                 let mut cuda_verified = false;
+                // Whether any candidate got far enough to be verified at all.
+                // Without this the reason below says "cuda-verify-failed" for a
+                // run that never reached verify, which is the first line anyone
+                // reads in a bug report and sends them after the wrong thing
+                // (#502: the install had been killed mid-download).
+                let mut cuda_installed = false;
                 for tag in &candidates {
                     append_to_setup_log(
                         &data_dir,
@@ -1900,6 +1906,7 @@ fn ensure_torch_device(
                         append_to_setup_log(&data_dir, &format!("{tag} install failed: {e}"));
                         continue;
                     }
+                    cuda_installed = true;
                     if verify_cuda_torch(&python) {
                         append_to_setup_log(&data_dir, &format!("{tag} verified"));
                         cuda_verified = true;
@@ -1915,14 +1922,23 @@ fn ensure_torch_device(
                     // module scope, so a wheel that cannot load keeps the
                     // backend from starting at all. Put the CPU wheels back
                     // (#324).
+                    let stage = if cuda_installed {
+                        "cuda-verify-failed"
+                    } else {
+                        "cuda-install-failed"
+                    };
                     match restore_cpu_torch(&python, &state, &app) {
-                        Ok(()) => "cuda-verify-failed",
+                        Ok(()) => stage,
                         Err(e) => {
                             append_to_setup_log(
                                 &data_dir,
                                 &format!("CPU torch restore failed: {e}"),
                             );
-                            "cuda-verify-failed-cpu-restore-failed"
+                            if cuda_installed {
+                                "cuda-verify-failed-cpu-restore-failed"
+                            } else {
+                                "cuda-install-failed-cpu-restore-failed"
+                            }
                         }
                     }
                 };
@@ -2666,6 +2682,22 @@ fn run_pip_install(
     Err(classify_cuda_install_error(&stderr))
 }
 
+/// How long pip may go completely silent before it is considered wedged.
+///
+/// pip emits a `Progress` line continuously while bytes are moving, so a gap
+/// this long means nothing is arriving. Generous enough to cover the pauses
+/// that are not stalls: resolving the index, and the decompress-and-write at
+/// the end of a large wheel, which produces no output at all.
+#[cfg(not(target_os = "macos"))]
+const PIP_STALL_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+
+/// Backstop for a pip that never goes quiet but never finishes either. Nothing
+/// legitimate approaches this: the reporter whose install prompted the change
+/// took about 17 minutes for the whole 3 GB pass on a slow link. The window
+/// close handler kills the child through `setup_child_pid` long before here.
+#[cfg(not(target_os = "macos"))]
+const PIP_HARD_CAP: Duration = Duration::from_secs(4 * 60 * 60);
+
 /// One `python -m pip install` run, streamed. Split out of `run_pip_install`
 /// only so the progress flag can be dropped and the whole thing retried.
 #[cfg(not(target_os = "macos"))]
@@ -2695,7 +2727,8 @@ fn spawn_pip(
     }
     let output = child_output_streaming(
         child,
-        Duration::from_secs(20 * 60),
+        PIP_STALL_TIMEOUT,
+        PIP_HARD_CAP,
         label,
         pip_line_reporter(app.clone(), label.to_string()),
     );
@@ -4935,18 +4968,27 @@ fn update_setup_config<const N: usize>(
 /// text used to classify an error, which is only wanted once, at the end.
 fn child_output_streaming<F>(
     mut child: Child,
-    timeout: Duration,
+    stall: Duration,
+    cap: Duration,
     label: &str,
     mut on_stdout_line: F,
 ) -> Result<Output, String>
 where
     F: FnMut(&str) + Send + 'static,
 {
+    // Every line stamps this, and the wait loop reads it. Only stdout counts as
+    // activity: pip writes its progress there, and stderr is read to EOF in one
+    // go rather than line by line, so it has nothing per-line to stamp with.
+    let last_line = Arc::new(Mutex::new(Instant::now()));
+    let stamp = Arc::clone(&last_line);
     let stdout_reader = child.stdout.take().map(|pipe| {
         thread::spawn(move || {
             let mut collected = Vec::new();
             for line in BufReader::new(pipe).lines() {
                 let Ok(line) = line else { break };
+                if let Ok(mut at) = stamp.lock() {
+                    *at = Instant::now();
+                }
                 on_stdout_line(&line);
                 collected.extend_from_slice(line.as_bytes());
                 collected.push(b'\n');
@@ -4961,7 +5003,12 @@ where
             buf
         })
     });
-    wait_for_child(child, timeout, label, stdout_reader, stderr_reader)
+    let deadline = Deadline::Stall {
+        stall,
+        cap,
+        last: last_line,
+    };
+    wait_for_child(child, deadline, label, stdout_reader, stderr_reader)
 }
 
 fn child_output_with_timeout(
@@ -4984,14 +5031,41 @@ fn child_output_with_timeout(
         })
     });
 
-    wait_for_child(child, timeout, label, stdout_reader, stderr_reader)
+    wait_for_child(
+        child,
+        Deadline::Fixed(timeout),
+        label,
+        stdout_reader,
+        stderr_reader,
+    )
+}
+
+/// How long a child gets, and measured from what.
+enum Deadline {
+    /// A fixed budget from spawn. Right when the work should take a bounded
+    /// time whatever machine it runs on.
+    Fixed(Duration),
+    /// Give up only once nothing has been heard for `stall`, bounded by a hard
+    /// `cap` so a child that chatters forever still ends.
+    ///
+    /// Right when the duration is set by the user's connection rather than by
+    /// us. A fixed budget on a download is really an undeclared bandwidth
+    /// requirement: the Linux CUDA runtime pass moves about 3 GB, so the 20
+    /// minutes it used to get demanded a sustained 2.5 MB/s, and a reporter on
+    /// 0.77 MB/s had a perfectly healthy install killed at 1200 seconds while
+    /// bytes were still arriving (#502). Silence is the only honest signal.
+    Stall {
+        stall: Duration,
+        cap: Duration,
+        last: Arc<Mutex<Instant>>,
+    },
 }
 
 /// The wait half both readers above share: poll for exit, kill at the deadline,
 /// and join the reader threads either way so neither is leaked.
 fn wait_for_child(
     mut child: Child,
-    timeout: Duration,
+    deadline: Deadline,
     label: &str,
     stdout_reader: Option<thread::JoinHandle<Vec<u8>>>,
     stderr_reader: Option<thread::JoinHandle<Vec<u8>>>,
@@ -5000,7 +5074,7 @@ fn wait_for_child(
         reader.and_then(|h| h.join().ok()).unwrap_or_default()
     };
 
-    let deadline = Instant::now() + timeout;
+    let started = Instant::now();
     loop {
         if let Some(status) = child
             .try_wait()
@@ -5014,7 +5088,25 @@ fn wait_for_child(
                 stderr: collect(stderr_reader),
             });
         }
-        if Instant::now() >= deadline {
+        // What "out of time" means depends on which kind of deadline this is,
+        // and the message has to say which one actually fired: "timed out after
+        // 1200 seconds" on a download that was still moving sent the last
+        // reporter looking for a hang that was never there.
+        let expired: Option<String> = match &deadline {
+            Deadline::Fixed(budget) => (started.elapsed() >= *budget)
+                .then(|| format!("after {} seconds", budget.as_secs())),
+            Deadline::Stall { stall, cap, last } => {
+                let quiet = last.lock().map(|t| t.elapsed()).unwrap_or(Duration::ZERO);
+                if quiet >= *stall {
+                    Some(format!("after {} seconds with no output", stall.as_secs()))
+                } else if started.elapsed() >= *cap {
+                    Some(format!("after {} seconds", cap.as_secs()))
+                } else {
+                    None
+                }
+            }
+        };
+        if let Some(why) = expired {
             let _ = child.kill();
             let _ = child.wait();
             // Detached, not joined. Killing the child closes only the pipe ends
@@ -5031,10 +5123,7 @@ fn wait_for_child(
             // caller is held there too.
             drop(stdout_reader);
             drop(stderr_reader);
-            return Err(format!(
-                "{label} timed out after {} seconds",
-                timeout.as_secs()
-            ));
+            return Err(format!("{label} timed out {why}"));
         }
         thread::sleep(Duration::from_millis(100));
     }
@@ -5278,6 +5367,89 @@ mod tests {
             "gave up after {:?}; the timeout is what stops setup hanging forever",
             started.elapsed()
         );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_slow_but_moving_download_is_not_killed() {
+        // The #502 regression. A 3 GB pip pass used to get a flat 20 minutes
+        // from spawn, which is an undeclared 2.5 MB/s requirement: a reporter
+        // downloading at 0.77 MB/s was killed at 1200 seconds with bytes still
+        // arriving, and their next run succeeded only because their connection
+        // happened to be 4.7x faster that time.
+        //
+        // Ten seconds of steady output against a two second stall budget. Under
+        // the old fixed deadline this child is killed; under a stall budget it
+        // must be left alone, because it was never quiet.
+        let mut command = Command::new("sh");
+        command
+            .arg("-c")
+            .arg("for i in $(seq 20); do echo \"Progress $i of 20\"; sleep 0.5; done")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let child = command.spawn().expect("spawn");
+
+        let output = super::child_output_streaming(
+            child,
+            Duration::from_secs(2),
+            Duration::from_secs(120),
+            "slow but moving",
+            |_line| {},
+        )
+        .expect("a child that keeps producing output must be left to finish");
+
+        assert!(output.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).lines().count(),
+            20,
+            "every line must still be collected"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_download_that_goes_quiet_is_given_up_on() {
+        // The other half: silence is what a genuine stall looks like, and it
+        // still has to end. One line, then nothing.
+        let mut command = Command::new("sh");
+        command
+            .arg("-c")
+            .arg("echo 'Progress 1 of 100'; sleep 300")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let child = command.spawn().expect("spawn");
+
+        let started = std::time::Instant::now();
+        let result = super::child_output_streaming(
+            child,
+            Duration::from_secs(2),
+            Duration::from_secs(600),
+            "wedged download",
+            |_line| {},
+        );
+
+        assert!(result.is_err(), "a silent child must not be waited on");
+        assert!(
+            result.unwrap_err().contains("no output"),
+            "the message must say it went quiet, not that it ran long"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(30),
+            "gave up after {:?}",
+            started.elapsed()
+        );
+    }
+
+    #[test]
+    #[cfg(not(target_os = "macos"))]
+    fn the_pip_stall_budget_outlasts_a_quiet_wheel_install() {
+        // A large wheel decompresses and writes with no output at all, so the
+        // budget has to clear that pause comfortably. It is a stall budget, not
+        // a total budget, so being generous costs nothing on a healthy run.
+        assert!(super::PIP_STALL_TIMEOUT >= Duration::from_secs(60));
+        assert!(super::PIP_STALL_TIMEOUT <= Duration::from_secs(15 * 60));
+        // And the backstop must still be a backstop.
+        assert!(super::PIP_HARD_CAP > super::PIP_STALL_TIMEOUT);
     }
 
     #[test]
@@ -5729,7 +5901,13 @@ mod tests {
 
     #[test]
     fn other_device_reasons_pass_through_unchanged() {
-        for reason in ["verified", "no-gpu-detected", "cuda-verify-failed", "mps"] {
+        for reason in [
+            "verified",
+            "no-gpu-detected",
+            "cuda-verify-failed",
+            "cuda-install-failed",
+            "mps",
+        ] {
             assert_eq!(
                 super::effective_device_reason(Some(reason.to_string()), false).as_deref(),
                 Some(reason),

--- a/desktop/ui/setup.js
+++ b/desktop/ui/setup.js
@@ -468,12 +468,15 @@ async function runSetup() {
         // written here is invisible. Telling the user properly belongs in the
         // main UI, where the affected feature actually lives, and is its own
         // piece of work.
+        // camelCase, because ModelWarmupStatus is #[serde(rename_all =
+        // "camelCase")]. Reading the Rust field names instead gives four
+        // undefineds, `missing` is empty every time, and this says nothing.
         const status = await invoke("warmup_models");
         const missing = [
-          [status?.demucs_ready, "stem separation"],
-          [status?.beat_this_ready, "beat detection"],
-          [status?.sections_ready, "song sections"],
-          [status?.vocal_split_ready, "karaoke split"],
+          [status?.demucsReady, "stem separation"],
+          [status?.beatThisReady, "beat detection"],
+          [status?.sectionsReady, "song sections"],
+          [status?.vocalSplitReady, "karaoke split"],
         ]
           .filter(([ready]) => ready === false)
           .map(([, label]) => label);

--- a/desktop/ui/setup.js
+++ b/desktop/ui/setup.js
@@ -458,10 +458,16 @@ async function runSetup() {
         // an individual model failure; this catch is only for the whole
         // subprocess failing to run at all, e.g. a missing Python).
         //
-        // The per-model result is still worth saying out loud. It used to be
-        // thrown away here, so a user whose beat model never arrived saw a
-        // clean setup and then a permanently worse beat grid with nothing
-        // anywhere connecting the two (#502).
+        // The per-model result was thrown away here, so a user whose beat
+        // model never arrived saw a clean setup and then a permanently worse
+        // beat grid, with nothing anywhere connecting the two (#502). Naming
+        // it at least puts it in the log that gets attached to bug reports.
+        //
+        // Deliberately not setStatus: the next step overwrites the status line
+        // immediately and then navigates away to the backend, so anything
+        // written here is invisible. Telling the user properly belongs in the
+        // main UI, where the affected feature actually lives, and is its own
+        // piece of work.
         const status = await invoke("warmup_models");
         const missing = [
           [status?.demucs_ready, "stem separation"],
@@ -473,9 +479,6 @@ async function runSetup() {
           .map(([, label]) => label);
         if (missing.length) {
           console.warn("models not downloaded during setup:", missing.join(", "));
-          setStatus(
-            `Setup finished. ${missing.join(", ")} will download when first used.`,
-          );
         }
       } catch (err) {
         console.warn("model warmup failed (will download lazily on first use):", err);

--- a/desktop/ui/setup.js
+++ b/desktop/ui/setup.js
@@ -457,7 +457,26 @@ async function runSetup() {
         // never fails setup over this (warmup_models itself never throws for
         // an individual model failure; this catch is only for the whole
         // subprocess failing to run at all, e.g. a missing Python).
-        await invoke("warmup_models");
+        //
+        // The per-model result is still worth saying out loud. It used to be
+        // thrown away here, so a user whose beat model never arrived saw a
+        // clean setup and then a permanently worse beat grid with nothing
+        // anywhere connecting the two (#502).
+        const status = await invoke("warmup_models");
+        const missing = [
+          [status?.demucs_ready, "stem separation"],
+          [status?.beat_this_ready, "beat detection"],
+          [status?.sections_ready, "song sections"],
+          [status?.vocal_split_ready, "karaoke split"],
+        ]
+          .filter(([ready]) => ready === false)
+          .map(([, label]) => label);
+        if (missing.length) {
+          console.warn("models not downloaded during setup:", missing.join(", "));
+          setStatus(
+            `Setup finished. ${missing.join(", ")} will download when first used.`,
+          );
+        }
       } catch (err) {
         console.warn("model warmup failed (will download lazily on first use):", err);
       } finally {

--- a/static/js/audioEngine.js
+++ b/static/js/audioEngine.js
@@ -23,6 +23,7 @@ import {
   INPUT_COUNT, ZERO_INPUT, clampPitch, effectivePitch, inputForPitch,
 } from "./pitchBus.js";
 import { createPlaybackContext } from "./audioContext.js";
+import { createTickLoop } from "./tickLoop.js";
 
 export function createAudioEngine(stems, { onTime, onEnded, context } = {}) {
   // Mobile/iOS only starts audio from a context resumed inside a user gesture.
@@ -86,9 +87,26 @@ export function createAudioEngine(stems, { onTime, onEnded, context } = {}) {
   let playing = false;
   let startCtxTime = 0; // ctx.currentTime at playback start
   let startOffset = 0; // media offset at that moment
-  let rafId = null;
+  // `tick` is a hoisted function declaration below. Driving it through a tick
+  // loop rather than requestAnimationFrame directly keeps loop ends and
+  // end-of-track firing while the tab is hidden; see tickLoop.js (#600).
+  const tickLoop = createTickLoop(tick);
   let destroyed = false;
   let loop = { enabled: false, start: 0, end: 0 };
+
+  // A backgrounded tab can have its context suspended out from under it. The
+  // sources stay scheduled, so nothing here notices; the audio just stops. Ask
+  // for it back whenever that happens mid-playback.
+  //
+  // Held in a named function because the listener has to come off again in
+  // destroy(): when the caller passed a shared context (the mobile UI does),
+  // that context outlives this engine and would otherwise accumulate one dead
+  // listener per track the user opens.
+  const onCtxStateChange = () => {
+    if (playing && ctx.state === "suspended") ctx.resume().catch(() => {});
+  };
+  ctx.addEventListener("statechange", onCtxStateChange);
+
   // Bumped whenever the media-time -> ctx-time mapping below changes (start,
   // seek, loop jump, rate change, pause). The metronome watches this to know
   // when its already-scheduled clicks are stale and must be torn down.
@@ -267,7 +285,7 @@ export function createAudioEngine(stems, { onTime, onEnded, context } = {}) {
       return;
     }
     onTime?.(t);
-    rafId = requestAnimationFrame(tick);
+    tickLoop.schedule();
   }
 
   // `leadIn` (source seconds, default 0) delays the moment the stems begin so a
@@ -285,7 +303,7 @@ export function createAudioEngine(stems, { onTime, onEnded, context } = {}) {
     const when = ctx.currentTime + (lead > 0 ? (lead + COUNT_IN_MARGIN) / srcRate() : 0);
     startSources(off, when);
     playing = true;
-    rafId = requestAnimationFrame(tick);
+    tickLoop.schedule();
   }
 
   function pause() {
@@ -296,7 +314,7 @@ export function createAudioEngine(stems, { onTime, onEnded, context } = {}) {
     playing = false;
     startOffset = Math.max(0, Math.min(t, duration));
     _epoch++;
-    if (rafId) { cancelAnimationFrame(rafId); rafId = null; }
+    tickLoop.cancel();
   }
 
   function seek(t) {
@@ -378,7 +396,13 @@ export function createAudioEngine(stems, { onTime, onEnded, context } = {}) {
     destroyed = true;
     stopSources();
     resetProcessor();
-    if (rafId) { cancelAnimationFrame(rafId); rafId = null; }
+    // destroyPlayer() tears the engine down without pausing first, so an engine
+    // destroyed mid-playback used to leave `playing` true forever. isPlaying()
+    // then lied about a dead engine, and anything still holding a reference to
+    // the tick would have kept it alive on that stale flag.
+    playing = false;
+    tickLoop.dispose();
+    ctx.removeEventListener("statechange", onCtxStateChange);
     tracks.clear();
     if (stNode) { try { stNode.disconnect(); } catch { /* noop */ } }
     if (ownsCtx) ctx.close().catch(() => {});

--- a/static/js/chunkedAudioEngine.js
+++ b/static/js/chunkedAudioEngine.js
@@ -189,6 +189,7 @@ import {
   INPUT_COUNT, ZERO_INPUT, clampPitch, effectivePitch, inputForPitch,
 } from "./pitchBus.js";
 import { createPlaybackContext } from "./audioContext.js";
+import { createTickLoop } from "./tickLoop.js";
 
 export function createChunkedAudioEngine(stems, { onTime, onEnded, context } = {}) {
   const AC = window.AudioContext || window.webkitAudioContext;
@@ -288,7 +289,23 @@ export function createChunkedAudioEngine(stems, { onTime, onEnded, context } = {
   }
 
   let _duration = 0;
-  let rafId = null;
+  // `_tick` is a hoisted function declaration below. It is the only caller of
+  // _maybeSchedule(), so this loop stopping means chunk scheduling stops: the
+  // LOOKAHEAD_SEC already queued plays out and then the track goes silent with
+  // no error. requestAnimationFrame does exactly that to a hidden tab, which is
+  // the whole of #600. See tickLoop.js.
+  const tickLoop = createTickLoop(_tick);
+
+  // A backgrounded tab can have its context suspended out from under it. Ask
+  // for it back whenever that happens mid-playback. Named so destroy() can take
+  // the listener off again: a caller-supplied context (the mobile UI passes
+  // one) outlives this engine and would otherwise collect one dead listener per
+  // track the user opens.
+  const onCtxStateChange = () => {
+    if (playing && ctx.state === "suspended") ctx.resume().catch(() => {});
+  };
+  ctx.addEventListener("statechange", onCtxStateChange);
+
   // Why ready() resolved false, in words fit to show a user. Read via
   // getLoadError() by the caller that decides what to put on screen.
   let _loadError = null;
@@ -609,14 +626,14 @@ export function createChunkedAudioEngine(stems, { onTime, onEnded, context } = {
       playing = false;
       _audioStarted = false;
       _startOffset = _duration;
-      if (rafId) { cancelAnimationFrame(rafId); rafId = null; }
+      tickLoop.cancel();
       onTime?.(_duration);
       onEnded?.();
       return;
     }
     _maybeSchedule();
     onTime?.(t);
-    rafId = requestAnimationFrame(_tick);
+    tickLoop.schedule();
   }
 
   // --- public API ---
@@ -650,7 +667,7 @@ export function createChunkedAudioEngine(stems, { onTime, onEnded, context } = {
       _audioStarted = true;
       _epoch++; // mapping is valid from here; see isClockReady
       _fetchChunk(chunkIdx + 1); // pre-fetch next chunk
-      rafId = requestAnimationFrame(_tick);
+      tickLoop.schedule();
     };
 
     // chunk 0 is pre-decoded during ready(), so the sync path is the hot path.
@@ -677,7 +694,7 @@ export function createChunkedAudioEngine(stems, { onTime, onEnded, context } = {
     _audioStarted = false;
     _epoch++;
     _scheduledTo = _startOffset;
-    if (rafId) { cancelAnimationFrame(rafId); rafId = null; }
+    tickLoop.cancel();
   }
 
   function seek(t) {
@@ -687,7 +704,7 @@ export function createChunkedAudioEngine(stems, { onTime, onEnded, context } = {
       _stopNodes();
       playing = false;
       _audioStarted = false;
-      if (rafId) { cancelAnimationFrame(rafId); rafId = null; }
+      tickLoop.cancel();
     }
     _resetProcessor();
     _startOffset = clamped;
@@ -852,6 +869,11 @@ export function createChunkedAudioEngine(stems, { onTime, onEnded, context } = {
       destroyed = true;
       if (playing) pause();
       else _resetProcessor();
+      // pause() already cancelled the loop, but only on the playing path, and
+      // cancel is not what teardown needs anyway: a loop left registered keeps
+      // its closure reachable, and that closure holds every decoded chunk.
+      tickLoop.dispose();
+      ctx.removeEventListener("statechange", onCtxStateChange);
       if (stNode) { try { stNode.disconnect(); } catch { /* noop */ } }
       _cache.clear();
       stemMap.clear();

--- a/static/js/player.js
+++ b/static/js/player.js
@@ -1320,9 +1320,18 @@ export function wireUpAudio(jobId, stems, duration, thumbnail, mixUrl = null, ti
       `[player] canplay — ${stems.length} stems, ctx=${ctx?.state}, audios:`,
       mt.audios?.map((a, i) => `${orderedNames[i]}:${a?.constructor?.name}`),
     );
-    // Log load errors only for stems that actually have a source URL
+    // Log load errors only for stems that actually have a source URL.
+    //
+    // `useEngine` has to be part of that test, not just the stem descriptor.
+    // When the engine owns playback every multitrack stem is handed url: null
+    // above, so all of these elements have an empty src by design, while
+    // stemsByName still holds the real URL the engine is streaming from. Testing
+    // only the descriptor therefore passed, attached an error listener to an
+    // element that was never given a source, and logged six MEDIA_ELEMENT_ERROR
+    // "Empty src attribute" lines on every engine-backed track load. Harmless to
+    // playback, and noisy enough to bury a real error in a bug report.
     mt.audios?.forEach((a, i) => {
-      if (a instanceof HTMLMediaElement && stemsByName[orderedNames[i]]?.url) {
+      if (!useEngine && a instanceof HTMLMediaElement && stemsByName[orderedNames[i]]?.url) {
         a.addEventListener("error", () =>
           console.error(`[player] audio error stem[${i}] ${orderedNames[i]}:`, a.error?.message, a.error?.code),
         { once: true });

--- a/static/js/tickLoop.js
+++ b/static/js/tickLoop.js
@@ -1,0 +1,117 @@
+// A self-rescheduling callback that keeps running while the tab is hidden.
+//
+// requestAnimationFrame is not delivered to a hidden tab at all. That is right
+// for drawing and wrong for everything the audio depends on:
+//
+//   - chunkedAudioEngine calls _maybeSchedule() from its tick, and that is the
+//     only call site. When the tick stops, chunk scheduling stops, playback
+//     runs out the LOOKAHEAD_SEC already queued, and then it is silent. No
+//     error, no event, just twelve seconds and then nothing (#600).
+//   - audioEngine keeps sounding, because every source is scheduled up front,
+//     but it stops noticing loop ends and end-of-track until you come back.
+//
+// While hidden the same callback runs from setTimeout instead. Browsers clamp
+// background timers to roughly 1 Hz, which is far below frame rate and far
+// above what either scheduler needs against a twelve second lookahead.
+//
+// This lives in its own module because both engines need it and because the
+// cancel path is easy to get wrong: the handle is a raf id or a timeout id
+// depending on which clock scheduled it, and passing one to the other's cancel
+// silently does nothing.
+
+// Long enough to be well inside any lookahead, short enough that the clamp the
+// browser actually applies is what governs the rate, not this number.
+const HIDDEN_INTERVAL_MS = 100;
+
+// Every live loop, so that one document listener serves all of them. A
+// listener per loop would mean a listener per engine, and engines are created
+// and destroyed on every track change; document outlives all of them and would
+// hold each dead engine's closure, and its decoded buffers, forever.
+const live = new Set();
+let listening = false;
+
+function onVisibilityChange() {
+  // Only the hide transition needs help. On the way back the pending timeout
+  // fires normally and schedule() picks requestAnimationFrame again by itself.
+  if (!document.hidden) return;
+  for (const loop of live) loop._onHidden();
+}
+
+function ensureListening() {
+  if (listening || typeof document === "undefined") return;
+  document.addEventListener("visibilitychange", onVisibilityChange);
+  listening = true;
+}
+
+// Resolved per call rather than at module load: these are read from the global
+// at the moment they are used, so a test can install fakes after importing.
+const isHidden = () => typeof document !== "undefined" && document.hidden === true;
+const raf = (cb) =>
+  typeof requestAnimationFrame === "function"
+    ? requestAnimationFrame(cb)
+    : setTimeout(cb, HIDDEN_INTERVAL_MS);
+const cancelRaf = (id) => {
+  if (typeof cancelAnimationFrame === "function") cancelAnimationFrame(id);
+  else clearTimeout(id);
+};
+
+/**
+ * @param {() => void} fn Called once per tick. It is expected to call
+ *   `schedule()` again itself if it wants another tick, matching the shape of
+ *   a plain requestAnimationFrame loop.
+ */
+export function createTickLoop(fn) {
+  let handle = null;
+  let timed = false; // whether `handle` came from setTimeout rather than raf
+
+  function schedule() {
+    cancel();
+    if (isHidden()) {
+      timed = true;
+      handle = setTimeout(fn, HIDDEN_INTERVAL_MS);
+    } else {
+      timed = false;
+      handle = raf(fn);
+    }
+  }
+
+  function cancel() {
+    if (handle === null) return;
+    if (timed) clearTimeout(handle);
+    else cancelRaf(handle);
+    handle = null;
+  }
+
+  const loop = {
+    schedule,
+    cancel,
+
+    // Stop the loop and drop it from `live`. Callers must do this on teardown:
+    // a loop left in the set keeps its whole closure reachable, which for an
+    // audio engine means every decoded stem buffer it captured.
+    dispose() {
+      cancel();
+      live.delete(loop);
+    },
+
+    // The browser drops a pending animation frame when the tab hides rather
+    // than deferring it, so a loop waiting on one has no callback left to
+    // notice it should change clocks. This is that missing callback.
+    //
+    // Only a loop actually waiting on a frame is restarted. A stopped loop
+    // (handle null, after pause or dispose) stays stopped, and one already on
+    // a timeout is left alone.
+    _onHidden() {
+      if (handle !== null && !timed) schedule();
+    },
+  };
+
+  live.add(loop);
+  ensureListening();
+  return loop;
+}
+
+// Test seam. Not used by the app.
+export function _liveLoopCount() {
+  return live.size;
+}

--- a/tests/js/audio-routing.test.mjs
+++ b/tests/js/audio-routing.test.mjs
@@ -150,6 +150,21 @@ class FakeContext {
   }
   async resume() {}
   async close() {}
+
+  // A real AudioContext is an EventTarget. The engine listens for statechange
+  // on it so it can ask for the context back when a backgrounded tab has it
+  // suspended (#600), and removes the listener again on teardown.
+  addEventListener(type, fn) {
+    if (!this.listeners) this.listeners = new Map();
+    if (!this.listeners.has(type)) this.listeners.set(type, []);
+    this.listeners.get(type).push(fn);
+  }
+
+  removeEventListener(type, fn) {
+    const l = this.listeners?.get(type) || [];
+    const i = l.indexOf(fn);
+    if (i >= 0) l.splice(i, 1);
+  }
 }
 
 class FakeWorkletNode extends FakeNode {

--- a/tests/js/tick-loop.test.mjs
+++ b/tests/js/tick-loop.test.mjs
@@ -1,0 +1,191 @@
+// The clock behind both audio engines' tick.
+//
+// requestAnimationFrame is not delivered to a hidden tab, and a frame already
+// pending when the tab hides is dropped rather than deferred. A loop built
+// straight on rAF therefore has no callback left to notice it should do
+// anything about it, and simply stops. In the chunked engine that stops chunk
+// scheduling, so playback runs out its lookahead and goes silent about twelve
+// seconds later with no error anywhere (#600).
+//
+// These checks pin the two halves of the fix: the switch to a timer while
+// hidden, and the deregistration on dispose that keeps a torn-down engine from
+// being restarted (and from being kept alive at all -- the closure holds every
+// decoded buffer).
+
+// Installed before importing the module under test: createTickLoop binds the
+// document listener on first use, so the fake has to be in place by then.
+const raf = { scheduled: [], cancelled: [] };
+const timer = { scheduled: [], cleared: [] };
+let nextId = 0;
+
+const listeners = new Map();
+globalThis.document = {
+  hidden: false,
+  addEventListener(type, fn) {
+    if (!listeners.has(type)) listeners.set(type, []);
+    listeners.get(type).push(fn);
+  },
+  removeEventListener(type, fn) {
+    const l = listeners.get(type) || [];
+    const i = l.indexOf(fn);
+    if (i >= 0) l.splice(i, 1);
+  },
+};
+const fire = (type) => { for (const fn of [...(listeners.get(type) || [])]) fn(); };
+
+globalThis.requestAnimationFrame = (cb) => {
+  const id = ++nextId;
+  raf.scheduled.push({ id, cb });
+  return id;
+};
+globalThis.cancelAnimationFrame = (id) => { raf.cancelled.push(id); };
+globalThis.setTimeout = (cb, ms) => {
+  const id = ++nextId;
+  timer.scheduled.push({ id, cb, ms });
+  return id;
+};
+globalThis.clearTimeout = (id) => { timer.cleared.push(id); };
+
+const { createTickLoop, _liveLoopCount } = await import('../../static/js/tickLoop.js');
+
+let passed = 0;
+let failed = 0;
+
+function check(name, condition, detail = '') {
+  if (condition) {
+    passed++;
+    console.log(`PASS  ${name}`);
+  } else {
+    failed++;
+    console.log(`FAIL  ${name}${detail ? `  -- ${detail}` : ''}`);
+  }
+}
+
+function reset() {
+  raf.scheduled.length = 0;
+  raf.cancelled.length = 0;
+  timer.scheduled.length = 0;
+  timer.cleared.length = 0;
+  document.hidden = false;
+}
+
+{
+  // The ordinary case, unchanged from what the engines did before.
+  reset();
+  const loop = createTickLoop(() => {});
+  loop.schedule();
+  check(
+    'a visible tab schedules on requestAnimationFrame',
+    raf.scheduled.length === 1 && timer.scheduled.length === 0,
+  );
+  loop.dispose();
+}
+
+{
+  reset();
+  document.hidden = true;
+  const loop = createTickLoop(() => {});
+  loop.schedule();
+  check(
+    'a hidden tab schedules on a timer instead',
+    timer.scheduled.length === 1 && raf.scheduled.length === 0,
+  );
+  loop.dispose();
+}
+
+{
+  // The regression this file exists for. Before the fix the pending frame was
+  // silently dropped by the browser and nothing rescheduled, so the loop -- and
+  // with it chunk scheduling -- was simply over.
+  reset();
+  const loop = createTickLoop(() => {});
+  loop.schedule();
+  const pending = raf.scheduled[0].id;
+
+  document.hidden = true;
+  fire('visibilitychange');
+
+  check(
+    'hiding the tab moves a running loop onto a timer',
+    timer.scheduled.length === 1,
+    `timers=${timer.scheduled.length} rafs=${raf.scheduled.length}`,
+  );
+  check(
+    'the frame that will never fire is cancelled',
+    raf.cancelled.includes(pending),
+    `cancelled=${JSON.stringify(raf.cancelled)}`,
+  );
+  loop.dispose();
+}
+
+{
+  // Cancelling has to match the clock that scheduled it. Handing a timeout id
+  // to cancelAnimationFrame is not an error, it just does nothing, and the loop
+  // keeps ticking after the engine believes it stopped it.
+  reset();
+  document.hidden = true;
+  const loop = createTickLoop(() => {});
+  loop.schedule();
+  const id = timer.scheduled[0].id;
+  loop.cancel();
+  check(
+    'a timer-scheduled loop is cancelled with clearTimeout',
+    timer.cleared.includes(id) && raf.cancelled.length === 0,
+    `cleared=${JSON.stringify(timer.cleared)} rafCancelled=${JSON.stringify(raf.cancelled)}`,
+  );
+  loop.dispose();
+}
+
+{
+  // A paused engine must stay paused. Hiding the tab is not a reason to start
+  // ticking again.
+  reset();
+  const loop = createTickLoop(() => {});
+  loop.schedule();
+  loop.cancel();
+  document.hidden = true;
+  fire('visibilitychange');
+  check(
+    'a stopped loop is not restarted by hiding the tab',
+    timer.scheduled.length === 0,
+    `timers=${timer.scheduled.length}`,
+  );
+  loop.dispose();
+}
+
+{
+  // The leak. destroyPlayer() tears an engine down without pausing it, so
+  // before the fix a destroyed engine's loop was still registered, still saw
+  // `playing` as true, and was resurrected on the next tab switch -- against a
+  // closed AudioContext, forever, holding all of that track's decoded audio.
+  reset();
+  const before = _liveLoopCount();
+  const loop = createTickLoop(() => {});
+  loop.schedule();
+  loop.dispose();
+
+  check('dispose deregisters the loop', _liveLoopCount() === before);
+
+  document.hidden = true;
+  fire('visibilitychange');
+  check(
+    'a disposed loop is never restarted',
+    timer.scheduled.length === 0,
+    `timers=${timer.scheduled.length}`,
+  );
+}
+
+{
+  // One listener for the whole page, however many engines have come and gone.
+  reset();
+  const loops = [createTickLoop(() => {}), createTickLoop(() => {}), createTickLoop(() => {})];
+  check(
+    'every loop shares a single document listener',
+    (listeners.get('visibilitychange') || []).length === 1,
+    `listeners=${(listeners.get('visibilitychange') || []).length}`,
+  );
+  for (const l of loops) l.dispose();
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed) process.exit(1);

--- a/tests/js/wav-header.test.mjs
+++ b/tests/js/wav-header.test.mjs
@@ -110,6 +110,10 @@ const node = () => ({
 });
 class FakeCtx {
   constructor() { this.currentTime = 0; this.destination = {}; this.state = "running"; this.audioWorklet = null; }
+  // A real AudioContext is an EventTarget. The engine listens for statechange
+  // on it to recover from a backgrounded tab suspending it (#600).
+  addEventListener() {}
+  removeEventListener() {}
   createGain() { return node(); }
   createAnalyser() { return { fftSize: 0, connect() {}, disconnect() {} }; }
   createBuffer(ch, len, rate) {

--- a/tests/test_model_cache.py
+++ b/tests/test_model_cache.py
@@ -10,7 +10,16 @@ from __future__ import annotations
 
 import pytest
 
+import app.core.model_cache as model_cache
 from app.core.model_cache import load_or_heal
+
+
+@pytest.fixture(autouse=True)
+def _reset_healed():
+    """The once-per-process guard is module state and would leak between tests."""
+    model_cache._healed.clear()
+    yield
+    model_cache._healed.clear()
 
 
 def test_a_good_load_is_left_alone(tmp_path):
@@ -117,3 +126,26 @@ def test_an_unresolvable_cache_path_reports_the_original_failure(tmp_path):
 
     with pytest.raises(RuntimeError, match="the real problem"):
         load_or_heal(lambda: (_ for _ in ()).throw(RuntimeError("the real problem")), stale)
+
+
+def test_a_permanently_broken_load_is_only_healed_once(tmp_path):
+    """beat_this reports every failure as the same ValueError, so a load that a
+    fresh copy cannot fix is indistinguishable from a truncated one. Without a
+    guard that would re-fetch ~100 MB on every attempt for the life of the
+    process."""
+    artifact = tmp_path / "model.ckpt"
+    artifact.write_bytes(b"bad")
+    attempts = []
+
+    def load():
+        attempts.append(1)
+        raise RuntimeError("Could not load the checkpoint given the provided name")
+
+    for _ in range(3):
+        artifact.write_bytes(b"bad")  # as if a re-download landed damaged again
+        with pytest.raises(RuntimeError):
+            load_or_heal(load, lambda: [artifact])
+
+    # 2 for the first call (try, heal, retry), then 1 each for the two after it.
+    assert len(attempts) == 4
+    assert artifact.exists(), "later attempts must not keep deleting it"

--- a/tests/test_model_cache.py
+++ b/tests/test_model_cache.py
@@ -1,0 +1,119 @@
+"""A truncated checkpoint must not be trusted forever (#502).
+
+torch.hub and audio-separator both check only that a cached model file exists,
+never that it loads, so a connection that drops mid-download leaves a file that
+poisons every later run. The symptom is silent: beat detection quietly falls
+back to librosa and nothing tells the user why.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.model_cache import load_or_heal
+
+
+def test_a_good_load_is_left_alone(tmp_path):
+    """The happy path must not go near the cache, or touch the disk at all."""
+    artifact = tmp_path / "model.ckpt"
+    artifact.write_bytes(b"complete")
+    calls = []
+
+    def stale():
+        raise AssertionError("the cache must not be consulted on a successful load")
+
+    result = load_or_heal(lambda: calls.append(1) or "model", stale)
+
+    assert result == "model"
+    assert len(calls) == 1
+    assert artifact.exists()
+
+
+def test_a_truncated_checkpoint_is_discarded_and_refetched(tmp_path):
+    """The bug. First load fails on the bad file, second succeeds without it."""
+    artifact = tmp_path / "beat_this-final0.ckpt"
+    artifact.write_bytes(b"\x50\x4b\x03\x04truncated")
+    attempts = []
+
+    def load():
+        attempts.append(artifact.exists())
+        if artifact.exists():
+            raise RuntimeError("PytorchStreamReader failed reading zip archive")
+        return "healed"
+
+    assert load_or_heal(load, lambda: [artifact]) == "healed"
+    assert attempts == [True, False], "it must retry exactly once, after removing it"
+    assert not artifact.exists()
+
+
+def test_a_load_that_fails_with_nothing_cached_is_not_retried(tmp_path):
+    """Offline with an empty cache is not a corruption, and must not pay twice.
+
+    Retrying here would just spend the same network timeout again to reach the
+    same conclusion, on the machine least able to afford it.
+    """
+    attempts = []
+
+    def load():
+        attempts.append(1)
+        raise RuntimeError("connection refused")
+
+    with pytest.raises(RuntimeError, match="connection refused"):
+        load_or_heal(load, lambda: [tmp_path / "never-downloaded.ckpt"])
+
+    assert len(attempts) == 1
+
+
+def test_a_missing_package_is_never_blamed_on_the_cache(tmp_path):
+    """An ImportError means the wheel is absent. Deleting models cannot help."""
+    artifact = tmp_path / "model.ckpt"
+    artifact.write_bytes(b"fine")
+
+    with pytest.raises(ImportError):
+        load_or_heal(lambda: (_ for _ in ()).throw(ImportError("no beat_this")), lambda: [artifact])
+
+    assert artifact.exists(), "a good cache must survive an unrelated failure"
+
+
+def test_the_second_failure_is_reported_not_swallowed(tmp_path):
+    """Healing is one retry, not a loop. A genuinely dead download still raises."""
+    artifact = tmp_path / "model.ckpt"
+    artifact.write_bytes(b"bad")
+    attempts = []
+
+    def load():
+        attempts.append(1)
+        raise RuntimeError("still broken")
+
+    with pytest.raises(RuntimeError, match="still broken"):
+        load_or_heal(load, lambda: [artifact])
+
+    assert len(attempts) == 2
+
+
+def test_a_cache_directory_is_removed_whole(tmp_path):
+    """audio-separator caches a directory of files, not a single checkpoint."""
+    cache = tmp_path / "audio-separator"
+    cache.mkdir()
+    (cache / "UVR_MDXNET_KARA_2.onnx").write_bytes(b"truncated")
+    (cache / "model_data.json").write_text("{}")
+    attempts = []
+
+    def load():
+        attempts.append(cache.exists())
+        if cache.exists():
+            raise RuntimeError("Unsupported Model File: parameters for MD5 hash ...")
+        return "healed"
+
+    assert load_or_heal(load, lambda: [cache]) == "healed"
+    assert not cache.exists()
+
+
+def test_an_unresolvable_cache_path_reports_the_original_failure(tmp_path):
+    """If we cannot even work out where the cache is, the load error is the news."""
+
+    def stale():
+        raise RuntimeError("torch is not importable")
+
+    with pytest.raises(RuntimeError, match="the real problem"):
+        load_or_heal(lambda: (_ for _ in ()).throw(RuntimeError("the real problem")), stale)


### PR DESCRIPTION

## Credit

@the-observer07 reported #600, forked, and pushed a branch that identified the cause correctly: requestAnimationFrame is not delivered to a hidden tab, and a pending frame is dropped rather than deferred, so the loop needs an external kick to change clocks. The diagnosis here is theirs.
