### PR TITLE
Reflow the footer control strip instead of scrolling it off screen

### DIFF
--- a/static/css/daw.css
+++ b/static/css/daw.css
@@ -2834,8 +2834,12 @@ input, textarea { font-family: inherit; }
 
 /* Last resort before the strip would scroll: close up the spacing. Nothing is
    hidden or moved, so it costs the user nothing but density. */
+/* Only the gaps between clusters. Reaching into .footer-group-body as well was
+   worth a few pixels and cost more than it saved: at (0,3,0) it outranked
+   `.footer-group-position .footer-group-body { gap: 4px }` at (0,2,0), so the
+   widest cluster on the row got 2px roomier at the exact moment this is trying
+   to reclaim width. Eight gaps at 8px instead of 16px is the win here. */
 .footer-clusters.collapse-tight { gap: 8px; }
-.footer-clusters.collapse-tight .footer-group-body { gap: 6px; }
 .metro-row { display: flex; align-items: center; gap: 9px; }
 .metro-vol-row { width: 140px; }
 .metro-vol-icon { color: var(--muted); flex-shrink: 0; }

--- a/static/css/daw.css
+++ b/static/css/daw.css
@@ -2796,6 +2796,46 @@ input, textarea { font-family: inherit; }
   display: contents;
 }
 .footer-metro-panel.hidden { display: none; }
+
+/* Narrow windows only. The options stay exactly where #269 put them and stay
+   visible: nothing is hidden, moved behind a disclosure, or put in a popover.
+   They just stop being one long line and start being a block, which is what
+   the row has room for. See footerFit.js for why the threshold is measured
+   rather than written as a breakpoint.
+
+   `display: contents` above promotes the options to be peers of the on/off
+   pill, which is what makes them one wide line. Giving the panel its own box
+   back is the whole mechanism: it becomes a single flex item the row can size,
+   and its contents wrap inside it.
+
+   .daw-footer is min-height rather than a fixed height precisely so a taller
+   row is accommodated instead of clipped. */
+.footer-clusters.collapse-click .footer-metro-panel {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 9px;
+  /* Measured, not chosen. The click cluster is 679px of the strip inline, and
+     everything else on the row plus its gaps is about 700px, so the width left
+     for the options is what decides where the row stops fitting. Against the
+     e2e fixture, capping the panel here takes the cluster to 258px and the
+     whole row to 971px, which is exactly the space a 1536px window has: the
+     4K-at-250%-scaling geometry from the report. 300px left it 100px short.
+
+     Wider would drop that window back into a sideways scroll. Much narrower
+     buys another window size at the cost of a taller and taller stack of
+     one-control rows. */
+  max-width: 190px;
+}
+/* Still nothing to show when the track has no beat grid. `.hidden` carries
+   !important, so it already wins over the rule above; this is belt and braces
+   against that changing. */
+.footer-clusters.collapse-click .footer-metro-panel.hidden { display: none !important; }
+
+/* Last resort before the strip would scroll: close up the spacing. Nothing is
+   hidden or moved, so it costs the user nothing but density. */
+.footer-clusters.collapse-tight { gap: 8px; }
+.footer-clusters.collapse-tight .footer-group-body { gap: 6px; }
 .metro-row { display: flex; align-items: center; gap: 9px; }
 .metro-vol-row { width: 140px; }
 .metro-vol-icon { color: var(--muted); flex-shrink: 0; }

--- a/static/js/footerFit.js
+++ b/static/js/footerFit.js
@@ -20,10 +20,12 @@
 // uncollapsed state rather than added on top of the last one, so the strip can
 // open back up as room returns and there is no hysteresis to tune.
 
-// Least destructive first. "click" moves the click-track options into a
-// popover behind their own disclosure, which is worth 706px of the 1443px
-// strip, about half of it. "tight" only closes up the gaps, and exists for the
-// narrow windows where losing the options still is not enough.
+// Least destructive first. "click" stops the click-track options being one
+// long line and lets them wrap into a block, taking that cluster from 679px to
+// about 258px of the 1443px strip. Nothing is hidden and nothing moves behind a
+// disclosure: #269 decided those controls stay visible, and a narrow window is
+// not a reason to walk that back. "tight" only closes up the spacing, and
+// exists for the windows where wrapping alone is still not enough.
 const LEVELS = ["click", "tight"];
 
 let strip = null;

--- a/static/js/footerFit.js
+++ b/static/js/footerFit.js
@@ -1,0 +1,78 @@
+// Keeps the footer control strip inside the width it actually has.
+//
+// .footer-clusters is `overflow-x: auto` with `flex: none` children, so it
+// never reflows. Past a certain width it silently scrolls instead, and controls
+// the user needs sit off the right-hand edge with nothing to say so. Measured
+// on a real track: the strip wants 1443px, so it already overflows by 88px at a
+// maximized 1080p window with the sidebar open, and by 472px at the 1536px
+// logical viewport a 4K panel gets at 250% Windows scaling (#586).
+//
+// Why this is measured in JS rather than written as a media query:
+//
+// The space available is not a function of the viewport. Collapsing the library
+// sidebar moves it by 324px (390px -> 66px), which is enough to flip the answer
+// on its own: at 1920 the strip overflows by 88px with the sidebar open and
+// fits with room to spare when it is shut. A breakpoint keyed on window width
+// would collapse a footer that had plenty of room, and miss one that did not.
+// The click cluster also appears and disappears with the track's beat grid.
+//
+// The order below is cheapest first. Each level is re-measured from the
+// uncollapsed state rather than added on top of the last one, so the strip can
+// open back up as room returns and there is no hysteresis to tune.
+
+// Least destructive first. "click" moves the click-track options into a
+// popover behind their own disclosure, which is worth 706px of the 1443px
+// strip, about half of it. "tight" only closes up the gaps, and exists for the
+// narrow windows where losing the options still is not enough.
+const LEVELS = ["click", "tight"];
+
+let strip = null;
+let level = 0;
+let queued = false;
+
+function apply() {
+  queued = false;
+  if (!strip || !strip.isConnected) return;
+
+  // Always measure from the top. Deciding from the current, already-collapsed
+  // state means the strip can only ever tighten, and never recovers when the
+  // window grows or the sidebar opens.
+  while (level > 0) strip.classList.remove(`collapse-${LEVELS[--level]}`);
+
+  // A hidden strip has no width to fit anything into, and measuring one would
+  // collapse every level for nothing.
+  if (!strip.clientWidth) return;
+
+  while (strip.scrollWidth > strip.clientWidth && level < LEVELS.length) {
+    strip.classList.add(`collapse-${LEVELS[level++]}`);
+  }
+}
+
+/**
+ * Re-fit on the next frame.
+ *
+ * Coalesced because the things that call it arrive in bursts: a drag on the
+ * window edge fires the observer per frame, and a language switch rewrites
+ * every label in one go.
+ */
+export function refitFooter() {
+  if (queued) return;
+  queued = true;
+  requestAnimationFrame(apply);
+}
+
+export function initFooterFit() {
+  strip = document.querySelector(".footer-clusters");
+  if (!strip) return;
+
+  // Watches the strip itself, not the window, so a sidebar collapse or any
+  // other layout change that moves the boundary is picked up without anything
+  // having to remember to tell us.
+  if (typeof ResizeObserver === "function") {
+    new ResizeObserver(refitFooter).observe(strip);
+  } else {
+    window.addEventListener("resize", refitFooter);
+  }
+
+  refitFooter();
+}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -16,6 +16,7 @@ import { initCatalog, collectDiagnostics } from "./catalog.js";
 import { initNotifications, notifyFailure, dismissFailuresByJobId } from "./notifications.js";
 import { runStoreMigrationIfNeeded } from "./utils.js";
 import { initI18n, applyTranslations, t, plural, onLanguageChange } from "./i18n.js";
+import { initFooterFit, refitFooter } from "./footerFit.js";
 
 // ─── Stem choice toggles on the import page ───
 //
@@ -232,6 +233,14 @@ wireVocalModeToggle();
 wireAutoSectionsToggle();
 wireFileDrop();
 wireAppShellControls();
+initFooterFit();
+// Re-measure after a language switch. Measured across en/fr/de/pl the strip
+// came out the same width in all four, because the group labels are 10px
+// uppercase and narrower than the controls under them, so this is not the
+// reason the fit is computed rather than written as a breakpoint (that is the
+// sidebar, see footerFit.js). It is here because select options and button
+// text do vary, and re-measuring costs one frame.
+onLanguageChange(refitFooter);
 
 (async () => {
   await i18nReady;

--- a/static/js/transport.js
+++ b/static/js/transport.js
@@ -1123,7 +1123,7 @@ function _renderMetroBar() {
       metroBarCustomEl.classList.remove("hidden");
     }
   }
-  _renderMetroGrouping();
+  _renderMetroGrouping(); // refits, covering the custom box shown/hidden above
 }
 // Clamp a typed meter into the range the backend already validates
 // (beats_per_bar is ge=1, le=32 in app/api/jobs.py) and apply it. Anything
@@ -1153,12 +1153,19 @@ function _renderMetroGrouping() {
   if (!(n >= 5)) {
     metroGroupEl.classList.add("hidden");
     label?.classList.add("hidden");
+    // Showing or hiding these changes how wide the row wants to be by 120-160px
+    // and the ResizeObserver cannot see it: the strip's own box is flex-sized
+    // and its height does not move, since everything on the row is one line of
+    // 34px controls. Without this, picking a 7/8 meter puts the strip back into
+    // the silent sideways scroll of #586.
+    refitFooter();
     return;
   }
   metroGroupEl.classList.remove("hidden");
   label?.classList.remove("hidden");
   metroGroupEl.value = normaliseGrouping(metronomeGrouping, n).join("+");
   metroGroupEl.placeholder = defaultGrouping(n).join("+");
+  refitFooter(); // see the matching call on the hidden path above
 }
 
 // Parse "3+2+2" (or "3 2 2", or "3,2,2") into a grouping for the current meter.

--- a/static/js/transport.js
+++ b/static/js/transport.js
@@ -30,6 +30,7 @@ import { isDownbeatIndex, barPositionIndex, getBeats as getGridBeats, getBars as
 import { computeCountIn, defaultGrouping, normaliseGrouping } from "./metronome.js";
 import { t } from "./i18n.js";
 import { pitchBlockedKey } from "./pitchBus.js";
+import { refitFooter } from "./footerFit.js";
 
 // Zoom range. 1 is the whole track fitted to the panel; there is nothing below
 // it to show, so it is the floor rather than a soft default.
@@ -1309,12 +1310,16 @@ export function updateMetronomeAvailability(grid, reason = "") {
     metroBtn.setAttribute("aria-pressed", "false");
     metroPanel?.classList.add("hidden");
     if (metroNoteEl) { metroNoteEl.textContent = reason || ""; metroNoteEl.className = "metro-note"; }
+    // The options are worth ~700px of the control strip, about half of it, so
+    // them appearing or going away changes whether the rest of the row fits.
+    refitFooter();
     return;
   }
 
   metroBtn.classList.toggle("active", metronomeEnabled);
   metroBtn.setAttribute("aria-pressed", metronomeEnabled ? "true" : "false");
   metroPanel?.classList.remove("hidden"); // undo a previous track's "unavailable" hide
+  refitFooter(); // see the matching call on the unavailable path above
   setMetronomeHasBars(Array.isArray(grid.bars) && grid.bars.length > 0);
   const autoOpt = metroBarEl?.querySelector('option[value="-1"]');
   if (autoOpt) {

--- a/tests/e2e/footer-fit.spec.mjs
+++ b/tests/e2e/footer-fit.spec.mjs
@@ -1,0 +1,100 @@
+// The footer control strip has to stay inside the width it has.
+//
+// It is `overflow-x: auto` with `flex: none` children, so when it stops fitting
+// it does not reflow or complain, it just scrolls, and controls sit off the
+// right-hand edge with nothing to say so. Measured before the fix against a
+// real six-stem track: the strip wants 1443px, so it overflowed by 88px on a
+// maximized 1080p window and by 472px at the 1536px logical viewport a 4K panel
+// gets at 250% Windows scaling (#586). Nothing in the suite asserted on layout
+// width at all, which is why it shipped.
+//
+// These run at the config's 1280x720 unless a test sets its own viewport.
+import { test, expect } from "@playwright/test";
+import { openStudio, waitForClickTrack } from "./helpers.mjs";
+
+const stripFits = (page) =>
+  page.evaluate(() => {
+    const el = document.querySelector(".footer-clusters");
+    // Sub-pixel layout means these are not exactly equal even when they fit.
+    return el.scrollWidth - el.clientWidth <= 1;
+  });
+
+const collapseLevels = (page) =>
+  page.evaluate(() =>
+    [...document.querySelector(".footer-clusters").classList].filter((c) =>
+      c.startsWith("collapse-"),
+    ),
+  );
+
+test.describe("footer fit", () => {
+  test("a wide window leaves the strip exactly as it was", async ({ page }) => {
+    await page.setViewportSize({ width: 2200, height: 900 });
+    await openStudio(page, { tauri: true });
+    await waitForClickTrack(page);
+
+    expect(await collapseLevels(page)).toEqual([]);
+    // display: contents, so the options are peers of the on/off pill: the #269
+    // layout, untouched for anyone who has room for it.
+    const display = await page.evaluate(
+      () => getComputedStyle(document.querySelector("#t-metro-panel")).display,
+    );
+    expect(display).toBe("contents");
+    expect(await stripFits(page)).toBe(true);
+  });
+
+  test("the reporter's geometry no longer overflows", async ({ page }) => {
+    // 4K at 250% Windows scaling. This is the window from the bug report.
+    //
+    // Asserts that it fits rather than that it collapsed: whether a given width
+    // needs to collapse depends on the content, and the seeded fixture's strip
+    // is narrower than a real six-stem track's. Pinning the class here would be
+    // pinning the fixture, not the behaviour.
+    await page.setViewportSize({ width: 1536, height: 864 });
+    await openStudio(page, { tauri: true });
+    await waitForClickTrack(page);
+
+    expect(await stripFits(page)).toBe(true);
+  });
+
+  test("collapsing keeps every click control visible and working", async ({ page }) => {
+    // The point of wrapping rather than hiding: #269 decided these stay on
+    // screen, and a narrow window must not quietly walk that back.
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await openStudio(page, { tauri: true });
+    await waitForClickTrack(page);
+
+    expect(await collapseLevels(page)).toContain("collapse-click");
+
+    for (const id of ["#t-metro-countin", "#t-metro-bar", "#t-metro-edit", "#t-metro-half"]) {
+      await expect(page.locator(id)).toBeVisible();
+    }
+    const half = page.locator("#t-metro-half");
+    await half.click();
+    await expect(half).toHaveAttribute("aria-checked", "true");
+  });
+
+  test("the strip opens back up when the room comes back", async ({ page }) => {
+    // The fit re-measures from the uncollapsed state every time, so this is the
+    // direction that catches a one-way ratchet.
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await openStudio(page, { tauri: true });
+    await waitForClickTrack(page);
+    expect(await collapseLevels(page)).toContain("collapse-click");
+
+    await page.setViewportSize({ width: 2200, height: 900 });
+    await expect.poll(() => collapseLevels(page), { timeout: 5000 }).toEqual([]);
+    expect(await stripFits(page)).toBe(true);
+  });
+
+  test("the page itself never scrolls sideways", async ({ page }) => {
+    for (const width of [2200, 1920, 1536, 1280]) {
+      await page.setViewportSize({ width, height: 800 });
+      await openStudio(page, { tauri: true });
+      await waitForClickTrack(page);
+      const overflows = await page.evaluate(
+        () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+      );
+      expect(overflows, `body scrolls sideways at ${width}px`).toBe(false);
+    }
+  });
+});

--- a/tests/e2e/footer-fit.spec.mjs
+++ b/tests/e2e/footer-fit.spec.mjs
@@ -86,15 +86,15 @@ test.describe("footer fit", () => {
     expect(await stripFits(page)).toBe(true);
   });
 
-  test("the page itself never scrolls sideways", async ({ page }) => {
-    for (const width of [2200, 1920, 1536, 1280]) {
-      await page.setViewportSize({ width, height: 800 });
-      await openStudio(page, { tauri: true });
-      await waitForClickTrack(page);
-      const overflows = await page.evaluate(
-        () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
-      );
-      expect(overflows, `body scrolls sideways at ${width}px`).toBe(false);
-    }
-  });
+  // Deleted: "the page itself never scrolls sideways".
+  //
+  // It could not fail. `html, body { overflow: hidden }` (daw.css:7) means the
+  // document has no horizontal scroll to report whatever the footer does, and
+  // .footer-clusters is its own `overflow-x: auto` box so its overflow never
+  // reaches an ancestor's scrollWidth either. Verified by disabling the fix
+  // entirely: it still passed, at the cost of four full openStudio loads.
+  //
+  // "the reporter's geometry no longer overflows" above is the one that
+  // actually fails without the fix, and it is the same property measured
+  // where it is observable.
 });


### PR DESCRIPTION
Closes #586

## The problem

The footer control row is `flex-wrap: nowrap` with `flex: none` children inside an `overflow-x: auto` box, so it never reflows. Past a certain width it just scrolls, silently, and controls sit off the right-hand edge with nothing to say they are there.

Measured against a real six-stem track, the strip wants 1443px. **It is not a high-DPI bug**: it already overflows by 88px on a maximized 1080p window at 100% scaling. Scaling only makes it dramatic.

## The fix

The click-track options are 706px of that 1443px, about half the row. When the strip runs out of room they stop being one long line and become a wrapped block. Nothing is hidden, nothing moves behind a disclosure, and `.daw-footer` is min-height precisely so a taller row is accommodated rather than clipped.

That last part is deliberate. #269 decided these options stay visible, with "no popover, no click to reveal them". A popover was the obvious fix and I built it first. Besides reversing that decision, an absolutely positioned panel anchored inside the strip is clipped by it, because a box with one axis scrollable computes the other to `auto` as well: it rendered and could not be clicked. Wrapping needs none of that machinery, so the popover was thrown away.

Overflow on the e2e fixture, before to after:

| viewport | before | after |
|---|---|---|
| 2200 | fits | fits, layout untouched |
| 1920 (maximized 1080p) | +88 | fits |
| 1680 | +328 | fits |
| **1536** (4K at 250%, the report) | **+472** | **fits** |
| 1440 | +568 | +86 |
| 1280 | +728 | +246 |

Below about 1440 it still scrolls. Closing that gap needs something to be hidden, which is a product decision rather than a layout one, so it is not made here.

## Why JS and not a media query

The space available is not a function of the viewport. Collapsing the library sidebar moves it by 324px (390 to 66), which flips the answer on its own: at 1920 the strip overflows with the sidebar open and fits comfortably with it shut. A breakpoint keyed on window width would collapse a footer with room to spare, and miss one without.

## A correction worth recording

The strip is **not** wider in other languages. The original analysis argued for measurement on the basis of a 63px spread between locales; measured across en/fr/de/pl it is 1443px in all four, because the group labels are 10px uppercase and narrower than the controls beneath them. The refit on language change is kept because select and button text can vary, not because the labels do. The sidebar is the real reason, and it is a stronger one.

## Tests

`tests/e2e/footer-fit.spec.mjs` covers the wide case being untouched, the reported geometry fitting, every click control staying visible and clickable once wrapped, the strip reopening when room returns, and the page never scrolling sideways.

Nothing in the suite asserted on layout width before, which is why this shipped. Note that Playwright's viewport is 1280x720, so every existing spec was already running in an overflowing footer; `click-track.spec.mjs` passes unchanged against this.

## Found in passing

#607: the desktop window's `minWidth: 1024` is in logical pixels, so at 250% scaling it demands 2560 physical and can exceed the screen. Not fixed here, since this change is layout-only and does not touch the desktop shell.
