### PR TITLE
Stop Collapse "All" taking the library with it

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -143,10 +143,14 @@
                struck once everything is away. The trap is the threshold: read
                as "is anything hidden" it struck itself through the moment you
                hid Analysis on its own, which looks like you pressed it. It is
-               off only when all four are. -->
+               off only when all three are.
+
+               The library is not one of them, and not by omission: "All" used
+               to collapse it too, and nothing in this row could put it back
+               (#588). Its control lives in the rail. -->
           <span class="daw-panel-toggles-label" data-i18n="panels.collapse">Collapse</span>
           <button class="daw-panel-toggle daw-panel-toggle-all" type="button" data-panel-all aria-pressed="true"
-                  title="Show or hide every panel and the library" data-i18n-title="panels.allTitle" data-i18n-aria-label="panels.allTitle">
+                  title="Show or hide every panel" data-i18n-title="panels.allTitle" data-i18n-aria-label="panels.allTitle">
             <span data-i18n="panels.all">All</span>
           </button>
           <span class="daw-panel-toggles-sep" aria-hidden="true">-</span>

--- a/static/js/i18n.js
+++ b/static/js/i18n.js
@@ -348,7 +348,7 @@ const en = {
 
   "panels.collapse": "Collapse",
 
-  "panels.allTitle": "Show or hide every panel and the library",
+  "panels.allTitle": "Show or hide every panel",
   "mixer.hint": "Drag fader · M/S",
   "stemsPanel.ariaLabel": "Stems",
 
@@ -962,7 +962,7 @@ const pl = {
 
   "panels.collapse": "Zwiń",
 
-  "panels.allTitle": "Pokaż lub ukryj wszystkie panele i bibliotekę",
+  "panels.allTitle": "Pokaż lub ukryj wszystkie panele",
   "mixer.hint": "Przeciągnij suwak · M/S",
   "stemsPanel.ariaLabel": "Ścieżki",
 
@@ -1566,7 +1566,7 @@ const ja = {
 
   "panels.collapse": "折りたたむ",
 
-  "panels.allTitle": "すべてのパネルとライブラリの表示を切り替えます",
+  "panels.allTitle": "すべてのパネルの表示を切り替えます",
   "mixer.hint": "フェーダーをドラッグ · M/S",
   "stemsPanel.ariaLabel": "パート",
 
@@ -2145,7 +2145,7 @@ const zhHans = {
 
   "panels.collapse": "折叠",
 
-  "panels.allTitle": "显示或隐藏所有面板和音乐库",
+  "panels.allTitle": "显示或隐藏所有面板",
   "mixer.hint": "拖动推子 · M/S",
   "stemsPanel.ariaLabel": "音轨",
 
@@ -2724,7 +2724,7 @@ const de = {
 
   "panels.collapse": "Einklappen",
 
-  "panels.allTitle": "Alle Bereiche und die Bibliothek ein- oder ausblenden",
+  "panels.allTitle": "Alle Bereiche ein- oder ausblenden",
   "mixer.hint": "Fader ziehen · M/S",
   "stemsPanel.ariaLabel": "Stems",
 
@@ -3314,7 +3314,7 @@ const pt = {
 
   "panels.collapse": "Recolher",
 
-  "panels.allTitle": "Mostrar ou ocultar todos os painéis e a biblioteca",
+  "panels.allTitle": "Mostrar ou ocultar todos os painéis",
   "mixer.hint": "Arraste o fader · M/S",
   "stemsPanel.ariaLabel": "Stems",
 
@@ -3906,7 +3906,7 @@ const id = {
 
   "panels.collapse": "Ciutkan",
 
-  "panels.allTitle": "Tampilkan atau sembunyikan semua panel dan pustaka",
+  "panels.allTitle": "Tampilkan atau sembunyikan semua panel",
   "mixer.hint": "Seret fader · M/S",
   "stemsPanel.ariaLabel": "Stem",
 
@@ -4485,7 +4485,7 @@ const fr = {
 
   "panels.collapse": "Réduire",
 
-  "panels.allTitle": "Afficher ou masquer tous les panneaux et la bibliothèque",
+  "panels.allTitle": "Afficher ou masquer tous les panneaux",
   "mixer.hint": "Glissez le fader · M/S",
   "stemsPanel.ariaLabel": "Pistes",
 
@@ -5193,7 +5193,7 @@ const es = {
 
   "panels.collapse": "Contraer",
 
-  "panels.allTitle": "Mostrar u ocultar todos los paneles y la biblioteca",
+  "panels.allTitle": "Mostrar u ocultar todos los paneles",
   "mixer.hint": "Arrastra el fader · M/S",
   "stemsPanel.ariaLabel": "Stems",
 
@@ -5806,7 +5806,7 @@ const ko = {
 
   "panels.collapse": "접기",
 
-  "panels.allTitle": "모든 패널과 라이브러리 표시하거나 숨기기",
+  "panels.allTitle": "모든 패널 표시하거나 숨기기",
   "mixer.hint": "페이더 드래그 · M/S",
   "stemsPanel.ariaLabel": "스템",
 

--- a/static/js/ui-chrome.js
+++ b/static/js/ui-chrome.js
@@ -2,8 +2,6 @@
 // attributes so the Content-Security-Policy can forbid inline script (#171).
 // Loaded as a module (deferred), so the DOM is parsed before this runs.
 
-import { setSidebarCollapsed, isSidebarCollapsed } from "./catalog.js";
-
 // Upload button → trigger the hidden file input.
 document.getElementById("uploadFileBtn")?.addEventListener("click", () => {
   document.getElementById("fileInput")?.click();
@@ -82,16 +80,21 @@ function wirePanelToggles() {
   wireAllToggle(app, toggles.map((btn) => btn.dataset.panel), apply, persist);
 }
 
-// "All" clears the studio down to the mixer in one press, and brings it back
-// in one more. Clearing the three panels while the library still holds its
-// column barely changes what you see, which is what made a fourth button worth
-// having rather than three presses.
+// "All" clears the three panels in one press and brings them back in one more.
 //
-// It greys and strikes through like the other three once everything is away.
+// Deliberately not the library. It used to take that too, and the row could
+// not put it back: the three buttons beside it only know about their own
+// panels, so after an "All" press you could turn Analysis, Sections and
+// Timeline back on, watch "All" light up as though everything had returned,
+// and still be looking at a collapsed library with nothing in this row able to
+// reach it (#588). The library has its own control in the rail, which is where
+// a reader of this row would not think to look for it.
+//
+// It greys and strikes through like the other three once all three are away.
 // The threshold is the whole trick. Read as "is anything hidden", it struck
 // itself through the moment Analysis was hidden on its own, which looks exactly
-// like you pressed it. It is off only when all four are off, so it describes
-// the row rather than the loudest thing in it.
+// like you pressed it. It is off only when every panel it governs is off, so it
+// describes the row rather than the loudest thing in it.
 //
 // It stores nothing. The state is derived from .app either way, so there is no
 // fourth flag to disagree with the other three.
@@ -100,24 +103,23 @@ function wireAllToggle(app, names, apply, persist) {
   if (!btn) return;
 
   const hiddenCount = () =>
-    names.filter((name) => app.classList.contains(`panel-${name}-off`)).length +
-    (isSidebarCollapsed() ? 1 : 0);
+    names.filter((name) => app.classList.contains(`panel-${name}-off`)).length;
 
-  const sync = () => btn.setAttribute("aria-pressed", String(hiddenCount() < names.length + 1));
+  const sync = () => btn.setAttribute("aria-pressed", String(hiddenCount() < names.length));
 
   btn.addEventListener("click", () => {
     // Anything still on screen means the press is asking to clear it away.
-    const show = hiddenCount() === names.length + 1;
+    const show = hiddenCount() === names.length;
     for (const name of names) {
       apply(name, show);
       persist(name, show);
     }
-    setSidebarCollapsed(!show);
   });
 
-  // The panels and the sidebar can each be moved from their own controls, and
-  // both land as a class on .app, so watching that one attribute keeps this
-  // button honest without every other handler having to remember it exists.
+  // Each panel can also be moved from its own button, and they all land as a
+  // class on .app, so watching that one attribute keeps this button honest
+  // without every other handler having to remember it exists. The library's
+  // class lands there too and is ignored, which is the point.
   new MutationObserver(sync).observe(app, { attributes: true, attributeFilter: ["class"] });
   sync();
 }

--- a/tests/e2e/panel-toggles.spec.mjs
+++ b/tests/e2e/panel-toggles.spec.mjs
@@ -1,0 +1,91 @@
+// The Collapse row governs three panels. Not the library.
+//
+// "All" used to take the library with it, and nothing in the row could put it
+// back: the three buttons beside it only know about their own panels. So the
+// reported sequence was press All, then turn Analysis, Sections and Timeline
+// back on one at a time, and watch All light up as though everything had
+// returned while the library stayed collapsed with no way to reach it from
+// there (#588). The library has its own control in the rail.
+import { test, expect } from "@playwright/test";
+import { openStudio } from "./helpers.mjs";
+
+const PANELS = ["analysis", "sections", "timeline"];
+
+const state = (page) =>
+  page.evaluate((panels) => {
+    const app = document.querySelector(".app");
+    const all = document.querySelector(".daw-panel-toggle[data-panel-all]");
+    return {
+      hidden: panels.filter((n) => app.classList.contains(`panel-${n}-off`)),
+      libraryCollapsed: app.classList.contains("cat-collapsed"),
+      allPressed: all.getAttribute("aria-pressed") === "true",
+    };
+  }, PANELS);
+
+const clickAll = (page) => page.locator(".daw-panel-toggle[data-panel-all]").click();
+const clickPanel = (page, name) => page.locator(`.daw-panel-toggle[data-panel="${name}"]`).click();
+
+test.describe("collapse row", () => {
+  test("All leaves the library alone in both directions", async ({ page }) => {
+    await openStudio(page, { tauri: true });
+    expect((await state(page)).libraryCollapsed).toBe(false);
+
+    await clickAll(page);
+    let s = await state(page);
+    expect(s.hidden, "every panel it governs is away").toEqual(PANELS);
+    expect(s.libraryCollapsed, "the library is not one of them").toBe(false);
+
+    await clickAll(page);
+    s = await state(page);
+    expect(s.hidden).toEqual([]);
+    expect(s.libraryCollapsed).toBe(false);
+  });
+
+  test("the reporter's sequence leaves nothing stranded", async ({ page }) => {
+    await openStudio(page, { tauri: true });
+
+    // Press All, then bring each panel back from its own button.
+    await clickAll(page);
+    for (const name of PANELS) await clickPanel(page, name);
+
+    const s = await state(page);
+    // The bug was that All read as fully on here while the library was still
+    // collapsed and unreachable from this row.
+    expect(s.allPressed, "All reflects the row").toBe(true);
+    expect(s.hidden).toEqual([]);
+    expect(s.libraryCollapsed, "nothing was left collapsed behind it").toBe(false);
+  });
+
+  test("All still greys out only when every panel it governs is away", async ({ page }) => {
+    await openStudio(page, { tauri: true });
+
+    // One panel hidden must not read as "you pressed All".
+    await clickPanel(page, "analysis");
+    expect((await state(page)).allPressed).toBe(true);
+
+    await clickPanel(page, "sections");
+    expect((await state(page)).allPressed).toBe(true);
+
+    await clickPanel(page, "timeline");
+    expect((await state(page)).allPressed, "all three away, so the row is away").toBe(false);
+  });
+
+  test("collapsing the library does not change what All reports", async ({ page }) => {
+    // The library's class lands on the same element the observer watches, so
+    // this is the check that it is genuinely ignored rather than accidentally
+    // absent from the count.
+    await openStudio(page, { tauri: true });
+    await page.locator("#sidebarCollapseBtn").click();
+    await expect
+      .poll(async () => (await state(page)).libraryCollapsed, { timeout: 5000 })
+      .toBe(true);
+
+    expect((await state(page)).allPressed, "the library is not part of the row").toBe(true);
+
+    // And All must not resurrect it on the way past.
+    await clickAll(page);
+    expect((await state(page)).libraryCollapsed).toBe(true);
+    await clickAll(page);
+    expect((await state(page)).libraryCollapsed).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #588

## The problem

@wastedbits reported it precisely: "All" collapsed the library alongside Analysis, Sections and Timeline, and nothing in that row could bring it back. The three buttons beside it only know about their own panels.

So the sequence was: press All, turn each of the three back on, watch All light up as though everything had returned, and still be looking at a collapsed library with no control in that row able to reach it.

It also made the button lie. Its pressed state is derived rather than stored, and the derivation counted the library as a fourth panel, so All could read as fully on while something it had collapsed was still away.

## The fix

The row now governs exactly the three panels it names. The library keeps its own toggle in the rail, which is where it already was and where its state is legible.

That is the reporter's own suggestion, and it is the right one: a control that can put something away has to be able to bring it back, and this one could not.

## Unchanged, deliberately

The greying threshold. Hiding one panel on its own must not grey the button through, because that reads exactly like you pressed it. It is off only when every panel it governs is off, now three rather than four.

## Tests

`tests/e2e/panel-toggles.spec.mjs`, a file that did not exist: this row had no coverage at all, which is why it shipped.

Covers the reporter's exact sequence, that All is inert on the library in both directions, that the greying threshold still needs all three, and that collapsing the library from the rail does not change what All reports. That last one earns its place because the library's class lands on the same element the button observes, so it checks the library is genuinely ignored rather than accidentally missing from the count.

All four fail against the previous behaviour.

## i18n

`panels.allTitle` said "and the library" in all ten language tables. Updated in each, since it now describes something the button does not do.
