### PR TITLE
Serve the frontend with correct MIME types, whatever the host registry says

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,7 @@ import functools
 import io
 import json
 import logging
+import mimetypes
 import os
 import re
 import signal
@@ -1087,6 +1088,38 @@ app.add_middleware(
     minimum_size=MINIMUM_SIZE,
     compresslevel=COMPRESS_LEVEL,
 )
+
+
+def _pin_static_mime_types() -> None:
+    """Serve the frontend with correct content types regardless of the host.
+
+    StaticFiles asks `mimetypes` for a type, and on Windows `mimetypes` reads
+    HKEY_CLASSES_ROOT. Any program that ever registered `.js` as `text/plain`
+    leaves it that way for everyone, so StemDeck would serve its own modules as
+    plain text on that machine and nowhere else.
+
+    Browsers enforce strict MIME checking on ES modules and refuse to execute
+    one served as `text/plain`. Every module is then blocked, no listener is
+    ever attached, and the app renders fully but responds to nothing: hover and
+    typing still work because the engine does those itself (#617).
+
+    Nothing in the response is wrong on a healthy machine, which is why this
+    survives CI and every developer box. Pinning the handful of types the app
+    actually serves costs nothing and removes the dependency on a registry
+    StemDeck does not control.
+    """
+    for ext, ctype in (
+        (".js", "text/javascript"),
+        (".mjs", "text/javascript"),
+        (".css", "text/css"),
+        (".json", "application/json"),
+        (".svg", "image/svg+xml"),
+        (".wasm", "application/wasm"),
+    ):
+        mimetypes.add_type(ctype, ext)
+
+
+_pin_static_mime_types()
 
 app.include_router(router, prefix="/api")
 app.mount("/", StaticFiles(directory=STATIC_DIR, html=True), name="static")

--- a/tests/test_static_mime.py
+++ b/tests/test_static_mime.py
@@ -1,0 +1,126 @@
+"""The frontend must be served with correct content types on any host.
+
+StaticFiles asks `mimetypes` for a type, and on Windows `mimetypes` reads
+HKEY_CLASSES_ROOT. A machine where some other program registered `.js` as
+`text/plain` made StemDeck serve its own ES modules as plain text, which
+browsers refuse to execute under strict MIME checking. Every module was
+blocked, so nothing wired itself up and the app responded to nothing while
+still rendering and still hovering (#617).
+
+Nothing is wrong on a healthy machine, which is exactly why CI and every
+developer box missed it. These tests reproduce the broken host instead of
+trusting the one they run on.
+"""
+
+from __future__ import annotations
+
+import mimetypes
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import _pin_static_mime_types, app
+
+JS_TYPES = {"text/javascript", "application/javascript"}
+
+
+@pytest.fixture
+def _restore_mimetypes():
+    """`mimetypes` maps are process-global, so a test that edits them must undo it."""
+    saved_types = dict(mimetypes.types_map)
+    saved_non_standard = dict(mimetypes.common_types)
+    yield
+    mimetypes.types_map.clear()
+    mimetypes.types_map.update(saved_types)
+    mimetypes.common_types.clear()
+    mimetypes.common_types.update(saved_non_standard)
+
+
+def test_js_is_javascript_after_import():
+    """Importing the app is enough; no request has to happen first.
+
+    Note this cannot fail on a host whose registry is already correct, which is
+    every CI runner and most developer machines. It guards the healthy case.
+    The tests that actually exercise the fix are the hostile-host ones below,
+    which reproduce the broken mapping rather than trusting the host.
+    """
+    guessed, _ = mimetypes.guess_type("anything.js")
+    assert guessed in JS_TYPES, guessed
+
+
+def test_a_host_that_calls_js_plain_text_is_overridden(_restore_mimetypes):
+    """The actual reported failure: a registry mapping .js to text/plain."""
+    mimetypes.add_type("text/plain", ".js")
+    assert mimetypes.guess_type("x.js")[0] == "text/plain"
+
+    _pin_static_mime_types()
+
+    assert mimetypes.guess_type("x.js")[0] in JS_TYPES
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("x.js", JS_TYPES),
+        ("x.mjs", JS_TYPES),
+        ("x.css", {"text/css"}),
+        ("x.json", {"application/json"}),
+        ("x.svg", {"image/svg+xml"}),
+        ("x.wasm", {"application/wasm"}),
+    ],
+)
+def test_every_pinned_type_survives_a_hostile_host(name, expected, _restore_mimetypes):
+    """A host that calls everything plain text must not change what we serve."""
+    for ext in (".js", ".mjs", ".css", ".json", ".svg", ".wasm"):
+        mimetypes.add_type("text/plain", ext)
+
+    _pin_static_mime_types()
+
+    assert mimetypes.guess_type(name)[0] in expected
+
+
+def test_a_real_module_is_served_as_javascript():
+    """End to end through StaticFiles, which is what the browser actually sees.
+
+    A module served as text/plain is refused by strict MIME checking, so this
+    header is the whole difference between a working app and a dead one.
+
+    Like the import test above, this passes on a healthy host either way. The
+    next test is the one that proves the fix reaches StaticFiles.
+    """
+    with TestClient(app) as c:
+        resp = c.get("/js/main.js")
+
+    assert resp.status_code == 200
+    ctype = resp.headers["content-type"].split(";")[0].strip()
+    assert ctype in JS_TYPES, ctype
+
+
+def test_a_hostile_host_still_serves_javascript_end_to_end(_restore_mimetypes):
+    """The reported failure, reproduced and then fixed, through a real request.
+
+    This is the test that can fail. It puts the broken mapping in place first,
+    so without `_pin_static_mime_types` the response really does come back as
+    text/plain and the assertion fails on any machine, healthy registry or not.
+    """
+    mimetypes.add_type("text/plain", ".js")
+    with TestClient(app) as c:
+        broken = c.get("/js/main.js")
+    assert broken.headers["content-type"].split(";")[0].strip() == "text/plain"
+
+    _pin_static_mime_types()
+
+    with TestClient(app) as c:
+        fixed = c.get("/js/main.js")
+
+    assert fixed.status_code == 200
+    ctype = fixed.headers["content-type"].split(";")[0].strip()
+    assert ctype in JS_TYPES, ctype
+
+
+def test_the_stylesheet_is_served_as_css():
+    with TestClient(app) as c:
+        resp = c.get("/css/variables.css")
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].split(";")[0].strip() == "text/css"


### PR DESCRIPTION
Closes #617

## The problem

`StaticFiles` asks `mimetypes` for a content type, and on Windows `mimetypes` reads `HKEY_CLASSES_ROOT`. Any program that ever registered `.js` as `text/plain` leaves it that way for every application on that machine. StemDeck then served its own ES modules as plain text there, and nowhere else.

Browsers enforce strict MIME checking on module scripts and refuse to execute one served as `text/plain`:

```
Failed to load module script: Expected a JavaScript-or-Wasm module script but the
server responded with a MIME type of "text/plain". Strict MIME type checking is
enforced for module scripts per HTML spec.
```

Every module is blocked, so nothing wires itself up. The app renders completely and responds to nothing. Hover and text selection keep working because the engine does those itself; buttons and file drop do nothing because no listener was ever attached.

Nothing in the response is malformed on a healthy machine, which is exactly why this survived CI, every developer box, and the whole e2e suite. The bug is the dependency on a registry StemDeck does not control.

Diagnosed by @DrSiemer, who supplied the console output and identified the cause.

## The fix

`_pin_static_mime_types()` registers the handful of types the app actually serves, before the `StaticFiles` mount: `.js`, `.mjs`, `.css`, `.json`, `.svg`, `.wasm`.

It sits next to the mount it protects rather than at the top of the module, so the reason is visible from the thing it affects.

## Test plan

`tests/test_static_mime.py`, 11 tests. They reproduce the broken host rather than trusting the one they run on.

- [x] **Two tests deliberately cannot fail on a correct registry**, and say so in their docstrings. They guard the healthy case: the type after import, and a real `/js/main.js` request. On a sane machine these pass with or without the fix, and pretending otherwise would be worse than saying it.
- [x] **The tests that carry the weight install the `text/plain` mapping first.** One parametrised case per pinned extension, plus an end-to-end request that asserts the response really does come back `text/plain` before asserting the fix corrects it.
- [x] **Verified the tests can fail.** With `add_type` replaced by `pass`, 8 of 11 fail, including the end-to-end one.
- [x] Full suite: 999 passed
- [x] `ruff check` and `ruff format --check` clean
- [x] `bandit -r app/ -ll` clean
- [x] `git diff --stat uv.lock` empty, so the desktop in-app updater is unaffected

### Pre-existing, unrelated

8 failures in `test_click_render.py` and `test_transpose_export.py` on my Windows box. The identical 8 fail on clean `main`; they are ffmpeg/rubberband environment issues, not this change.

## Reproducing it by hand

On Windows, point `.js` at `text/plain` and start the app:

```
reg add "HKCR\.js" /ve /d "text/plain" /f
```

Before this change the window renders and ignores every click. After it, the app works. Restore with `/d "text/javascript"`.

## Relationship to #619

#619 is a separate problem found while investigating this one: the app could not report a boot failure at all, because `main.js` registers its error handlers after the wiring run that fails. That is why this arrived with clean logs. The two are independent and neither replaces the other. With #619 in place, this failure would have named itself on screen instead of presenting as a dead window.