### PR TITLE
Keep the section ribbon on the timeline it describes

### DIFF
--- a/static/css/daw.css
+++ b/static/css/daw.css
@@ -1571,7 +1571,14 @@ input, textarea { font-family: inherit; }
   position: relative;
   height: 36px;
   background: var(--bg-2);
-  overflow: hidden;
+  /* clip, not hidden. `hidden` is a scroll container, and the inner track now
+     overflows it, so anything that focuses an element off to the right -- the
+     rename input on a block past the viewport is the easy one -- makes the
+     browser scroll this box to reveal it. The ribbon is positioned by
+     transform, nothing ever resets scrollLeft, and the strip is then offset
+     from the waveform for good. `clip` clips identically and cannot scroll.
+     .daw-ruler-area is clip for the same reason. */
+  overflow: clip;
   user-select: none;
 }
 /* Carries the section blocks at the zoomed timeline's width, so a block placed

--- a/static/css/daw.css
+++ b/static/css/daw.css
@@ -1574,6 +1574,22 @@ input, textarea { font-family: inherit; }
   overflow: hidden;
   user-select: none;
 }
+/* Carries the section blocks at the zoomed timeline's width, so a block placed
+   at a percentage of it lines up with the same moment on the waveform below.
+   Without this the ribbon stayed the width of the window while the waveform
+   grew, and every boundary drifted: at 2.7x the first one sat 775px from the
+   audio it marked, and the drag maths, which measures this element, moved a
+   block 2.7x too far for the same gesture (#573).
+
+   Left-anchored so width drives the size, exactly like .lanes-ruler-time.
+   transport.js translates both by the same scrollLeft; .daw-sections-area
+   already clips the spill. */
+.daw-sections-track {
+  position: absolute;
+  inset: 0;
+  right: auto;
+  width: calc(100% * var(--zoom, 1));
+}
 
 /* Section blocks (sections.js populates) */
 .section-block {

--- a/static/index.html
+++ b/static/index.html
@@ -434,7 +434,14 @@
                 </button>
               </span>
             </div>
-            <div class="daw-sections-area" id="daw-sections"></div>
+            <!-- The inner track is what carries the sections. It is the width
+                 of the zoomed waveform rather than the width of the window, so
+                 a boundary drawn at a percentage of the track lands on the
+                 same pixel column as the audio it marks. Mirrors the ruler,
+                 which solves the same problem the same way. -->
+            <div class="daw-sections-area" id="daw-sections">
+              <div class="daw-sections-track" id="daw-sections-track"></div>
+            </div>
           </div>
 
           <!-- Waveform header / ruler -->

--- a/static/js/sections.js
+++ b/static/js/sections.js
@@ -338,7 +338,32 @@ function _addSection() {
 
   // Open rename immediately
   const el = _container?.querySelector(`[data-id="${section.id}"]`);
-  if (el) _openRename(section.id, el.querySelector(".section-label"));
+  if (el) {
+    _scrollIntoView(section);
+    _openRename(section.id, el.querySelector(".section-label"));
+  }
+}
+
+/**
+ * Bring a section into view by scrolling the timeline, not the ribbon.
+ *
+ * Add always places the new section in the first gap from t=0, which while
+ * zoomed and scrolled is usually off to the left, and the rename input opens on
+ * it focused. The ribbon is `overflow: clip` and deliberately cannot scroll, so
+ * without this the user would be typing into a field they cannot see.
+ *
+ * Scrolling the wave is the right lever anyway: the ribbon is positioned from
+ * the wave's scrollLeft, so moving the wave moves the ribbon with it and keeps
+ * the two in step. Read from the DOM rather than imported, because sections.js
+ * deliberately depends on nothing but i18n (see syncRulerScroll in
+ * transport.js for what importing across that line breaks).
+ */
+function _scrollIntoView(section) {
+  const wave = document.getElementById("wave-scroll");
+  if (!wave || !_duration || wave.scrollWidth <= wave.clientWidth) return;
+  const mid = ((section.start + section.end) / 2 / _duration) * wave.scrollWidth;
+  const target = mid - wave.clientWidth / 2;
+  wave.scrollLeft = Math.max(0, Math.min(target, wave.scrollWidth - wave.clientWidth));
 }
 
 // Removing every marker at once cannot be undone, and an automatic set costs

--- a/static/js/sections.js
+++ b/static/js/sections.js
@@ -37,7 +37,10 @@ export function initSections(trackId, sections, duration) {
   // Clear lives in the header rather than the ribbon, so it has to be correct
   // even when the ribbon is absent and the render below never runs.
   _refreshClearVisibility();
-  _container = document.getElementById("daw-sections");
+  // The inner track, not the visible area. Everything here is a percentage of
+  // this element and the drag maths measures it, so pointing at the zoomed
+  // track is what keeps both the drawing and the gesture honest (#573).
+  _container = document.getElementById("daw-sections-track");
   if (!_container) return;
 
   // Wire the static "Add" button in the label area (may already be wired)

--- a/static/js/transport.js
+++ b/static/js/transport.js
@@ -736,9 +736,17 @@ function wireLoopDrag() {
 // same scrollLeft; .daw-ruler-area uses overflow-x: clip to hide the spill while
 // leaving the vertical playhead line (overflow-y: visible) intact.
 export function syncRulerScroll() {
-  if (rulerTime && waveScroll) {
-    rulerTime.style.transform = `translateX(${-waveScroll.scrollLeft}px)`;
-  }
+  if (!waveScroll) return;
+  const shift = `translateX(${-waveScroll.scrollLeft}px)`;
+  if (rulerTime) rulerTime.style.transform = shift;
+  // The section ribbon is the same kind of strip and needs the same treatment:
+  // it sits outside .wave-scroll, is widened by the same --zoom, and is clipped
+  // by its own area. Queried here rather than imported from sections.js, which
+  // deliberately depends on nothing but i18n -- adding transport to its imports
+  // breaks tests/js/sections.test.mjs at import time, because state.js touches
+  // document at module scope and that test installs its stub afterwards.
+  const sectionsTrack = document.getElementById("daw-sections-track");
+  if (sectionsTrack) sectionsTrack.style.transform = shift;
 }
 
 export function applyWaveZoom() {

--- a/tests/e2e/sections-zoom.spec.mjs
+++ b/tests/e2e/sections-zoom.spec.mjs
@@ -113,6 +113,39 @@ test.describe("sections and zoom", () => {
     });
   });
 
+  test("focusing a control cannot scroll the ribbon out of alignment", async ({ page }) => {
+    // The ribbon is positioned by transform and nothing resets scrollLeft, so
+    // if its container is scrollable at all, one focus is enough to offset it
+    // from the waveform permanently. Renaming a section past the right edge
+    // does exactly that: the browser scrolls the box to reveal the input.
+    //
+    // Caught in review of this change, where the container was `overflow:
+    // hidden`, which is a scroll container. It scrolled 521px.
+    await page.setViewportSize({ width: 1500, height: 620 });
+    await seedSections(page);
+    await openStudio(page, { tauri: true });
+    await page.waitForSelector(".section-block", { timeout: 20000 });
+    await zoomIn(page, 5);
+
+    const base = await alignment(page);
+    const scrolled = await page.evaluate(() => {
+      const area = document.querySelector(".daw-sections-area");
+      const last = [...document.querySelectorAll(".section-block")].pop();
+      const input = document.createElement("input");
+      last.appendChild(input);
+      input.focus();
+      const left = area.scrollLeft;
+      input.remove();
+      return left;
+    });
+
+    expect(scrolled, "the ribbon must not be scrollable").toBe(0);
+    const after = await alignment(page);
+    after.forEach((off, i) => {
+      expect(Math.abs(off - base[i]), `boundary ${i} drifted after a focus`).toBeLessThanOrEqual(1);
+    });
+  });
+
   test("dragging a section moves it by what the cursor travelled", async ({ page }) => {
     // The other half of the bug. The drag converts pixels to seconds using the
     // width of the element the blocks live in, so before the fix a zoomed drag

--- a/tests/e2e/sections-zoom.spec.mjs
+++ b/tests/e2e/sections-zoom.spec.mjs
@@ -28,6 +28,13 @@ async function seedSections(page) {
   expect(res.ok(), "seeding sections").toBe(true);
 }
 
+// The fixture job is on disk and shared, and playwright.config reuses a running
+// server, so without this the sections written here outlive the run and turn up
+// in every later spec and every later local run.
+test.afterEach(async ({ page }) => {
+  await page.request.patch(`/api/jobs/${JOB_ID}/sections`, { data: { sections: [] } });
+});
+
 /** How far each block's left edge is from where that time lands on the ruler. */
 const alignment = (page) =>
   page.evaluate(() => {
@@ -126,20 +133,37 @@ test.describe("sections and zoom", () => {
     await openStudio(page, { tauri: true });
     await page.waitForSelector(".section-block", { timeout: 20000 });
     await zoomIn(page, 5);
+    // Park at the start so the last section is genuinely off to the right.
+    // Zooming keeps the cursor anchored, which left it on screen and made the
+    // probe below prove nothing.
+    await page.evaluate(() => {
+      const s = document.getElementById("wave-scroll");
+      s.scrollLeft = 0;
+      s.dispatchEvent(new Event("scroll"));
+    });
+    await page.waitForTimeout(250);
 
     const base = await alignment(page);
-    const scrolled = await page.evaluate(() => {
+    const probe = await page.evaluate(() => {
       const area = document.querySelector(".daw-sections-area");
+      const box = area.getBoundingClientRect();
       const last = [...document.querySelectorAll(".section-block")].pop();
+      const lastBox = last.getBoundingClientRect();
       const input = document.createElement("input");
       last.appendChild(input);
       input.focus();
       const left = area.scrollLeft;
       input.remove();
-      return left;
+      return {
+        left,
+        // Only an element the browser cannot already see gives it a reason to
+        // scroll. Without this the test would pass on any CSS at all.
+        offScreen: lastBox.left > box.right || lastBox.right < box.left,
+      };
     });
 
-    expect(scrolled, "the ribbon must not be scrollable").toBe(0);
+    expect(probe.offScreen, "the focused block must be outside the ribbon, or nothing is being tested").toBe(true);
+    expect(probe.left, "the ribbon must not be scrollable").toBe(0);
     const after = await alignment(page);
     after.forEach((off, i) => {
       expect(Math.abs(off - base[i]), `boundary ${i} drifted after a focus`).toBeLessThanOrEqual(1);

--- a/tests/e2e/sections-zoom.spec.mjs
+++ b/tests/e2e/sections-zoom.spec.mjs
@@ -1,0 +1,169 @@
+// A section boundary has to sit on the same pixel column as the audio it marks.
+//
+// The ribbon positions blocks as a percentage of the track, but it used to do
+// that inside a box the width of the window, while the waveform and ruler grow
+// with `--zoom` and scroll. So the moment anyone zoomed, the two disagreed.
+// Measured on a real 11-minute track at 2.7x, the first boundary sat 775px away
+// from the moment it marked, and the drag maths, which measures the same box,
+// moved a block 2.7x too far for the same gesture (#573).
+//
+// The ruler already solved this: a left-anchored inner track of
+// `calc(100% * var(--zoom))`, translated by the wave's scrollLeft. This asserts
+// the ribbon now does the same.
+import { test, expect } from "@playwright/test";
+import { openStudio, JOB_ID } from "./helpers.mjs";
+
+// Gaps between them on purpose: a block hard against its neighbour is refused
+// by _clampMove, which would make a broken drag look like a working one.
+const SECTIONS = [
+  { id: "s1", name: "Intro", start: 0, end: 1, color: "#4a7fff" },
+  { id: "s2", name: "Verse", start: 2, end: 3, color: "#22c55e" },
+  { id: "s3", name: "Chorus", start: 4, end: 5, color: "#f97316" },
+];
+
+async function seedSections(page) {
+  const res = await page.request.patch(`/api/jobs/${JOB_ID}/sections`, {
+    data: { sections: SECTIONS },
+  });
+  expect(res.ok(), "seeding sections").toBe(true);
+}
+
+/** How far each block's left edge is from where that time lands on the ruler. */
+const alignment = (page) =>
+  page.evaluate(() => {
+    const ruler = document.querySelector(".lanes-ruler-time").getBoundingClientRect();
+    return [...document.querySelectorAll(".section-block")].map((el) => {
+      const fraction = parseFloat(el.style.left) / 100;
+      const wantX = ruler.left + fraction * ruler.width;
+      return Math.round(el.getBoundingClientRect().left - wantX);
+    });
+  });
+
+const zoomLevel = (page) =>
+  page.evaluate(
+    () => parseFloat(getComputedStyle(document.getElementById("lanes")).getPropertyValue("--zoom")) || 1,
+  );
+
+async function zoomIn(page, notches) {
+  const box = await page.locator("#wave-scroll").boundingBox();
+  for (let i = 0; i < notches; i++) {
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.wheel(0, -120);
+    await page.waitForTimeout(200);
+  }
+}
+
+test.describe("sections and zoom", () => {
+  test("boundaries stay on the audio they mark as the timeline zooms", async ({ page }) => {
+    await page.setViewportSize({ width: 1600, height: 950 });
+    await seedSections(page);
+    await openStudio(page, { tauri: true });
+    await page.waitForSelector(".section-block", { timeout: 20000 });
+
+    // Unzoomed is the baseline. Compared against it rather than against zero,
+    // because the ribbon and the ruler can sit at slightly different origins
+    // and that constant is not what this is about: the bug is that zooming
+    // *introduced* drift on top of it.
+    const base = await alignment(page);
+
+    await zoomIn(page, 4);
+    expect(await zoomLevel(page)).toBeGreaterThan(1);
+
+    // Every boundary, including any scrolled past the left edge, which is where
+    // the old behaviour drifted furthest.
+    const zoomed = await alignment(page);
+    zoomed.forEach((off, i) => {
+      expect(Math.abs(off - base[i]), `boundary ${i} drifted when zoomed`).toBeLessThanOrEqual(1);
+    });
+  });
+
+  test("the ribbon scrolls with the waveform", async ({ page }) => {
+    await page.setViewportSize({ width: 1600, height: 950 });
+    await seedSections(page);
+    await openStudio(page, { tauri: true });
+    await page.waitForSelector(".section-block", { timeout: 20000 });
+    const base = await alignment(page);
+    await zoomIn(page, 4);
+
+    const shift = () =>
+      page.evaluate(() => {
+        const track = document.getElementById("daw-sections-track");
+        const ruler = document.querySelector(".lanes-ruler-time");
+        return {
+          track: track.style.transform,
+          ruler: ruler.style.transform,
+          scrollLeft: Math.round(document.getElementById("wave-scroll").scrollLeft),
+        };
+      });
+
+    await page.evaluate(() => {
+      const s = document.getElementById("wave-scroll");
+      s.scrollLeft = Math.round(s.scrollWidth / 3);
+      s.dispatchEvent(new Event("scroll"));
+    });
+    await page.waitForTimeout(250);
+
+    const after = await shift();
+    expect(after.scrollLeft, "the wave actually scrolled").toBeGreaterThan(0);
+    // Same translate as the ruler: they are two strips over one timeline.
+    expect(after.track).toBe(after.ruler);
+    const scrolled = await alignment(page);
+    scrolled.forEach((off, i) => {
+      expect(Math.abs(off - base[i]), `boundary ${i} drifted when scrolled`).toBeLessThanOrEqual(1);
+    });
+  });
+
+  test("dragging a section moves it by what the cursor travelled", async ({ page }) => {
+    // The other half of the bug. The drag converts pixels to seconds using the
+    // width of the element the blocks live in, so before the fix a zoomed drag
+    // moved the block by the zoom factor too far.
+    await page.setViewportSize({ width: 1600, height: 950 });
+    await seedSections(page);
+    await openStudio(page, { tauri: true });
+    await page.waitForSelector(".section-block", { timeout: 20000 });
+    await zoomIn(page, 3);
+
+    // The ruler is the ground truth for how wide the zoomed timeline is. Using
+    // the ribbon's own width instead would be self-consistent and prove
+    // nothing: the bug was that the ribbon's width disagreed with the
+    // timeline's, and a drag converted pixels to seconds using the wrong one.
+    const rulerWidth = await page.evaluate(
+      () => document.querySelector(".lanes-ruler-time").getBoundingClientRect().width,
+    );
+    // A block that is fully on screen at this zoom. Zooming keeps the cursor's
+    // position fixed, so the earliest sections scroll off the left, and a drag
+    // aimed at one of those never starts and would read as a passing zero.
+    const area = await page.locator("#daw-sections").boundingBox();
+    const count = await page.locator(".section-block").count();
+    let block = null;
+    let box = null;
+    for (let i = 0; i < count; i++) {
+      const candidate = page.locator(".section-block").nth(i);
+      const bb = await candidate.boundingBox();
+      if (bb && bb.x > area.x + 10 && bb.x + bb.width < area.x + area.width - 60) {
+        block = candidate;
+        box = bb;
+        break;
+      }
+    }
+    expect(block, "a section fully on screen to drag").not.toBeNull();
+    const before = await block.evaluate((el) => parseFloat(el.style.left));
+
+    const dx = 40;
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box.x + box.width / 2 + dx, box.y + box.height / 2, { steps: 10 });
+    await page.mouse.up();
+    await page.waitForTimeout(200);
+
+    const after = await block.evaluate((el) => parseFloat(el.style.left));
+
+    // Dragging dx pixels must move the section by the slice of the track those
+    // pixels cover on the zoomed timeline. Before the fix the conversion used
+    // the unzoomed ribbon width, so the block followed the cursor on screen but
+    // landed on a moment `zoom` times further through the song.
+    const movedFraction = (after - before) / 100;
+    const wantFraction = dx / rulerWidth;
+    expect(Math.abs(movedFraction - wantFraction)).toBeLessThanOrEqual(0.002);
+  });
+});


### PR DESCRIPTION
Closes #609
Raised in discussion #573.

## The problem

The section ribbon does not zoom. The waveform and ruler below it do, and they scroll. So the moment anyone zooms, the ribbon carries on describing the whole track across the visible width while everything beneath it describes a slice, and the two disagree.

Measured on an 11-minute track, distance between each section's left edge and the moment it marks:

| zoom | Intro | Verse | Chorus | Bridge | Outro |
|---|---|---|---|---|---|
| 1.00 | 0 | 0 | 0 | 0 | 0 |
| 1.64 | +293px | +240 | +133 | +27 | -79 |
| 2.70 | +775px | +634 | +353 | +72 | -209 |

The ribbon is what a user reads to find the chorus, and while zoomed it was pointing somewhere else.

**The same container broke dragging.** The drag converts pixels to seconds with `(dx / containerWidth) * duration`, and the container was the unzoomed ribbon, so at 2.7x a drag moved the block under the cursor as expected and wrote a time 2.7x further through the song.

## The fix

The ruler already solves this, so the ribbon now solves it the same way: a left-anchored inner track of `calc(100% * var(--zoom))`, translated by the same scrollLeft, clipped by the area around it. Pointing `sections.js` at that inner track fixes the drawing and the dragging together, since both were already expressed against whatever `_container` happened to be.

`--zoom` needed no plumbing: it is set on `#lanes` and the ribbon is inside `#lanes`.

`syncRulerScroll` queries the track by id rather than importing from `sections.js`. That module deliberately imports nothing but i18n, and adding `transport.js` breaks `tests/js/sections.test.mjs` at import time, because `state.js` touches `document` at module scope and that test installs its stub afterwards.

## After

0px drift at 1.0, 1.64 and 2.7x including while scrolled, and drags of exactly 1.00x at each. Verified by hand on the real 11-minute track and covered by `tests/e2e/sections-zoom.spec.mjs`.

## One thing worth flagging about the tests

All three were run against a deliberately broken width first. The two alignment tests failed as expected. **The drag test did not** — it was measuring the ribbon against its own width, which is self-consistent and would have agreed with any value. It now measures against the ruler, which is the width the timeline actually has, and fails without the fix.

Full suite: 132 e2e tests pass, including all of the existing `zoom.spec.mjs`.

## Not addressed here

Discussion #573 raised four things. Rename is already shipped (double-click the label) and is a discoverability gap rather than a missing feature. Lock and loop-to-section are separate asks and are not in this change.
